### PR TITLE
feat(android): add showPauseResumeActions option to notification config

### DIFF
--- a/documentation_site/docs/api-reference/API/interfaces/NotificationConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/NotificationConfig.md
@@ -66,6 +66,12 @@ Unique identifier for this notification
 
 Priority of the notification (affects how it's displayed)
 
+#### showPauseResumeActions?
+
+> `optional` **showPauseResumeActions**: `boolean`
+
+Whether to show pause/resume actions in the notification (default: true)
+
 #### waveform?
 
 > `optional` **waveform**: [`WaveformConfig`](WaveformConfig.md)

--- a/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
+++ b/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/AudioNotificationsManager.kt
@@ -165,19 +165,21 @@ class AudioNotificationManager private constructor(context: Context) {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        // Add only one pause/resume action based on current state
-        if (isPaused.get()) {
-            notificationBuilder.addAction(
-                R.drawable.ic_play,
-                "Resume",
-                resumePendingIntent
-            )
-        } else {
-            notificationBuilder.addAction(
-                R.drawable.ic_pause,
-                "Pause",
-                pausePendingIntent
-            )
+        // Add only one pause/resume action based on current state (if enabled)
+        if (recordingConfig.notification.showPauseResumeActions) {
+            if (isPaused.get()) {
+                notificationBuilder.addAction(
+                    R.drawable.ic_play,
+                    "Resume",
+                    resumePendingIntent
+                )
+            } else {
+                notificationBuilder.addAction(
+                    R.drawable.ic_pause,
+                    "Pause",
+                    pausePendingIntent
+                )
+            }
         }
 
         // Add configured custom actions (only if they don't already exist)

--- a/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/NotificationConfig.kt
+++ b/packages/expo-audio-studio/android/src/main/java/net/siteed/audiostream/NotificationConfig.kt
@@ -12,7 +12,8 @@ data class NotificationConfig(
     val waveform: WaveformConfig? = null,
     val lightColor: String = "#FF0000",
     val priority: String = "high",
-    val accentColor: String? = null
+    val accentColor: String? = null,
+    val showPauseResumeActions: Boolean = true
 ) {
     companion object {
         fun fromMap(map: Map<String, Any?>?): NotificationConfig {
@@ -32,7 +33,8 @@ data class NotificationConfig(
                 waveform = parseWaveformConfig(androidMap["waveform"] as? Map<String, Any?>),
                 lightColor = androidMap["lightColor"] as? String ?: "#FF0000",
                 priority = androidMap["priority"] as? String ?: "high",
-                accentColor = androidMap["accentColor"] as? String
+                accentColor = androidMap["accentColor"] as? String,
+                showPauseResumeActions = androidMap["showPauseResumeActions"] as? Boolean ?: true
             )
         }
 

--- a/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
+++ b/packages/expo-audio-studio/src/ExpoAudioStream.types.ts
@@ -524,6 +524,9 @@ export interface NotificationConfig {
 
         /** Accent color for the notification (used for the app icon and buttons) */
         accentColor?: string
+
+        /** Whether to show pause/resume actions in the notification (default: true) */
+        showPauseResumeActions?: boolean
     }
 
     /** iOS-specific notification configuration */


### PR DESCRIPTION
## Summary

Add a new optional `showPauseResumeActions` boolean property to the Android notification configuration, allowing users to hide pause/resume buttons from recording notifications.

## Changes

- **TypeScript Interface**: Added `showPauseResumeActions?: boolean` to Android notification config
- **Android Implementation**: Updated `NotificationConfig.kt` to parse the new option with default value `true`
- **Notification Manager**: Modified `AudioNotificationsManager.kt` to conditionally show pause/resume actions
- **Documentation**: Updated API reference documentation

## Usage

```typescript
const recordingConfig = {
  showNotification: true,
  notification: {
    title: 'Recording in progress',
    android: {
      channelId: 'recording',
      showPauseResumeActions: false // Hides pause/resume buttons
    }
  }
}
```

## Backward Compatibility

- Default value is `true`, maintaining existing behavior
- All existing code continues to work unchanged
- Custom notification actions still work alongside this setting

## Test Plan

- [x] TypeScript compilation passes
- [x] Android compilation succeeds 
- [x] Tested with `showPauseResumeActions: false` - pause/resume buttons are hidden
- [x] Tested with `showPauseResumeActions: true` - pause/resume buttons are shown
- [x] Tested default behavior (property omitted) - pause/resume buttons are shown
- [x] Verified custom actions still work correctly

## Resolves

Closes #276