### PR TITLE
fix(audio-studio): convert trim ranges from Double to Long on Android

### DIFF
--- a/apps/playground/src/agentic-bridge.ts
+++ b/apps/playground/src/agentic-bridge.ts
@@ -1214,14 +1214,23 @@ if (__DEV__) {
             void (async () => {
                 try {
                     const fileUri = await loadSampleFileUri()
-                    const result = await trimAudio({ fileUri, startTimeMs: 0, endTimeMs: 5000 })
+                    // Test 1: single mode
+                    const result1 = await trimAudio({ fileUri, startTimeMs: 0, endTimeMs: 5000 })
+                    // Test 2: keep mode with ranges (validates fix for #347)
+                    const result2 = await trimAudio({
+                        fileUri,
+                        mode: 'keep',
+                        ranges: [
+                            { startTimeMs: 0, endTimeMs: 2000 },
+                            { startTimeMs: 3000, endTimeMs: 5000 },
+                        ],
+                    })
                     _lastAsyncResult = {
                         op,
                         status: 'success',
                         result: {
-                            uri: result.uri,
-                            durationMs: result.durationMs,
-                            size: result.size,
+                            single: { uri: result1.uri, durationMs: result1.durationMs, size: result1.size },
+                            keepRanges: { uri: result2.uri, durationMs: result2.durationMs, size: result2.size },
                         },
                     }
                 } catch (e) {

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -382,7 +382,13 @@ class AudioStudioModule : Module(), EventSender {
                 val endTimeMs = (options["endTimeMs"] as? Number)?.toLong()
                 
                 @Suppress("UNCHECKED_CAST")
-                val ranges = options["ranges"] as? List<Map<String, Long>>
+                val rawRanges = options["ranges"] as? List<Map<String, Any>>
+                val ranges = rawRanges?.map { range ->
+                    mapOf(
+                        "startTimeMs" to ((range["startTimeMs"] as? Number)?.toLong() ?: 0L),
+                        "endTimeMs" to ((range["endTimeMs"] as? Number)?.toLong() ?: 0L)
+                    )
+                }
                 
                 val outputFileName = options["outputFileName"] as? String
                 


### PR DESCRIPTION
## Summary
- Fixes #347: `trimAudio` ignores `ranges` on Android for keep/remove modes
- The JS bridge sends numeric values as `Double`, but the Kotlin code cast `ranges` as `List<Map<String, Long>>` — the safe cast silently returned `null`
- Converts through `Number.toLong()` to match the existing pattern used for `startTimeMs`/`endTimeMs`

## Test plan
- [x] Validated on Android (Pixel 6a) via CDP bridge: `testTrimAudio()` returns both `single` (5000ms) and `keepRanges` (4000ms) results with correct durations and non-zero sizes