### PR TITLE
fix(audio-studio): move prepareRecording off main thread to prevent UI freeze (#361)

### DIFF
--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -183,28 +183,24 @@ class AudioStudioModule : Module(), EventSender {
 
 
         AsyncFunction("prepareRecording") { options: Map<String, Any?>, promise: Promise ->
-            try {
-                // If notifications are requested but permission not in manifest, modify options
-                if (options["showNotification"] as? Boolean == true && !enableNotificationHandling) {
-                    val modifiedOptions = options.toMutableMap()
-                    modifiedOptions["showNotification"] = false
-                    LogUtils.d(CLASS_NAME, "Notification permission not in manifest, disabling showNotification")
-                    
-                    if (audioRecorderManager.prepareRecording(modifiedOptions)) {
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val opts = if (options["showNotification"] as? Boolean == true && !enableNotificationHandling) {
+                        LogUtils.d(CLASS_NAME, "Notification permission not in manifest, disabling showNotification")
+                        options.toMutableMap().apply { this["showNotification"] = false }
+                    } else {
+                        options
+                    }
+
+                    if (audioRecorderManager.prepareRecording(opts)) {
                         promise.resolve(true)
                     } else {
                         promise.reject("PREPARE_ERROR", "Failed to prepare recording", null)
                     }
-                } else {
-                    if (audioRecorderManager.prepareRecording(options)) {
-                        promise.resolve(true)
-                    } else {
-                        promise.reject("PREPARE_ERROR", "Failed to prepare recording", null)
-                    }
+                } catch (e: Exception) {
+                    LogUtils.e(CLASS_NAME, "Error preparing recording", e)
+                    promise.reject("PREPARE_ERROR", "Failed to prepare recording: ${e.message}", e)
                 }
-            } catch (e: Exception) {
-                LogUtils.e(CLASS_NAME, "Error preparing recording", e)
-                promise.reject("PREPARE_ERROR", "Failed to prepare recording: ${e.message}", e)
             }
         }
 

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -830,16 +830,13 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             return false
         }
 
-        // Reset audio session before preparing new recording
+        // Deactivate the session to ensure a clean state before reconfiguring.
+        // The session will be activated once after configureAudioSession below.
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setActive(false, options: .notifyOthersOnDeactivation)
-            Thread.sleep(forTimeInterval: 0.1) // Brief pause to ensure clean state
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
-            Logger.debug("AudioStreamManager", "Failed to reset audio session: \(error)")
-            delegate?.audioStreamManager(self, didFailWithError: "Failed to reset audio session: \(error.localizedDescription)")
-            return false
+            Logger.debug("AudioStreamManager", "Failed to deactivate audio session (non-fatal): \(error)")
         }
 
         // Update auto-resume preference from settings
@@ -943,7 +940,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
 
             recordingSettings = newSettings  // Keep original settings with desired sample rate
 
-            audioEngine.prepare() // Prepare the engine without starting it
+            // audioEngine.prepare() is already called inside installTapWithHardwareFormat()
             
             // Setup compressed recording if enabled
             if settings.output.compressed.enabled {

--- a/packages/audio-studio/ios/AudioStudioModule.swift
+++ b/packages/audio-studio/ios/AudioStudioModule.swift
@@ -281,13 +281,15 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
                 
                 switch settingsResult {
                 case .success(let settings):
-                    Logger.debug("AudioStudioModule", "prepareRecording: Settings parsed successfully. Calling streamManager.prepareRecording")
-                    if self.streamManager.prepareRecording(settings: settings) {
-                        Logger.info("AudioStudioModule", "prepareRecording: Preparation successful.")
-                        promise.resolve(true)
-                    } else {
-                        Logger.error("AudioStudioModule", "prepareRecording: streamManager.prepareRecording returned false.")
-                        promise.reject("ERROR", "Failed to prepare recording.")
+                    Logger.debug("AudioStudioModule", "prepareRecording: Settings parsed successfully. Dispatching to background queue.")
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        if self.streamManager.prepareRecording(settings: settings) {
+                            Logger.info("AudioStudioModule", "prepareRecording: Preparation successful.")
+                            promise.resolve(true)
+                        } else {
+                            Logger.error("AudioStudioModule", "prepareRecording: streamManager.prepareRecording returned false.")
+                            promise.reject("ERROR", "Failed to prepare recording.")
+                        }
                     }
                     
                 case .failure(let error):


### PR DESCRIPTION
## Summary

Fixes #361

`prepareRecording` blocked the main thread / JS thread for ~5-8 seconds on first cold invocation, completely freezing the UI. This moves all heavy native work to a background thread on both platforms.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Root Cause & Solution

On both iOS and Android, `prepareRecording` ran expensive native operations (audio session setup, hardware probing, file I/O) synchronously on the main thread. The JS promise couldn't resolve until all that work completed, blocking the entire UI.

### iOS
- **Dispatch to background:** `streamManager.prepareRecording` now runs on `DispatchQueue.global(qos: .userInitiated)` instead of the main queue
- **Remove redundant `Thread.sleep(0.1)`** + `setActive(false/true)` reset cycle — the session is deactivated once then activated after `configureAudioSession`
- **Remove duplicate `audioEngine.prepare()`** — already called inside `installTapWithHardwareFormat()`

### Android
- **Dispatch to background:** `audioRecorderManager.prepareRecording` now runs inside `CoroutineScope(Dispatchers.IO)` (imports were already present)

## Testing

- Cold-start `prepareRecording` no longer freezes the UI
- Subsequent calls remain fast (~250ms, OS-cached)
- `startRecording` after `prepareRecording` works as expected on both platforms

## Related Issues

Fixes https://github.com/deeeed/audiolab/issues/361