### PR TITLE
fix(audio-studio): move module ops off main thread + fix iOS stop crash

### DIFF
--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
@@ -455,49 +455,55 @@ class AudioRecorderManager(
     }
 
     private fun initializePhoneStateListener() {
-        try {
-            LogUtils.d(CLASS_NAME, "Initializing phone state listener...")
+        // The legacy PhoneStateListener (API < 31) requires a Looper on the
+        // thread that constructs it; calling listen() also expects the same.
+        // prepareRecording now runs on Dispatchers.IO (no Looper), so we
+        // marshal the whole registration to the main thread's Looper. The
+        // API 31+ path uses context.mainExecutor and is thread-safe, but we
+        // route everything through main for consistency.
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            try {
+                LogUtils.d(CLASS_NAME, "Initializing phone state listener...")
 
-            if (permissionUtils.checkPhoneStatePermission()) {
-                LogUtils.d(CLASS_NAME, "Phone state permission granted")
+                if (permissionUtils.checkPhoneStatePermission()) {
+                    LogUtils.d(CLASS_NAME, "Phone state permission granted")
 
-                val localTelephonyManager = telephonyManager
-                if (localTelephonyManager != null) {
-                    try {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                            // API 31+: Use modern TelephonyCallback which reliably fires on Android 12+
-                            val callback = object : TelephonyCallback(), TelephonyCallback.CallStateListener {
-                                override fun onCallStateChanged(state: Int) {
-                                    handleCallStateChanged(state)
+                    val localTelephonyManager = telephonyManager
+                    if (localTelephonyManager != null) {
+                        try {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                val callback = object : TelephonyCallback(), TelephonyCallback.CallStateListener {
+                                    override fun onCallStateChanged(state: Int) {
+                                        handleCallStateChanged(state)
+                                    }
                                 }
-                            }
-                            telephonyCallback = callback
-                            localTelephonyManager.registerTelephonyCallback(context.mainExecutor, callback)
-                            LogUtils.d(CLASS_NAME, "Successfully registered TelephonyCallback (API 31+)")
-                        } else {
-                            // Legacy: PhoneStateListener for API < 31
-                            phoneStateListener = object : PhoneStateListener() {
-                                @Deprecated("Deprecated in API 31")
-                                override fun onCallStateChanged(state: Int, phoneNumber: String?) {
-                                    handleCallStateChanged(state)
+                                telephonyCallback = callback
+                                localTelephonyManager.registerTelephonyCallback(context.mainExecutor, callback)
+                                LogUtils.d(CLASS_NAME, "Successfully registered TelephonyCallback (API 31+)")
+                            } else {
+                                phoneStateListener = object : PhoneStateListener() {
+                                    @Deprecated("Deprecated in API 31")
+                                    override fun onCallStateChanged(state: Int, phoneNumber: String?) {
+                                        handleCallStateChanged(state)
+                                    }
                                 }
+                                localTelephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE)
+                                LogUtils.d(CLASS_NAME, "Successfully registered PhoneStateListener (legacy)")
                             }
-                            localTelephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE)
-                            LogUtils.d(CLASS_NAME, "Successfully registered PhoneStateListener (legacy)")
+                        } catch (e: SecurityException) {
+                            LogUtils.w(CLASS_NAME, "Missing permission for phone state listener: ${e.message}")
+                        } catch (e: Exception) {
+                            LogUtils.e(CLASS_NAME, "Failed to register phone state listener", e)
                         }
-                    } catch (e: SecurityException) {
-                        LogUtils.w(CLASS_NAME, "Missing permission for phone state listener: ${e.message}")
-                    } catch (e: Exception) {
-                        LogUtils.e(CLASS_NAME, "Failed to register phone state listener", e)
+                    } else {
+                        LogUtils.w(CLASS_NAME, "TelephonyManager is null, phone call interruption handling disabled (device may not have telephony service)")
                     }
                 } else {
-                    LogUtils.w(CLASS_NAME, "TelephonyManager is null, phone call interruption handling disabled (device may not have telephony service)")
+                    LogUtils.w(CLASS_NAME, "READ_PHONE_STATE permission not granted, phone call interruption handling disabled")
                 }
-            } else {
-                LogUtils.w(CLASS_NAME, "READ_PHONE_STATE permission not granted, phone call interruption handling disabled")
+            } catch (e: Exception) {
+                LogUtils.e(CLASS_NAME, "Failed to initialize phone state listener", e)
             }
-        } catch (e: Exception) {
-            LogUtils.e(CLASS_NAME, "Failed to initialize phone state listener", e)
         }
     }
 

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -17,6 +17,7 @@ import java.util.zip.CRC32
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -649,6 +650,10 @@ class AudioStudioModule : Module(), EventSender {
         }
 
         OnDestroy {
+            // Cancel in-flight prepare/trim/extract coroutines so promises
+            // and event sends do not outlive the React context. SupervisorJob
+            // alone does not get cancelled by Expo automatically.
+            coroutineScope.cancel()
             AudioRecorderManager.destroy()
         }
 

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -454,198 +454,198 @@ class AudioStudioModule : Module(), EventSender {
             // Heavy DSP: file decode + STFT + mel projection. Off the shared
             // module executor so other JS calls don't block.
             coroutineScope.launch(Dispatchers.IO) {
-            try {
-                LogUtils.d(CLASS_NAME, "extractMelSpectrogram called with options: $options")
+                try {
+                    LogUtils.d(CLASS_NAME, "extractMelSpectrogram called with options: $options")
                 
-                // Extract required parameters with detailed logging
-                val fileUri = options["fileUri"] as? String
-                LogUtils.d(CLASS_NAME, "fileUri: $fileUri")
-                if (fileUri == null) {
-                    LogUtils.e(CLASS_NAME, "Missing required parameter: fileUri")
-                    throw IllegalArgumentException("fileUri is required")
-                }
-                
-                val windowSizeMs = options["windowSizeMs"] as? Double
-                LogUtils.d(CLASS_NAME, "windowSizeMs: $windowSizeMs")
-                if (windowSizeMs == null) {
-                    LogUtils.e(CLASS_NAME, "Missing required parameter: windowSizeMs")
-                    throw IllegalArgumentException("windowSizeMs is required")
-                }
-                
-                val hopLengthMs = options["hopLengthMs"] as? Double
-                LogUtils.d(CLASS_NAME, "hopLengthMs: $hopLengthMs")
-                if (hopLengthMs == null) {
-                    LogUtils.e(CLASS_NAME, "Missing required parameter: hopLengthMs")
-                    throw IllegalArgumentException("hopLengthMs is required")
-                }
-                
-                // Handle nMels which might come as Double from JavaScript
-                val nMelsValue = options["nMels"]
-                LogUtils.d(CLASS_NAME, "Raw nMels value: $nMelsValue (type: ${nMelsValue?.javaClass?.name})")
-                
-                val nMels = when (nMelsValue) {
-                    is Int -> nMelsValue
-                    is Double -> nMelsValue.toInt()
-                    is Number -> nMelsValue.toInt()
-                    else -> {
-                        LogUtils.e(CLASS_NAME, "Missing or invalid required parameter: nMels")
-                        throw IllegalArgumentException("nMels is required and must be a number")
+                    // Extract required parameters with detailed logging
+                    val fileUri = options["fileUri"] as? String
+                    LogUtils.d(CLASS_NAME, "fileUri: $fileUri")
+                    if (fileUri == null) {
+                        LogUtils.e(CLASS_NAME, "Missing required parameter: fileUri")
+                        throw IllegalArgumentException("fileUri is required")
                     }
-                }
                 
-                LogUtils.d(CLASS_NAME, "Converted nMels: $nMels (from ${nMelsValue?.javaClass?.name})")
-
-                // Extract optional parameters with defaults
-                val fMin = options["fMin"] as? Double ?: 0.0
-                val fMax = options["fMax"] as? Double
-                val windowType = options["windowType"] as? String ?: "hann"
-                val normalize = options["normalize"] as? Boolean ?: false
-                val logScale = options["logScale"] as? Boolean ?: true
-                
-                // Fix the conversion from Number to Long to preserve decimal values
-                val startTimeMsNumber = options["startTimeMs"] as? Number
-                val endTimeMsNumber = options["endTimeMs"] as? Number
-                val startTimeMs = startTimeMsNumber?.toLong() ?: startTimeMsNumber?.toDouble()?.toLong()
-                val endTimeMs = endTimeMsNumber?.toLong() ?: endTimeMsNumber?.toDouble()?.toLong()
-
-                LogUtils.d(CLASS_NAME, """
-                    Optional parameters:
-                    - fMin: $fMin
-                    - fMax: $fMax
-                    - windowType: $windowType
-                    - normalize: $normalize
-                    - logScale: $logScale
-                    - startTimeMs: $startTimeMs (original: $startTimeMsNumber)
-                    - endTimeMs: $endTimeMs (original: $endTimeMsNumber)
-                """.trimIndent())
-
-                // Handle decoding options
-                val decodingOptions = options["decodingOptions"] as? Map<String, Any>
-                LogUtils.d(CLASS_NAME, "Decoding options: $decodingOptions")
-                
-                val config = decodingOptions?.let {
-                    val targetSampleRateValue = it["targetSampleRate"]
-                    val targetSampleRate = when (targetSampleRateValue) {
-                        is Int -> targetSampleRateValue
-                        is Double -> targetSampleRateValue.toInt()
-                        is Number -> targetSampleRateValue.toInt()
-                        else -> null
+                    val windowSizeMs = options["windowSizeMs"] as? Double
+                    LogUtils.d(CLASS_NAME, "windowSizeMs: $windowSizeMs")
+                    if (windowSizeMs == null) {
+                        LogUtils.e(CLASS_NAME, "Missing required parameter: windowSizeMs")
+                        throw IllegalArgumentException("windowSizeMs is required")
                     }
+                
+                    val hopLengthMs = options["hopLengthMs"] as? Double
+                    LogUtils.d(CLASS_NAME, "hopLengthMs: $hopLengthMs")
+                    if (hopLengthMs == null) {
+                        LogUtils.e(CLASS_NAME, "Missing required parameter: hopLengthMs")
+                        throw IllegalArgumentException("hopLengthMs is required")
+                    }
+                
+                    // Handle nMels which might come as Double from JavaScript
+                    val nMelsValue = options["nMels"]
+                    LogUtils.d(CLASS_NAME, "Raw nMels value: $nMelsValue (type: ${nMelsValue?.javaClass?.name})")
+                
+                    val nMels = when (nMelsValue) {
+                        is Int -> nMelsValue
+                        is Double -> nMelsValue.toInt()
+                        is Number -> nMelsValue.toInt()
+                        else -> {
+                            LogUtils.e(CLASS_NAME, "Missing or invalid required parameter: nMels")
+                            throw IllegalArgumentException("nMels is required and must be a number")
+                        }
+                    }
+                
+                    LogUtils.d(CLASS_NAME, "Converted nMels: $nMels (from ${nMelsValue?.javaClass?.name})")
+
+                    // Extract optional parameters with defaults
+                    val fMin = options["fMin"] as? Double ?: 0.0
+                    val fMax = options["fMax"] as? Double
+                    val windowType = options["windowType"] as? String ?: "hann"
+                    val normalize = options["normalize"] as? Boolean ?: false
+                    val logScale = options["logScale"] as? Boolean ?: true
+                
+                    // Fix the conversion from Number to Long to preserve decimal values
+                    val startTimeMsNumber = options["startTimeMs"] as? Number
+                    val endTimeMsNumber = options["endTimeMs"] as? Number
+                    val startTimeMs = startTimeMsNumber?.toLong() ?: startTimeMsNumber?.toDouble()?.toLong()
+                    val endTimeMs = endTimeMsNumber?.toLong() ?: endTimeMsNumber?.toDouble()?.toLong()
+
+                    LogUtils.d(CLASS_NAME, """
+                        Optional parameters:
+                        - fMin: $fMin
+                        - fMax: $fMax
+                        - windowType: $windowType
+                        - normalize: $normalize
+                        - logScale: $logScale
+                        - startTimeMs: $startTimeMs (original: $startTimeMsNumber)
+                        - endTimeMs: $endTimeMs (original: $endTimeMsNumber)
+                    """.trimIndent())
+
+                    // Handle decoding options
+                    val decodingOptions = options["decodingOptions"] as? Map<String, Any>
+                    LogUtils.d(CLASS_NAME, "Decoding options: $decodingOptions")
+                
+                    val config = decodingOptions?.let {
+                        val targetSampleRateValue = it["targetSampleRate"]
+                        val targetSampleRate = when (targetSampleRateValue) {
+                            is Int -> targetSampleRateValue
+                            is Double -> targetSampleRateValue.toInt()
+                            is Number -> targetSampleRateValue.toInt()
+                            else -> null
+                        }
                     
-                    val targetChannelsValue = it["targetChannels"]
-                    val targetChannels = when (targetChannelsValue) {
-                        is Int -> targetChannelsValue
-                        is Double -> targetChannelsValue.toInt()
-                        is Number -> targetChannelsValue.toInt()
-                        else -> 1
-                    }
+                        val targetChannelsValue = it["targetChannels"]
+                        val targetChannels = when (targetChannelsValue) {
+                            is Int -> targetChannelsValue
+                            is Double -> targetChannelsValue.toInt()
+                            is Number -> targetChannelsValue.toInt()
+                            else -> 1
+                        }
                     
-                    val targetBitDepthValue = it["targetBitDepth"]
-                    val targetBitDepth = when (targetBitDepthValue) {
-                        is Int -> targetBitDepthValue
-                        is Double -> targetBitDepthValue.toInt()
-                        is Number -> targetBitDepthValue.toInt()
-                        else -> 16
-                    }
+                        val targetBitDepthValue = it["targetBitDepth"]
+                        val targetBitDepth = when (targetBitDepthValue) {
+                            is Int -> targetBitDepthValue
+                            is Double -> targetBitDepthValue.toInt()
+                            is Number -> targetBitDepthValue.toInt()
+                            else -> 16
+                        }
                     
-                    val normalizeAudio = it["normalizeAudio"] as? Boolean ?: false
+                        val normalizeAudio = it["normalizeAudio"] as? Boolean ?: false
                     
-                    DecodingConfig(
-                        targetSampleRate = targetSampleRate,
-                        targetChannels = targetChannels,
-                        targetBitDepth = targetBitDepth,
-                        normalizeAudio = normalizeAudio
-                    ).also { config ->
-                        LogUtils.d(CLASS_NAME, """
-                            Using decoding config:
-                            - targetSampleRate: ${config.targetSampleRate ?: "original"}
-                            - targetChannels: ${config.targetChannels ?: "original"}
-                            - targetBitDepth: ${config.targetBitDepth}
-                            - normalizeAudio: ${config.normalizeAudio}
-                        """.trimIndent())
+                        DecodingConfig(
+                            targetSampleRate = targetSampleRate,
+                            targetChannels = targetChannels,
+                            targetBitDepth = targetBitDepth,
+                            normalizeAudio = normalizeAudio
+                        ).also { config ->
+                            LogUtils.d(CLASS_NAME, """
+                                Using decoding config:
+                                - targetSampleRate: ${config.targetSampleRate ?: "original"}
+                                - targetChannels: ${config.targetChannels ?: "original"}
+                                - targetBitDepth: ${config.targetBitDepth}
+                                - normalizeAudio: ${config.normalizeAudio}
+                            """.trimIndent())
+                        }
+                    } ?: DecodingConfig(targetSampleRate = null, targetChannels = 1, targetBitDepth = 16).also {
+                        LogUtils.d(CLASS_NAME, "Using default decoding config")
                     }
-                } ?: DecodingConfig(targetSampleRate = null, targetChannels = 1, targetBitDepth = 16).also {
-                    LogUtils.d(CLASS_NAME, "Using default decoding config")
-                }
 
-                // Check if the audio data is too short
-                if (startTimeMs != null && endTimeMs != null) {
-                    val durationMs = endTimeMs - startTimeMs
-                    LogUtils.d(CLASS_NAME, "Audio duration for spectrogram: $durationMs ms")
-                    if (durationMs < 25) {  // 25ms is minimum for a single window
-                        LogUtils.w(CLASS_NAME, "Audio duration is too short for spectrogram analysis: $durationMs ms")
-                        throw IllegalArgumentException("Audio duration must be at least 25ms for spectrogram analysis")
+                    // Check if the audio data is too short
+                    if (startTimeMs != null && endTimeMs != null) {
+                        val durationMs = endTimeMs - startTimeMs
+                        LogUtils.d(CLASS_NAME, "Audio duration for spectrogram: $durationMs ms")
+                        if (durationMs < 25) {  // 25ms is minimum for a single window
+                            LogUtils.w(CLASS_NAME, "Audio duration is too short for spectrogram analysis: $durationMs ms")
+                            throw IllegalArgumentException("Audio duration must be at least 25ms for spectrogram analysis")
+                        }
                     }
-                }
 
-                // Load audio data with optional time range
-                LogUtils.d(CLASS_NAME, "Loading audio data...")
-                val audioData = when {
-                    startTimeMs != null && endTimeMs != null -> {
-                        LogUtils.d(CLASS_NAME, "Loading audio range: $startTimeMs to $endTimeMs ms")
-                        audioProcessor.loadAudioRange(fileUri, startTimeMs, endTimeMs, config)
+                    // Load audio data with optional time range
+                    LogUtils.d(CLASS_NAME, "Loading audio data...")
+                    val audioData = when {
+                        startTimeMs != null && endTimeMs != null -> {
+                            LogUtils.d(CLASS_NAME, "Loading audio range: $startTimeMs to $endTimeMs ms")
+                            audioProcessor.loadAudioRange(fileUri, startTimeMs, endTimeMs, config)
+                        }
+                        else -> {
+                            LogUtils.d(CLASS_NAME, "Loading entire audio file")
+                            audioProcessor.loadAudioFromAnyFormat(fileUri, config)
+                        }
                     }
-                    else -> {
-                        LogUtils.d(CLASS_NAME, "Loading entire audio file")
-                        audioProcessor.loadAudioFromAnyFormat(fileUri, config)
-                    }
-                }
                 
-                if (audioData == null) {
-                    LogUtils.e(CLASS_NAME, "Failed to load audio data")
-                    throw IllegalStateException("Failed to load audio data")
-                }
+                    if (audioData == null) {
+                        LogUtils.e(CLASS_NAME, "Failed to load audio data")
+                        throw IllegalStateException("Failed to load audio data")
+                    }
                 
-                LogUtils.d(CLASS_NAME, """
-                    Audio data loaded successfully:
-                    - data size: ${audioData.data.size} bytes
-                    - sampleRate: ${audioData.sampleRate}
-                    - channels: ${audioData.channels}
-                    - bitDepth: ${audioData.bitDepth}
-                    - durationMs: ${audioData.durationMs}
-                """.trimIndent())
+                    LogUtils.d(CLASS_NAME, """
+                        Audio data loaded successfully:
+                        - data size: ${audioData.data.size} bytes
+                        - sampleRate: ${audioData.sampleRate}
+                        - channels: ${audioData.channels}
+                        - bitDepth: ${audioData.bitDepth}
+                        - durationMs: ${audioData.durationMs}
+                    """.trimIndent())
 
-                // Validate that we have enough audio data for processing
-                if (audioData.data.size == 0 || audioData.durationMs < windowSizeMs) {
-                    LogUtils.e(CLASS_NAME, "Audio data is too short for spectrogram analysis: ${audioData.durationMs}ms, data size: ${audioData.data.size} bytes")
-                    throw IllegalArgumentException(
-                        "Audio data is too short for spectrogram analysis. " +
-                        "Duration: ${audioData.durationMs}ms, minimum required: ${windowSizeMs}ms"
+                    // Validate that we have enough audio data for processing
+                    if (audioData.data.size == 0 || audioData.durationMs < windowSizeMs) {
+                        LogUtils.e(CLASS_NAME, "Audio data is too short for spectrogram analysis: ${audioData.durationMs}ms, data size: ${audioData.data.size} bytes")
+                        throw IllegalArgumentException(
+                            "Audio data is too short for spectrogram analysis. " +
+                            "Duration: ${audioData.durationMs}ms, minimum required: ${windowSizeMs}ms"
+                        )
+                    }
+
+                    // Compute mel-spectrogram
+                    LogUtils.d(CLASS_NAME, "Computing mel-spectrogram...")
+                    val spectrogramData = audioProcessor.extractMelSpectrogram(
+                        audioData = audioData,
+                        windowSizeMs = windowSizeMs.toFloat(),
+                        hopLengthMs = hopLengthMs.toFloat(),
+                        nMels = nMels,
+                        fMin = fMin.toFloat(),
+                        fMax = fMax?.toFloat() ?: (audioData.sampleRate.toFloat() / 2),
+                        normalize = normalize,
+                        logScaling = logScale,
+                        windowType = windowType
                     )
+                
+                    LogUtils.d(CLASS_NAME, "Mel-spectrogram computed successfully with ${spectrogramData.spectrogram.size} time steps")
+
+                    // Convert to map for React Native
+                    val result = mapOf(
+                        "spectrogram" to spectrogramData.spectrogram.map { it.toList() },
+                        "sampleRate" to audioData.sampleRate,
+                        "nMels" to nMels,
+                        "timeSteps" to spectrogramData.spectrogram.size,
+                        "durationMs" to audioData.durationMs
+                    )
+                
+                    LogUtils.d(CLASS_NAME, "Returning result with ${result["timeSteps"]} time steps and $nMels mel bands")
+                    promise.resolve(result)
+                } catch (e: Exception) {
+                    LogUtils.e(CLASS_NAME, "Failed to extract mel-spectrogram: ${e.message}")
+                    LogUtils.e(CLASS_NAME, "Stack trace: ${e.stackTraceToString()}")
+                    promise.reject("SPECTROGRAM_ERROR", e.message ?: "Unknown error", e)
                 }
-
-                // Compute mel-spectrogram
-                LogUtils.d(CLASS_NAME, "Computing mel-spectrogram...")
-                val spectrogramData = audioProcessor.extractMelSpectrogram(
-                    audioData = audioData,
-                    windowSizeMs = windowSizeMs.toFloat(),
-                    hopLengthMs = hopLengthMs.toFloat(),
-                    nMels = nMels,
-                    fMin = fMin.toFloat(),
-                    fMax = fMax?.toFloat() ?: (audioData.sampleRate.toFloat() / 2),
-                    normalize = normalize,
-                    logScaling = logScale,
-                    windowType = windowType
-                )
-                
-                LogUtils.d(CLASS_NAME, "Mel-spectrogram computed successfully with ${spectrogramData.spectrogram.size} time steps")
-
-                // Convert to map for React Native
-                val result = mapOf(
-                    "spectrogram" to spectrogramData.spectrogram.map { it.toList() },
-                    "sampleRate" to audioData.sampleRate,
-                    "nMels" to nMels,
-                    "timeSteps" to spectrogramData.spectrogram.size,
-                    "durationMs" to audioData.durationMs
-                )
-                
-                LogUtils.d(CLASS_NAME, "Returning result with ${result["timeSteps"]} time steps and $nMels mel bands")
-                promise.resolve(result)
-            } catch (e: Exception) {
-                LogUtils.e(CLASS_NAME, "Failed to extract mel-spectrogram: ${e.message}")
-                LogUtils.e(CLASS_NAME, "Stack trace: ${e.stackTraceToString()}")
-                promise.reject("SPECTROGRAM_ERROR", e.message ?: "Unknown error", e)
-            }
             }
         }
 
@@ -680,275 +680,275 @@ class AudioStudioModule : Module(), EventSender {
             // Off the shared executor so other JS calls don't block during
             // multi-second analysis on large files.
             coroutineScope.launch(Dispatchers.IO) {
-            try {
-                val fileUri = requireNotNull(options["fileUri"] as? String) { "fileUri is required" }
+                try {
+                    val fileUri = requireNotNull(options["fileUri"] as? String) { "fileUri is required" }
 
-                // Get time or byte range options
-                val startTimeMs = options["startTimeMs"] as? Number
-                val endTimeMs = options["endTimeMs"] as? Number
-                val position = options["position"] as? Number
-                val length = options["length"] as? Number
-                val segmentDurationMs = (options["segmentDurationMs"] as? Number)?.toInt() ?: 100
+                    // Get time or byte range options
+                    val startTimeMs = options["startTimeMs"] as? Number
+                    val endTimeMs = options["endTimeMs"] as? Number
+                    val position = options["position"] as? Number
+                    val length = options["length"] as? Number
+                    val segmentDurationMs = (options["segmentDurationMs"] as? Number)?.toInt() ?: 100
                 
-                // Validate ranges - can have time range OR byte range OR no range
-                val hasTimeRange = startTimeMs != null && endTimeMs != null
-                val hasByteRange = position != null && length != null
+                    // Validate ranges - can have time range OR byte range OR no range
+                    val hasTimeRange = startTimeMs != null && endTimeMs != null
+                    val hasByteRange = position != null && length != null
                 
-                // Only throw if both ranges are provided
-                if (hasTimeRange && hasByteRange) {
-                    throw IllegalArgumentException("Cannot specify both time range and byte range")
-                }
+                    // Only throw if both ranges are provided
+                    if (hasTimeRange && hasByteRange) {
+                        throw IllegalArgumentException("Cannot specify both time range and byte range")
+                    }
 
-                // Get decoding options with default configuration
-                val defaultConfig = DecodingConfig(
-                    targetSampleRate = null,
-                    targetChannels = 1, // Default to mono
-                    targetBitDepth = 16,
-                    normalizeAudio = false
-                )
-                
-                val config = (options["decodingOptions"] as? Map<String, Any>)?.let { decodingOptionsMap ->
-                    DecodingConfig(
-                        targetSampleRate = decodingOptionsMap["targetSampleRate"] as? Int,
-                        targetChannels = decodingOptionsMap["targetChannels"] as? Int,
-                        targetBitDepth = (decodingOptionsMap["targetBitDepth"] as? Int) ?: 16,
-                        normalizeAudio = (decodingOptionsMap["normalizeAudio"] as? Boolean) ?: false
+                    // Get decoding options with default configuration
+                    val defaultConfig = DecodingConfig(
+                        targetSampleRate = null,
+                        targetChannels = 1, // Default to mono
+                        targetBitDepth = 16,
+                        normalizeAudio = false
                     )
-                } ?: defaultConfig
-
-                // Load audio data based on range type (or full file if no range specified)
-                val audioData = when {
-                    hasByteRange -> {
-                        val format = audioProcessor.getAudioFormat(fileUri) 
-                            ?: throw IllegalArgumentException("Could not determine audio format")
-                        
-                        // Calculate time range from byte position
-                        val bytesPerSecond = format.sampleRate * format.channels * (format.bitDepth / 8)
-                        val effectiveStartTimeMs = (position!!.toLong() * 1000) / bytesPerSecond
-                        val effectiveEndTimeMs = effectiveStartTimeMs + (length!!.toLong() * 1000) / bytesPerSecond
-                        
-                        LogUtils.d(CLASS_NAME, "Loading audio with byte range: position=$position, length=$length")
-                        
-                        audioProcessor.loadAudioRange(
-                            fileUri = fileUri,
-                            startTimeMs = effectiveStartTimeMs,
-                            endTimeMs = effectiveEndTimeMs,
-                            config = config
+                
+                    val config = (options["decodingOptions"] as? Map<String, Any>)?.let { decodingOptionsMap ->
+                        DecodingConfig(
+                            targetSampleRate = decodingOptionsMap["targetSampleRate"] as? Int,
+                            targetChannels = decodingOptionsMap["targetChannels"] as? Int,
+                            targetBitDepth = (decodingOptionsMap["targetBitDepth"] as? Int) ?: 16,
+                            normalizeAudio = (decodingOptionsMap["normalizeAudio"] as? Boolean) ?: false
                         )
-                    }
-                    hasTimeRange -> {
-                        LogUtils.d(CLASS_NAME, "Loading audio with time range: startTimeMs=$startTimeMs, endTimeMs=$endTimeMs")
+                    } ?: defaultConfig
+
+                    // Load audio data based on range type (or full file if no range specified)
+                    val audioData = when {
+                        hasByteRange -> {
+                            val format = audioProcessor.getAudioFormat(fileUri) 
+                                ?: throw IllegalArgumentException("Could not determine audio format")
                         
-                        audioProcessor.loadAudioRange(
-                            fileUri = fileUri,
-                            startTimeMs = startTimeMs!!.toLong(),
-                            endTimeMs = endTimeMs!!.toLong(),
-                            config = config
-                        )
-                    }
-                    else -> {
-                        LogUtils.d(CLASS_NAME, "Loading entire audio file")
-                        audioProcessor.loadAudioFromAnyFormat(fileUri, config)
-                    }
-                } ?: throw IllegalStateException("Failed to load audio data")
+                            // Calculate time range from byte position
+                            val bytesPerSecond = format.sampleRate * format.channels * (format.bitDepth / 8)
+                            val effectiveStartTimeMs = (position!!.toLong() * 1000) / bytesPerSecond
+                            val effectiveEndTimeMs = effectiveStartTimeMs + (length!!.toLong() * 1000) / bytesPerSecond
+                        
+                            LogUtils.d(CLASS_NAME, "Loading audio with byte range: position=$position, length=$length")
+                        
+                            audioProcessor.loadAudioRange(
+                                fileUri = fileUri,
+                                startTimeMs = effectiveStartTimeMs,
+                                endTimeMs = effectiveEndTimeMs,
+                                config = config
+                            )
+                        }
+                        hasTimeRange -> {
+                            LogUtils.d(CLASS_NAME, "Loading audio with time range: startTimeMs=$startTimeMs, endTimeMs=$endTimeMs")
+                        
+                            audioProcessor.loadAudioRange(
+                                fileUri = fileUri,
+                                startTimeMs = startTimeMs!!.toLong(),
+                                endTimeMs = endTimeMs!!.toLong(),
+                                config = config
+                            )
+                        }
+                        else -> {
+                            LogUtils.d(CLASS_NAME, "Loading entire audio file")
+                            audioProcessor.loadAudioFromAnyFormat(fileUri, config)
+                        }
+                    } ?: throw IllegalStateException("Failed to load audio data")
 
-                val featuresMap = options["features"] as? Map<*, *>
-                val features = Features.parseFeatureOptions(featuresMap)
+                    val featuresMap = options["features"] as? Map<*, *>
+                    val features = Features.parseFeatureOptions(featuresMap)
 
-                val recordingConfig = RecordingConfig(
-                    sampleRate = audioData.sampleRate,
-                    channels = audioData.channels,
-                    encoding = when (audioData.bitDepth) {
-                        8 -> "pcm_8bit"
-                        16 -> "pcm_16bit"
-                        32 -> "pcm_32bit"
-                        else -> throw IllegalArgumentException("Unsupported bit depth: ${audioData.bitDepth}")
-                    },
-                    segmentDurationMs = segmentDurationMs,
-                    features = features
-                )
+                    val recordingConfig = RecordingConfig(
+                        sampleRate = audioData.sampleRate,
+                        channels = audioData.channels,
+                        encoding = when (audioData.bitDepth) {
+                            8 -> "pcm_8bit"
+                            16 -> "pcm_16bit"
+                            32 -> "pcm_32bit"
+                            else -> throw IllegalArgumentException("Unsupported bit depth: ${audioData.bitDepth}")
+                        },
+                        segmentDurationMs = segmentDurationMs,
+                        features = features
+                    )
 
-                LogUtils.d(CLASS_NAME, "extractAudioAnalysis: $recordingConfig")
-                audioProcessor.resetCumulativeAmplitudeRange()
+                    LogUtils.d(CLASS_NAME, "extractAudioAnalysis: $recordingConfig")
+                    audioProcessor.resetCumulativeAmplitudeRange()
 
-                val analysisData = audioProcessor.processAudioData(audioData.data, recordingConfig)
-                promise.resolve(analysisData.toDictionary())
-            } catch (e: Exception) {
-                LogUtils.e(CLASS_NAME, "Failed to extract audio analysis: ${e.message}", e)
-                promise.reject("PROCESSING_ERROR", e.message ?: "Unknown error", e)
-            }
+                    val analysisData = audioProcessor.processAudioData(audioData.data, recordingConfig)
+                    promise.resolve(analysisData.toDictionary())
+                } catch (e: Exception) {
+                    LogUtils.e(CLASS_NAME, "Failed to extract audio analysis: ${e.message}", e)
+                    promise.reject("PROCESSING_ERROR", e.message ?: "Unknown error", e)
+                }
             }
         }
 
         AsyncFunction("extractAudioData") { options: Map<String, Any>, promise: Promise ->
             // Off the shared executor so concurrent JS calls don't block.
             coroutineScope.launch(Dispatchers.IO) {
-            try {
-                val fileUri = requireNotNull(options["fileUri"] as? String) { "fileUri is required" }
-                val startTimeMs = options["startTimeMs"] as? Number
-                val endTimeMs = options["endTimeMs"] as? Number
-                val position = options["position"] as? Number
-                val length = options["length"] as? Number
+                try {
+                    val fileUri = requireNotNull(options["fileUri"] as? String) { "fileUri is required" }
+                    val startTimeMs = options["startTimeMs"] as? Number
+                    val endTimeMs = options["endTimeMs"] as? Number
+                    val position = options["position"] as? Number
+                    val length = options["length"] as? Number
                 
-                // Validate that we have either time range or byte range, but not both and not neither
-                val hasTimeRange = startTimeMs != null && endTimeMs != null
-                val hasByteRange = position != null && length != null
+                    // Validate that we have either time range or byte range, but not both and not neither
+                    val hasTimeRange = startTimeMs != null && endTimeMs != null
+                    val hasByteRange = position != null && length != null
                 
-                if (!hasTimeRange && !hasByteRange) {
-                    throw IllegalArgumentException("Must specify either time range (startTimeMs, endTimeMs) or byte range (position, length)")
-                }
-                if (hasTimeRange && hasByteRange) {
-                    throw IllegalArgumentException("Cannot specify both time range and byte range")
-                }
-                
-                // Get decoding options
-                val decodingOptionsMap = options["decodingOptions"] as? Map<String, Any>
-                val decodingConfig = if (decodingOptionsMap != null) {
-                    DecodingConfig(
-                        targetSampleRate = decodingOptionsMap["targetSampleRate"] as? Int,
-                        targetChannels = decodingOptionsMap["targetChannels"] as? Int,
-                        targetBitDepth = (decodingOptionsMap["targetBitDepth"] as? Int) ?: 16,
-                        normalizeAudio = (decodingOptionsMap["normalizeAudio"] as? Boolean) ?: false
-                    ).also {
-                        LogUtils.d(CLASS_NAME, """
-                            Using decoding config:
-                            - targetSampleRate: ${it.targetSampleRate ?: "original"}
-                            - targetChannels: ${it.targetChannels ?: "original"}
-                            - targetBitDepth: ${it.targetBitDepth}
-                            - normalizeAudio: ${it.normalizeAudio}
-                        """.trimIndent())
+                    if (!hasTimeRange && !hasByteRange) {
+                        throw IllegalArgumentException("Must specify either time range (startTimeMs, endTimeMs) or byte range (position, length)")
                     }
-                } else null
+                    if (hasTimeRange && hasByteRange) {
+                        throw IllegalArgumentException("Cannot specify both time range and byte range")
+                    }
+                
+                    // Get decoding options
+                    val decodingOptionsMap = options["decodingOptions"] as? Map<String, Any>
+                    val decodingConfig = if (decodingOptionsMap != null) {
+                        DecodingConfig(
+                            targetSampleRate = decodingOptionsMap["targetSampleRate"] as? Int,
+                            targetChannels = decodingOptionsMap["targetChannels"] as? Int,
+                            targetBitDepth = (decodingOptionsMap["targetBitDepth"] as? Int) ?: 16,
+                            normalizeAudio = (decodingOptionsMap["normalizeAudio"] as? Boolean) ?: false
+                        ).also {
+                            LogUtils.d(CLASS_NAME, """
+                                Using decoding config:
+                                - targetSampleRate: ${it.targetSampleRate ?: "original"}
+                                - targetChannels: ${it.targetChannels ?: "original"}
+                                - targetBitDepth: ${it.targetBitDepth}
+                                - normalizeAudio: ${it.normalizeAudio}
+                            """.trimIndent())
+                        }
+                    } else null
 
-                val audioData = if (hasByteRange) {
-                    val format = audioProcessor.getAudioFormat(fileUri) 
-                        ?: throw IllegalArgumentException("Could not determine audio format")
+                    val audioData = if (hasByteRange) {
+                        val format = audioProcessor.getAudioFormat(fileUri) 
+                            ?: throw IllegalArgumentException("Could not determine audio format")
                     
-                    // Calculate time range from byte position
-                    val bytesPerSecond = format.sampleRate * format.channels * (format.bitDepth / 8)
-                    val effectiveStartTimeMs = (position!!.toLong() * 1000) / bytesPerSecond
-                    val effectiveEndTimeMs = effectiveStartTimeMs + (length!!.toLong() * 1000) / bytesPerSecond
+                        // Calculate time range from byte position
+                        val bytesPerSecond = format.sampleRate * format.channels * (format.bitDepth / 8)
+                        val effectiveStartTimeMs = (position!!.toLong() * 1000) / bytesPerSecond
+                        val effectiveEndTimeMs = effectiveStartTimeMs + (length!!.toLong() * 1000) / bytesPerSecond
                     
+                        LogUtils.d(CLASS_NAME, """
+                            Converting byte range to time range:
+                            - position: $position bytes
+                            - length: $length bytes
+                            - bytesPerSecond: $bytesPerSecond
+                            - effectiveStartTimeMs: $effectiveStartTimeMs
+                            - effectiveEndTimeMs: $effectiveEndTimeMs
+                        """.trimIndent())
+                    
+                        audioProcessor.loadAudioRange(
+                            fileUri = fileUri,
+                            startTimeMs = effectiveStartTimeMs,
+                            endTimeMs = effectiveEndTimeMs,
+                            config = decodingConfig
+                        )
+                    } else {
+                        // Must be time range due to earlier validation
+                        LogUtils.d(CLASS_NAME, """
+                            Using time range:
+                            - startTimeMs: $startTimeMs
+                            - endTimeMs: $endTimeMs
+                        """.trimIndent())
+                    
+                        audioProcessor.loadAudioRange(
+                            fileUri = fileUri,
+                            startTimeMs = startTimeMs!!.toLong(),
+                            endTimeMs = endTimeMs!!.toLong(),
+                            config = decodingConfig
+                        )
+                    } ?: throw IllegalStateException("Failed to load audio data")
+
                     LogUtils.d(CLASS_NAME, """
-                        Converting byte range to time range:
-                        - position: $position bytes
-                        - length: $length bytes
-                        - bytesPerSecond: $bytesPerSecond
-                        - effectiveStartTimeMs: $effectiveStartTimeMs
-                        - effectiveEndTimeMs: $effectiveEndTimeMs
+                        Audio data loaded successfully:
+                        - data size: ${audioData.data.size} bytes
+                        - sampleRate: ${audioData.sampleRate}
+                        - channels: ${audioData.channels}
+                        - bitDepth: ${audioData.bitDepth}
+                        - durationMs: ${audioData.durationMs}
                     """.trimIndent())
-                    
-                    audioProcessor.loadAudioRange(
-                        fileUri = fileUri,
-                        startTimeMs = effectiveStartTimeMs,
-                        endTimeMs = effectiveEndTimeMs,
-                        config = decodingConfig
-                    )
-                } else {
-                    // Must be time range due to earlier validation
-                    LogUtils.d(CLASS_NAME, """
-                        Using time range:
-                        - startTimeMs: $startTimeMs
-                        - endTimeMs: $endTimeMs
-                    """.trimIndent())
-                    
-                    audioProcessor.loadAudioRange(
-                        fileUri = fileUri,
-                        startTimeMs = startTimeMs!!.toLong(),
-                        endTimeMs = endTimeMs!!.toLong(),
-                        config = decodingConfig
-                    )
-                } ?: throw IllegalStateException("Failed to load audio data")
 
-                LogUtils.d(CLASS_NAME, """
-                    Audio data loaded successfully:
-                    - data size: ${audioData.data.size} bytes
-                    - sampleRate: ${audioData.sampleRate}
-                    - channels: ${audioData.channels}
-                    - bitDepth: ${audioData.bitDepth}
-                    - durationMs: ${audioData.durationMs}
-                """.trimIndent())
-
-                val includeNormalizedData = options["includeNormalizedData"] as? Boolean ?: false
-                val includeBase64Data = options["includeBase64Data"] as? Boolean ?: false
-                val includeWavHeader = options["includeWavHeader"] as? Boolean ?: false
-                val bytesPerSample = audioData.bitDepth / 8
-                val samples = audioData.data.size / (bytesPerSample * audioData.channels)
+                    val includeNormalizedData = options["includeNormalizedData"] as? Boolean ?: false
+                    val includeBase64Data = options["includeBase64Data"] as? Boolean ?: false
+                    val includeWavHeader = options["includeWavHeader"] as? Boolean ?: false
+                    val bytesPerSample = audioData.bitDepth / 8
+                    val samples = audioData.data.size / (bytesPerSample * audioData.channels)
                 
-                // Create the result map
-                val resultMap = mutableMapOf<String, Any>()
+                    // Create the result map
+                    val resultMap = mutableMapOf<String, Any>()
                 
-                // Add WAV header if requested
-                if (includeWavHeader) {
-                    // Use ByteArrayOutputStream to write the WAV header and data
-                    val outputStream = java.io.ByteArrayOutputStream()
-                    val audioFileHandler = AudioFileHandler(appContext.reactContext!!.filesDir)
+                    // Add WAV header if requested
+                    if (includeWavHeader) {
+                        // Use ByteArrayOutputStream to write the WAV header and data
+                        val outputStream = java.io.ByteArrayOutputStream()
+                        val audioFileHandler = AudioFileHandler(appContext.reactContext!!.filesDir)
                     
-                    // Write the WAV header
-                    audioFileHandler.writeWavHeader(
-                        outputStream,
-                        audioData.sampleRate,
-                        audioData.channels,
-                        audioData.bitDepth
-                    )
+                        // Write the WAV header
+                        audioFileHandler.writeWavHeader(
+                            outputStream,
+                            audioData.sampleRate,
+                            audioData.channels,
+                            audioData.bitDepth
+                        )
                     
-                    // Write the PCM data
-                    outputStream.write(audioData.data)
+                        // Write the PCM data
+                        outputStream.write(audioData.data)
                     
-                    // Get the complete WAV data
-                    val wavData = outputStream.toByteArray()
+                        // Get the complete WAV data
+                        val wavData = outputStream.toByteArray()
                     
-                    resultMap["pcmData"] = wavData
-                    resultMap["hasWavHeader"] = true
+                        resultMap["pcmData"] = wavData
+                        resultMap["hasWavHeader"] = true
                     
-                    LogUtils.d(CLASS_NAME, "Added WAV header to PCM data, total size: ${wavData.size} bytes")
-                } else {
-                    resultMap["pcmData"] = audioData.data
-                    resultMap["hasWavHeader"] = false
+                        LogUtils.d(CLASS_NAME, "Added WAV header to PCM data, total size: ${wavData.size} bytes")
+                    } else {
+                        resultMap["pcmData"] = audioData.data
+                        resultMap["hasWavHeader"] = false
+                    }
+                
+                    // Add the rest of the data
+                    resultMap.putAll(mapOf(
+                        "sampleRate" to audioData.sampleRate,
+                        "channels" to audioData.channels,
+                        "bitDepth" to audioData.bitDepth,
+                        "durationMs" to audioData.durationMs,
+                        "format" to "pcm_${audioData.bitDepth}bit",
+                        "samples" to samples
+                    ))
+                
+                    // Add checksum if requested
+                    if (options["computeChecksum"] == true) {
+                        val crc32 = CRC32()
+                        crc32.update(audioData.data)
+                        resultMap["checksum"] = crc32.value.toInt()
+                    
+                        LogUtils.d(CLASS_NAME, "Computed CRC32 checksum: ${crc32.value}")
+                    }
+                
+                    if (includeNormalizedData) {
+                        val float32Data = AudioFormatUtils.convertByteArrayToFloatArray(
+                            audioData.data,
+                            "pcm_${audioData.bitDepth}bit"
+                        )
+                        resultMap["normalizedData"] = float32Data
+                    }
+                
+                    if (includeBase64Data) {
+                        // Convert the PCM data to a base64 string
+                        val base64Data = android.util.Base64.encodeToString(
+                            audioData.data, 
+                            android.util.Base64.NO_WRAP
+                        )
+                        resultMap["base64Data"] = base64Data
+                    }
+                
+                    promise.resolve(resultMap)
+                } catch (e: Exception) {
+                    LogUtils.e(CLASS_NAME, "Failed to extract audio data: ${e.message}")
+                    LogUtils.e(CLASS_NAME, "Stack trace: ${e.stackTraceToString()}")
+                    promise.reject("PROCESSING_ERROR", e.message ?: "Unknown error", e)
                 }
-                
-                // Add the rest of the data
-                resultMap.putAll(mapOf(
-                    "sampleRate" to audioData.sampleRate,
-                    "channels" to audioData.channels,
-                    "bitDepth" to audioData.bitDepth,
-                    "durationMs" to audioData.durationMs,
-                    "format" to "pcm_${audioData.bitDepth}bit",
-                    "samples" to samples
-                ))
-                
-                // Add checksum if requested
-                if (options["computeChecksum"] == true) {
-                    val crc32 = CRC32()
-                    crc32.update(audioData.data)
-                    resultMap["checksum"] = crc32.value.toInt()
-                    
-                    LogUtils.d(CLASS_NAME, "Computed CRC32 checksum: ${crc32.value}")
-                }
-                
-                if (includeNormalizedData) {
-                    val float32Data = AudioFormatUtils.convertByteArrayToFloatArray(
-                        audioData.data,
-                        "pcm_${audioData.bitDepth}bit"
-                    )
-                    resultMap["normalizedData"] = float32Data
-                }
-                
-                if (includeBase64Data) {
-                    // Convert the PCM data to a base64 string
-                    val base64Data = android.util.Base64.encodeToString(
-                        audioData.data, 
-                        android.util.Base64.NO_WRAP
-                    )
-                    resultMap["base64Data"] = base64Data
-                }
-                
-                promise.resolve(resultMap)
-            } catch (e: Exception) {
-                LogUtils.e(CLASS_NAME, "Failed to extract audio data: ${e.message}")
-                LogUtils.e(CLASS_NAME, "Stack trace: ${e.stackTraceToString()}")
-                promise.reject("PROCESSING_ERROR", e.message ?: "Unknown error", e)
-            }
             }
         }
     }

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -16,6 +16,7 @@ import expo.modules.interfaces.permissions.Permissions
 import java.util.zip.CRC32
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -31,7 +32,7 @@ class AudioStudioModule : Module(), EventSender {
     private var enableNotificationHandling: Boolean = false // Default to false until we check manifest
     private var enableBackgroundAudio: Boolean = false // Default to false until we check manifest
     private var enableDeviceDetection: Boolean = false // Default to false until we check manifest
-    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+    private val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     private val audioFileHandler by lazy { 
         AudioFileHandler(appContext.reactContext?.filesDir ?: throw IllegalStateException("React context not available")) 
@@ -183,28 +184,27 @@ class AudioStudioModule : Module(), EventSender {
 
 
         AsyncFunction("prepareRecording") { options: Map<String, Any?>, promise: Promise ->
-            try {
-                // If notifications are requested but permission not in manifest, modify options
-                if (options["showNotification"] as? Boolean == true && !enableNotificationHandling) {
-                    val modifiedOptions = options.toMutableMap()
-                    modifiedOptions["showNotification"] = false
-                    LogUtils.d(CLASS_NAME, "Notification permission not in manifest, disabling showNotification")
-                    
-                    if (audioRecorderManager.prepareRecording(modifiedOptions)) {
+            // Heavy native init (AudioRecord probe, MediaRecorder.prepare, file I/O)
+            // must run off the main thread to keep the JS/UI thread responsive.
+            // Module-scoped Job ensures cancellation on module destroy.
+            coroutineScope.launch(Dispatchers.IO) {
+                try {
+                    val opts = if (options["showNotification"] as? Boolean == true && !enableNotificationHandling) {
+                        LogUtils.d(CLASS_NAME, "Notification permission not in manifest, disabling showNotification")
+                        options.toMutableMap().apply { this["showNotification"] = false }
+                    } else {
+                        options
+                    }
+
+                    if (audioRecorderManager.prepareRecording(opts)) {
                         promise.resolve(true)
                     } else {
                         promise.reject("PREPARE_ERROR", "Failed to prepare recording", null)
                     }
-                } else {
-                    if (audioRecorderManager.prepareRecording(options)) {
-                        promise.resolve(true)
-                    } else {
-                        promise.reject("PREPARE_ERROR", "Failed to prepare recording", null)
-                    }
+                } catch (e: Exception) {
+                    LogUtils.e(CLASS_NAME, "Error preparing recording", e)
+                    promise.reject("PREPARE_ERROR", "Failed to prepare recording: ${e.message}", e)
                 }
-            } catch (e: Exception) {
-                LogUtils.e(CLASS_NAME, "Error preparing recording", e)
-                promise.reject("PREPARE_ERROR", "Failed to prepare recording: ${e.message}", e)
             }
         }
 
@@ -368,93 +368,92 @@ class AudioStudioModule : Module(), EventSender {
         }
 
         AsyncFunction("trimAudio") { options: Map<String, Any>, promise: Promise ->
-            try {
-                val fileUri = options["fileUri"] as? String ?: run {
-                    promise.reject("INVALID_URI", "fileUri is required", null)
-                    return@AsyncFunction
-                }
+            // Trim does heavy decode/encode + file I/O — must run off the
+            // shared module executor so other JS calls don't queue behind it.
+            coroutineScope.launch(Dispatchers.IO) {
+                try {
+                    val fileUri = options["fileUri"] as? String ?: run {
+                        promise.reject("INVALID_URI", "fileUri is required", null)
+                        return@launch
+                    }
 
-                LogUtils.d(CLASS_NAME, "trimAudio called with fileUri: $fileUri")
-                LogUtils.d(CLASS_NAME, "Full options: $options")
+                    LogUtils.d(CLASS_NAME, "trimAudio called with fileUri: $fileUri")
+                    LogUtils.d(CLASS_NAME, "Full options: $options")
 
-                val mode = options["mode"] as? String ?: "single"
-                val startTimeMs = (options["startTimeMs"] as? Number)?.toLong()
-                val endTimeMs = (options["endTimeMs"] as? Number)?.toLong()
-                
-                @Suppress("UNCHECKED_CAST")
-                val rawRanges = options["ranges"] as? List<Map<String, Any>>
-                val ranges = rawRanges?.map { range ->
-                    mapOf(
-                        "startTimeMs" to ((range["startTimeMs"] as? Number)?.toLong() ?: 0L),
-                        "endTimeMs" to ((range["endTimeMs"] as? Number)?.toLong() ?: 0L)
+                    val mode = options["mode"] as? String ?: "single"
+                    val startTimeMs = (options["startTimeMs"] as? Number)?.toLong()
+                    val endTimeMs = (options["endTimeMs"] as? Number)?.toLong()
+
+                    @Suppress("UNCHECKED_CAST")
+                    val rawRanges = options["ranges"] as? List<Map<String, Any>>
+                    val ranges = rawRanges?.map { range ->
+                        mapOf(
+                            "startTimeMs" to ((range["startTimeMs"] as? Number)?.toLong() ?: 0L),
+                            "endTimeMs" to ((range["endTimeMs"] as? Number)?.toLong() ?: 0L)
+                        )
+                    }
+
+                    val outputFileName = options["outputFileName"] as? String
+
+                    @Suppress("UNCHECKED_CAST")
+                    var outputFormatMap = options["outputFormat"] as? Map<String, Any>
+
+                    if (outputFormatMap != null) {
+                        val format = outputFormatMap["format"] as? String
+                        if (format != null && format != "wav" && format != "aac" && format != "opus") {
+                            LogUtils.w(CLASS_NAME, "Requested format '$format' is not fully supported. Using 'aac' instead.")
+                            val newOutputFormat = HashMap<String, Any>(outputFormatMap)
+                            newOutputFormat["format"] = "aac"
+                            outputFormatMap = newOutputFormat
+                        }
+                    }
+
+                    LogUtils.d(CLASS_NAME, "Output format options: $outputFormatMap")
+
+                    val progressListener = object : AudioTrimmer.ProgressListener {
+                        override fun onProgress(progress: Float, bytesProcessed: Long, totalBytes: Long) {
+                            sendEvent(Constants.TRIM_PROGRESS_EVENT, mapOf(
+                                "progress" to progress,
+                                "bytesProcessed" to bytesProcessed,
+                                "totalBytes" to totalBytes
+                            ))
+                        }
+                    }
+
+                    val startTime = System.currentTimeMillis()
+
+                    val result = audioTrimmer.trimAudio(
+                        fileUri = fileUri,
+                        mode = mode,
+                        startTimeMs = startTimeMs,
+                        endTimeMs = endTimeMs,
+                        ranges = ranges,
+                        outputFileName = outputFileName,
+                        outputFormat = outputFormatMap,
+                        progressListener = progressListener
                     )
+
+                    val processingTimeMs = System.currentTimeMillis() - startTime
+
+                    val resultWithProcessingTime = result.toMutableMap()
+                    resultWithProcessingTime["processingInfo"] = mapOf(
+                        "durationMs" to processingTimeMs
+                    )
+
+                    LogUtils.d(CLASS_NAME, "Trim operation completed successfully in ${processingTimeMs}ms: $result")
+                    promise.resolve(resultWithProcessingTime)
+                } catch (e: Exception) {
+                    LogUtils.e(CLASS_NAME, "Error trimming audio: ${e.message}", e)
+                    promise.reject("TRIM_ERROR", "Error trimming audio: ${e.message}", e)
                 }
-                
-                val outputFileName = options["outputFileName"] as? String
-                
-                @Suppress("UNCHECKED_CAST")
-                var outputFormatMap = options["outputFormat"] as? Map<String, Any>
-                
-                // Validate output format if provided
-                if (outputFormatMap != null) {
-                    val format = outputFormatMap["format"] as? String
-                    if (format != null && format != "wav" && format != "aac" && format != "opus") {
-                        LogUtils.w(CLASS_NAME, "Requested format '$format' is not fully supported. Using 'aac' instead.")
-                        // Create a new map with the corrected format
-                        val newOutputFormat = HashMap<String, Any>(outputFormatMap)
-                        newOutputFormat["format"] = "aac"
-                        outputFormatMap = newOutputFormat
-                    }
-                }
-                
-                LogUtils.d(CLASS_NAME, "Output format options: $outputFormatMap")
-                
-                // Create progress listener
-                val progressListener = object : AudioTrimmer.ProgressListener {
-                    override fun onProgress(progress: Float, bytesProcessed: Long, totalBytes: Long) {
-                        sendEvent(Constants.TRIM_PROGRESS_EVENT, mapOf(
-                            "progress" to progress,
-                            "bytesProcessed" to bytesProcessed,
-                            "totalBytes" to totalBytes
-                        ))
-                    }
-                }
-
-                // Record start time
-                val startTime = System.currentTimeMillis()
-
-                // Perform the trim operation
-                val result = audioTrimmer.trimAudio(
-                    fileUri = fileUri,
-                    mode = mode,
-                    startTimeMs = startTimeMs,
-                    endTimeMs = endTimeMs,
-                    ranges = ranges,
-                    outputFileName = outputFileName,
-                    outputFormat = outputFormatMap,
-                    progressListener = progressListener
-                )
-
-                // Calculate processing time
-                val processingTimeMs = System.currentTimeMillis() - startTime
-                
-                // Add processing time to result
-                val resultWithProcessingTime = result.toMutableMap()
-                resultWithProcessingTime["processingInfo"] = mapOf(
-                    "durationMs" to processingTimeMs
-                )
-
-                LogUtils.d(CLASS_NAME, "Trim operation completed successfully in ${processingTimeMs}ms: $result")
-                promise.resolve(resultWithProcessingTime)
-            } catch (e: Exception) {
-                LogUtils.e(CLASS_NAME, "Error trimming audio: ${e.message}", e)
-                promise.reject("TRIM_ERROR", "Error trimming audio: ${e.message}", e)
             }
         }
 
         AsyncFunction("extractMelSpectrogram") { options: Map<String, Any>, promise: Promise ->
+            // Heavy DSP: file decode + STFT + mel projection. Off the shared
+            // module executor so other JS calls don't block.
+            coroutineScope.launch(Dispatchers.IO) {
             try {
-                // Log all incoming options for debugging
                 LogUtils.d(CLASS_NAME, "extractMelSpectrogram called with options: $options")
                 
                 // Extract required parameters with detailed logging
@@ -646,6 +645,7 @@ class AudioStudioModule : Module(), EventSender {
                 LogUtils.e(CLASS_NAME, "Stack trace: ${e.stackTraceToString()}")
                 promise.reject("SPECTROGRAM_ERROR", e.message ?: "Unknown error", e)
             }
+            }
         }
 
         OnDestroy {
@@ -669,9 +669,12 @@ class AudioStudioModule : Module(), EventSender {
 
 
         AsyncFunction("extractAudioAnalysis") { options: Map<String, Any>, promise: Promise ->
+            // Off the shared executor so other JS calls don't block during
+            // multi-second analysis on large files.
+            coroutineScope.launch(Dispatchers.IO) {
             try {
                 val fileUri = requireNotNull(options["fileUri"] as? String) { "fileUri is required" }
-                
+
                 // Get time or byte range options
                 val startTimeMs = options["startTimeMs"] as? Number
                 val endTimeMs = options["endTimeMs"] as? Number
@@ -766,9 +769,12 @@ class AudioStudioModule : Module(), EventSender {
                 LogUtils.e(CLASS_NAME, "Failed to extract audio analysis: ${e.message}", e)
                 promise.reject("PROCESSING_ERROR", e.message ?: "Unknown error", e)
             }
+            }
         }
 
         AsyncFunction("extractAudioData") { options: Map<String, Any>, promise: Promise ->
+            // Off the shared executor so concurrent JS calls don't block.
+            coroutineScope.launch(Dispatchers.IO) {
             try {
                 val fileUri = requireNotNull(options["fileUri"] as? String) { "fileUri is required" }
                 val startTimeMs = options["startTimeMs"] as? Number
@@ -934,6 +940,7 @@ class AudioStudioModule : Module(), EventSender {
                 LogUtils.e(CLASS_NAME, "Failed to extract audio data: ${e.message}")
                 LogUtils.e(CLASS_NAME, "Stack trace: ${e.stackTraceToString()}")
                 promise.reject("PROCESSING_ERROR", e.message ?: "Unknown error", e)
+            }
             }
         }
     }

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -17,7 +17,7 @@ import java.util.zip.CRC32
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -651,9 +651,12 @@ class AudioStudioModule : Module(), EventSender {
 
         OnDestroy {
             // Cancel in-flight prepare/trim/extract coroutines so promises
-            // and event sends do not outlive the React context. SupervisorJob
-            // alone does not get cancelled by Expo automatically.
-            coroutineScope.cancel()
+            // and event sends do not outlive the React context. Use
+            // cancelChildren rather than cancel() so the scope itself stays
+            // usable: Expo can re-invoke definition() on dev-client reloads
+            // while keeping the same module instance, and a fully cancelled
+            // scope would silently no-op every subsequent launch.
+            coroutineScope.coroutineContext.cancelChildren()
             AudioRecorderManager.destroy()
         }
 

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -1059,16 +1059,21 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         // Prepare notifications if enabled but don't show yet.
         // initializeNotifications schedules a Timer on the current thread's
         // RunLoop; prepareRecording runs on audioLifecycleQueue which has
-        // no running RunLoop. Hop to main *synchronously* so notificationManager
-        // is constructed before prepareRecording returns — otherwise a
-        // back-to-back startRecording would race past the async block and
-        // see notificationManager still nil.
+        // no running RunLoop, so the work has to land on main.
+        //
+        // .async is sufficient for the prepare → start ordering: this dispatch
+        // is enqueued before the promise.resolve hop in AudioStudioModule
+        // (which also goes through DispatchQueue.main), and main is FIFO, so
+        // initializeNotifications always runs before JS observes the resolve
+        // and queues startRecording. Using .async also avoids a forward
+        // deadlock hazard if a future caller ever invokes prepareRecording
+        // synchronously from main.
         if settings.showNotification {
             if Thread.isMainThread {
                 initializeNotifications()
             } else {
-                DispatchQueue.main.sync {
-                    self.initializeNotifications()
+                DispatchQueue.main.async { [weak self] in
+                    self?.initializeNotifications()
                 }
             }
         }
@@ -1649,13 +1654,9 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
            settings.enableProcessing,
            let _ = self.audioProcessor {
             let dataToAnalyze = takeAccumulatedAnalysisSnapshot()
-            if dataToAnalyze.isEmpty {
-                // Nothing to analyze yet; reset clock so we don't spin
-                self.lastEmissionTimeAnalysis = currentTime
-                return
-            }
             self.lastEmissionTimeAnalysis = currentTime
 
+            if !dataToAnalyze.isEmpty {
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self, let processor = self.audioProcessor, let settings = self.recordingSettings else {
                     // Logger.debug("Analysis Dispatch SKIP: self, processor, or settings nil")
@@ -1685,6 +1686,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                          Logger.debug("Analysis Dispatch FAIL: processor.processAudioBuffer returned nil")
                     }
                 }
+            }
             }
             // Logger.debug("Dispatched analysis task.") // Optional: Re-enable if needed
         }

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -65,6 +65,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     internal var lastEmittedCompressedSize: Int64 = 0
     private var totalDataSize: Int64 = 0
     private var lastBufferTime: AVAudioTime?
+    /// Guarded by `accumulatedDataLock`.
     private var accumulatedData = Data()
 
     // Data emission for onAudioAnalysis
@@ -73,6 +74,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     internal var lastEmittedCompressedSizeAnalysis: Int64 = 0
     private var totalDataSizeAnalysis: Int64 = 0
     private var lastBufferTimeAnalysis: AVAudioTime?
+    /// Guarded by `accumulatedDataLock`.
     private var accumulatedAnalysisData = Data()
 
     // Guards accumulatedData and accumulatedAnalysisData. The audio tap
@@ -1056,19 +1058,10 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("AudioStreamManager", "AudioProcessor activated successfully.")
         }
         
-        // Prepare notifications if enabled but don't show yet.
-        // initializeNotifications schedules a Timer on the current thread's
-        // RunLoop; prepareRecording runs on audioLifecycleQueue which has
-        // no running RunLoop, so the work has to land on main.
-        //
-        // Use .sync (with a Thread.isMainThread fast path) so the manager
-        // exists before prepareRecording returns. The direct-start path —
-        // startRecording calling prepareRecording recursively on the same
-        // audioLifecycleQueue and then continuing on to notificationManager?.
-        // startUpdates(...) without ever yielding to main — would otherwise
-        // see a nil manager and silently skip notification updates.
-        // No deadlock: the dispatch architecture never blocks main waiting
-        // on audioLifecycleQueue.
+        // initializeNotifications schedules a Timer that needs main's RunLoop,
+        // and notificationManager must exist before prepareRecording returns
+        // (the recursive startRecording → prepareRecording path uses it
+        // immediately). .sync is safe: nothing on main blocks on audioLifecycleQueue.
         if settings.showNotification {
             if Thread.isMainThread {
                 initializeNotifications()

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -1056,9 +1056,15 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("AudioStreamManager", "AudioProcessor activated successfully.")
         }
         
-        // Prepare notifications if enabled but don't show yet
+        // Prepare notifications if enabled but don't show yet.
+        // initializeNotifications schedules a Timer on the current thread's
+        // RunLoop; prepareRecording now runs on a background queue with no
+        // running RunLoop, so dispatch this to main to keep the elapsed-time
+        // / Now Playing updates firing reliably.
         if settings.showNotification {
-            initializeNotifications()
+            DispatchQueue.main.async { [weak self] in
+                self?.initializeNotifications()
+            }
         }
         
         // Mark preparation as complete

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -75,6 +75,54 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     private var lastBufferTimeAnalysis: AVAudioTime?
     private var accumulatedAnalysisData = Data()
 
+    // Guards accumulatedData and accumulatedAnalysisData. The audio tap
+    // appends from the render thread while emit/pause/stop snapshot-and-clear
+    // from other threads. Without this lock, base64EncodedString crashed
+    // mid-flush (issue #314) and short emissions were occasionally dropped.
+    private let accumulatedDataLock = NSLock()
+
+    /// Append the same chunk to both buffers under the lock.
+    /// Called from the audio tap thread.
+    private func appendAccumulated(_ data: Data) {
+        accumulatedDataLock.lock()
+        accumulatedData.append(data)
+        accumulatedAnalysisData.append(data)
+        accumulatedDataLock.unlock()
+    }
+
+    /// Atomically snapshot accumulatedData and clear it. Empty Data if buffer was empty.
+    private func takeAccumulatedSnapshot() -> Data {
+        accumulatedDataLock.lock()
+        defer { accumulatedDataLock.unlock() }
+        let snapshot = accumulatedData
+        accumulatedData.removeAll()
+        return snapshot
+    }
+
+    /// Atomically snapshot accumulatedAnalysisData and clear it.
+    private func takeAccumulatedAnalysisSnapshot() -> Data {
+        accumulatedDataLock.lock()
+        defer { accumulatedDataLock.unlock() }
+        let snapshot = accumulatedAnalysisData
+        accumulatedAnalysisData.removeAll()
+        return snapshot
+    }
+
+    /// Clear both buffers atomically (lifecycle resets).
+    private func resetAccumulated() {
+        accumulatedDataLock.lock()
+        accumulatedData.removeAll()
+        accumulatedAnalysisData.removeAll()
+        accumulatedDataLock.unlock()
+    }
+
+    /// Current size of accumulatedData for logs/probes.
+    private func accumulatedDataSize() -> Int {
+        accumulatedDataLock.lock()
+        defer { accumulatedDataLock.unlock() }
+        return accumulatedData.count
+    }
+
 
 
     private var fileManager = FileManager.default
@@ -848,8 +896,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         emissionIntervalAnalysis = max(10.0, Double(settings.intervalAnalysis ?? 500)) / 1000.0
         lastEmissionTime = nil // Will be set when recording starts
         lastEmissionTimeAnalysis = nil // Will be set when recording starts
-        accumulatedData.removeAll()
-        accumulatedAnalysisData.removeAll()
+        resetAccumulated()
         totalDataSize = 0
         totalDataSizeAnalysis = 0
         totalPausedDuration = 0
@@ -1176,16 +1223,12 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         Logger.debug("Pausing recording...")
         
         // Emit any remaining audio data before pausing
-        if !accumulatedData.isEmpty {
-            Logger.debug("Emitting final audio chunk of \(accumulatedData.count) bytes before pausing")
+        let finalData = takeAccumulatedSnapshot()
+        if !finalData.isEmpty {
+            Logger.debug("Emitting final audio chunk of \(finalData.count) bytes before pausing")
             let recordingTime = currentRecordingDuration()
             let finalTotalSize = self.totalDataSize
-            
-            // Create a copy of accumulated data to avoid race conditions
-            let finalData = accumulatedData
-            accumulatedData.removeAll()
-            
-            // Notify delegate with final audio data
+
             delegate?.audioStreamManager(
                 self,
                 didReceiveAudioData: finalData,
@@ -1541,9 +1584,9 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         }
 
         // --- Event Emission & Analysis (Always Happens) ---
-        // Audio streaming is independent of file output settings
-        accumulatedData.append(dataToWrite)
-        accumulatedAnalysisData.append(dataToWrite)
+        // Audio streaming is independent of file output settings.
+        // Lock-protected append: see accumulatedDataLock for rationale.
+        appendAccumulated(dataToWrite)
 
         if recordingSettings?.showNotification == true {
             updateNotificationDuration()
@@ -1554,34 +1597,36 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
 
         // Emit AudioData event
         if let lastEmission = self.lastEmissionTime {
-            // Log emission evaluation every 10th buffer
             if debugBufferCounter % 10 == 0 {
                 let timeGap = currentTime.timeIntervalSince(lastEmission)
                 let isTimeReady = timeGap >= emissionInterval
-                Logger.debug("EMISSION DEBUG: Time since last: \(timeGap)s, Threshold: \(emissionInterval)s, Ready: \(isTimeReady), DataSize: \(accumulatedData.count) bytes")
+                Logger.debug("EMISSION DEBUG: Time since last: \(timeGap)s, Threshold: \(emissionInterval)s, Ready: \(isTimeReady), DataSize: \(accumulatedDataSize()) bytes")
             }
-            
-            if currentTime.timeIntervalSince(lastEmission) >= emissionInterval,
-               !accumulatedData.isEmpty {
-                let dataToEmit = accumulatedData
-                let recordingTime = currentRecordingDuration()
-                self.lastEmissionTime = currentTime
-                self.lastEmittedSize = currentTotalSize
-                accumulatedData.removeAll()
-                let compressionInfo = buildCompressionInfo()
-                
-                Logger.debug("EMISSION SUCCESS: Emitting \(dataToEmit.count) bytes at recording time \(recordingTime)s")
-                
-                delegate?.audioStreamManager(
-                    self,
-                    didReceiveAudioData: dataToEmit,
-                    recordingTime: recordingTime,
-                    totalDataSize: currentTotalSize,
-                    compressionInfo: compressionInfo
-                )
+
+            if currentTime.timeIntervalSince(lastEmission) >= emissionInterval {
+                // Atomic snapshot+clear avoids the race that crashed
+                // base64EncodedString in the delegate (issue #314) and
+                // stops short writes from being dropped between read
+                // and clear.
+                let dataToEmit = takeAccumulatedSnapshot()
+                if !dataToEmit.isEmpty {
+                    let recordingTime = currentRecordingDuration()
+                    self.lastEmissionTime = currentTime
+                    self.lastEmittedSize = currentTotalSize
+                    let compressionInfo = buildCompressionInfo()
+
+                    Logger.debug("EMISSION SUCCESS: Emitting \(dataToEmit.count) bytes at recording time \(recordingTime)s")
+
+                    delegate?.audioStreamManager(
+                        self,
+                        didReceiveAudioData: dataToEmit,
+                        recordingTime: recordingTime,
+                        totalDataSize: currentTotalSize,
+                        compressionInfo: compressionInfo
+                    )
+                }
             }
         } else {
-            // This case occurs when lastEmissionTime is nil (either first run or after reset)
             Logger.debug("EMISSION DEBUG: lastEmissionTime is nil, setting to current time")
             lastEmissionTime = currentTime
         }
@@ -1590,11 +1635,14 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         if let lastEmissionAnalysis = self.lastEmissionTimeAnalysis,
            currentTime.timeIntervalSince(lastEmissionAnalysis) >= emissionIntervalAnalysis,
            settings.enableProcessing,
-           let _ = self.audioProcessor,
-           !accumulatedAnalysisData.isEmpty {
-            let dataToAnalyze = accumulatedAnalysisData
+           let _ = self.audioProcessor {
+            let dataToAnalyze = takeAccumulatedAnalysisSnapshot()
+            if dataToAnalyze.isEmpty {
+                // Nothing to analyze yet; reset clock so we don't spin
+                self.lastEmissionTimeAnalysis = currentTime
+                return
+            }
             self.lastEmissionTimeAnalysis = currentTime
-            accumulatedAnalysisData.removeAll()
 
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self, let processor = self.audioProcessor, let settings = self.recordingSettings else {
@@ -1743,24 +1791,23 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         
         Logger.debug("Stopping recording...")
         
-        // IMPORTANT: Emit any remaining audio data before stopping the engine
-        if isRecording && !accumulatedData.isEmpty {
-            Logger.debug("Emitting final audio chunk of \(accumulatedData.count) bytes before stopping")
-            let recordingTime = currentRecordingDuration()
-            let finalTotalSize = self.totalDataSize // Use current total size
-            
-            // Create a copy of accumulated data to avoid race conditions
-            let finalData = accumulatedData
-            accumulatedData.removeAll()
-            
-            // Notify delegate with final audio data
-            delegate?.audioStreamManager(
-                self,
-                didReceiveAudioData: finalData,
-                recordingTime: recordingTime,
-                totalDataSize: finalTotalSize,
-                compressionInfo: buildCompressionInfo()
-            )
+        // IMPORTANT: Emit any remaining audio data before stopping the engine.
+        // Atomic snapshot avoids the race documented in #314.
+        if isRecording {
+            let finalData = takeAccumulatedSnapshot()
+            if !finalData.isEmpty {
+                Logger.debug("Emitting final audio chunk of \(finalData.count) bytes before stopping")
+                let recordingTime = currentRecordingDuration()
+                let finalTotalSize = self.totalDataSize
+
+                delegate?.audioStreamManager(
+                    self,
+                    didReceiveAudioData: finalData,
+                    recordingTime: recordingTime,
+                    totalDataSize: finalTotalSize,
+                    compressionInfo: buildCompressionInfo()
+                )
+            }
         }
 
         disableWakeLock()
@@ -1903,8 +1950,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             lastEmittedSize = 0
             lastEmittedSizeAnalysis = 0
             lastEmittedCompressedSize = 0
-            accumulatedData.removeAll()
-            accumulatedAnalysisData.removeAll()
+            resetAccumulated()
             recordingUUID = nil
             totalDataSize = 0
             
@@ -1969,8 +2015,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             self.lastEmittedSize = 0
             self.lastEmittedSizeAnalysis = 0
             self.lastEmittedCompressedSize = 0
-            self.accumulatedData.removeAll()
-            self.accumulatedAnalysisData.removeAll()
+            self.resetAccumulated()
             self.recordingUUID = nil
             self.totalDataSize = 0
             self.cachedWavFileSize = 0
@@ -2172,16 +2217,16 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                 Logger.debug("Recording was manually paused, leaving engine paused after fallback.")
             }
 
-            // Emit any remaining audio data from the previous device before resetting timers
-            if !accumulatedData.isEmpty {
-                Logger.debug("Emitting final audio chunk of \(accumulatedData.count) bytes from previous device")
+            // Emit any remaining audio data from the previous device, then
+            // wipe both buffers atomically (analysis buffer is discarded since
+            // we want to start fresh on the fallback device).
+            let finalData = takeAccumulatedSnapshot()
+            _ = takeAccumulatedAnalysisSnapshot()
+            if !finalData.isEmpty {
+                Logger.debug("Emitting final audio chunk of \(finalData.count) bytes from previous device")
                 let recordingTime = currentRecordingDuration()
                 let finalTotalSize = self.totalDataSize
-                
-                // Create a copy of accumulated data to avoid race conditions
-                let finalData = accumulatedData
-                
-                // Notify delegate with final audio data from previous device
+
                 delegate?.audioStreamManager(
                     self,
                     didReceiveAudioData: finalData,
@@ -2190,15 +2235,10 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                     compressionInfo: buildCompressionInfo()
                 )
             }
-            
+
             // Reset emission timers to force new data emission with the fallback device
             lastEmissionTime = Date() // Reset to force immediate emission
             lastEmissionTimeAnalysis = Date() // Reset analysis timer too
-            
-            // Important: Do not reset totalDataSize here - it needs to be maintained
-            // We only clear the buffers to start accumulating new data from the fallback device
-            accumulatedData.removeAll() // Clear any partial data from previous device
-            accumulatedAnalysisData.removeAll() // Clear analysis data buffer
             Logger.debug("Emission timers reset. Current totalDataSize: \(totalDataSize)")
 
             // CRITICAL: Multiple scheduled recovery attempts
@@ -2208,14 +2248,13 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                     Logger.debug("FALLBACK RECOVERY: Checking for data at \(delaySeconds)s")
                     
                     // Force an immediate emission if data is being received but not emitted
-                    if !self.accumulatedData.isEmpty {
+                    let dataToEmit = self.takeAccumulatedSnapshot()
+                    if !dataToEmit.isEmpty {
                         Logger.debug("FALLBACK RECOVERY: Forcing emission from accumulated data after \(delaySeconds)s (total size: \(self.totalDataSize))")
-                        let dataToEmit = self.accumulatedData
                         let recordingTime = self.currentRecordingDuration()
                         let totalSize = self.totalDataSize
-                        
+
                         self.lastEmissionTime = Date() // Reset the emission timer
-                        self.accumulatedData.removeAll() // Clear the buffer
                         
                         // Direct delegate call with accumulated data
                         self.delegate?.audioStreamManager(

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -1058,12 +1058,18 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         
         // Prepare notifications if enabled but don't show yet.
         // initializeNotifications schedules a Timer on the current thread's
-        // RunLoop; prepareRecording now runs on a background queue with no
-        // running RunLoop, so dispatch this to main to keep the elapsed-time
-        // / Now Playing updates firing reliably.
+        // RunLoop; prepareRecording runs on audioLifecycleQueue which has
+        // no running RunLoop. Hop to main *synchronously* so notificationManager
+        // is constructed before prepareRecording returns — otherwise a
+        // back-to-back startRecording would race past the async block and
+        // see notificationManager still nil.
         if settings.showNotification {
-            DispatchQueue.main.async { [weak self] in
-                self?.initializeNotifications()
+            if Thread.isMainThread {
+                initializeNotifications()
+            } else {
+                DispatchQueue.main.sync {
+                    self.initializeNotifications()
+                }
             }
         }
         

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -1061,19 +1061,20 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         // RunLoop; prepareRecording runs on audioLifecycleQueue which has
         // no running RunLoop, so the work has to land on main.
         //
-        // .async is sufficient for the prepare → start ordering: this dispatch
-        // is enqueued before the promise.resolve hop in AudioStudioModule
-        // (which also goes through DispatchQueue.main), and main is FIFO, so
-        // initializeNotifications always runs before JS observes the resolve
-        // and queues startRecording. Using .async also avoids a forward
-        // deadlock hazard if a future caller ever invokes prepareRecording
-        // synchronously from main.
+        // Use .sync (with a Thread.isMainThread fast path) so the manager
+        // exists before prepareRecording returns. The direct-start path —
+        // startRecording calling prepareRecording recursively on the same
+        // audioLifecycleQueue and then continuing on to notificationManager?.
+        // startUpdates(...) without ever yielding to main — would otherwise
+        // see a nil manager and silently skip notification updates.
+        // No deadlock: the dispatch architecture never blocks main waiting
+        // on audioLifecycleQueue.
         if settings.showNotification {
             if Thread.isMainThread {
                 initializeNotifications()
             } else {
-                DispatchQueue.main.async { [weak self] in
-                    self?.initializeNotifications()
+                DispatchQueue.main.sync {
+                    self.initializeNotifications()
                 }
             }
         }

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -830,16 +830,14 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             return false
         }
 
-        // Reset audio session before preparing new recording
+        // Deactivate the session for a clean slate before reconfiguring.
+        // configureAudioSession() below will activate it once — no need for
+        // the previous deactivate→sleep→activate→reconfigure→activate cycle.
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setActive(false, options: .notifyOthersOnDeactivation)
-            Thread.sleep(forTimeInterval: 0.1) // Brief pause to ensure clean state
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
-            Logger.debug("AudioStreamManager", "Failed to reset audio session: \(error)")
-            delegate?.audioStreamManager(self, didFailWithError: "Failed to reset audio session: \(error.localizedDescription)")
-            return false
+            Logger.debug("AudioStreamManager", "Failed to deactivate audio session (non-fatal): \(error)")
         }
 
         // Update auto-resume preference from settings
@@ -943,8 +941,9 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
 
             recordingSettings = newSettings  // Keep original settings with desired sample rate
 
-            audioEngine.prepare() // Prepare the engine without starting it
-            
+            // audioEngine.prepare() is already called inside installTapWithHardwareFormat()
+            // (default prepareEngine: true). Don't call it twice.
+
             // Setup compressed recording if enabled
             if settings.output.compressed.enabled {
                 // Create compressed settings

--- a/packages/audio-studio/ios/AudioStudioModule.swift
+++ b/packages/audio-studio/ios/AudioStudioModule.swift
@@ -24,6 +24,14 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
     private let notificationIdentifier = "audio_recording_notification"
     private var deviceManager = AudioDeviceManager()
     private var deviceChangeObserver: Any?
+
+    // Serial queue for AVAudioEngine lifecycle ops (prepare/start/stop).
+    // Prevents concurrent mutation of shared engine state and keeps callers
+    // off the main thread to avoid UI freezes during heavy native init.
+    private let audioLifecycleQueue = DispatchQueue(
+        label: "net.siteed.audiostudio.lifecycle",
+        qos: .userInitiated
+    )
         
     public func definition() -> ModuleDefinition {
         Name("AudioStudio")
@@ -220,30 +228,37 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
                         }
                     }
 
-                    if let result = self.streamManager.startRecording(settings: settings) {
-                        var resultDict: [String: Any] = [
-                            "fileUri": result.fileUri,
-                            "channels": result.channels,
-                            "bitDepth": result.bitDepth,
-                            "sampleRate": result.sampleRate,
-                            "mimeType": result.mimeType,
-                        ]
+                    // Serialize on lifecycle queue: avoids racing with prepare/stop
+                    // and keeps the JS/UI thread responsive while audio session
+                    // and AVAudioEngine come up.
+                    self.audioLifecycleQueue.async {
+                        let result = self.streamManager.startRecording(settings: settings)
+                        DispatchQueue.main.async {
+                            if let result = result {
+                                var resultDict: [String: Any] = [
+                                    "fileUri": result.fileUri,
+                                    "channels": result.channels,
+                                    "bitDepth": result.bitDepth,
+                                    "sampleRate": result.sampleRate,
+                                    "mimeType": result.mimeType,
+                                ]
 
-                        // Add compression info if available
-                        if let compression = result.compression {
-                            resultDict["compression"] = [
-                                "compressedFileUri": compression.compressedFileUri,
-                                "mimeType": compression.mimeType,
-                                "bitrate": compression.bitrate,
-                                "format": compression.format
-                            ]
+                                if let compression = result.compression {
+                                    resultDict["compression"] = [
+                                        "compressedFileUri": compression.compressedFileUri,
+                                        "mimeType": compression.mimeType,
+                                        "bitrate": compression.bitrate,
+                                        "format": compression.format
+                                    ]
+                                }
+
+                                Logger.info("AudioStudioModule", "Recording started successfully")
+                                promise.resolve(resultDict)
+                            } else {
+                                Logger.error("AudioStudioModule", "Failed to start recording")
+                                promise.reject("ERROR", "Failed to start recording.")
+                            }
                         }
-
-                        Logger.info("AudioStudioModule", "Recording started successfully")
-                        promise.resolve(resultDict)
-                    } else {
-                        Logger.error("AudioStudioModule", "Failed to start recording")
-                        promise.reject("ERROR", "Failed to start recording.")
                     }
 
                 case .failure(let error):
@@ -275,21 +290,28 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
                     promise.reject("PERMISSION_DENIED", "Recording permission has not been granted")
                     return
                 }
-                
+
                 // Create settings with validation
                 let settingsResult = RecordingSettings.fromDictionary(options)
-                
+
                 switch settingsResult {
                 case .success(let settings):
-                    Logger.debug("AudioStudioModule", "prepareRecording: Settings parsed successfully. Calling streamManager.prepareRecording")
-                    if self.streamManager.prepareRecording(settings: settings) {
-                        Logger.info("AudioStudioModule", "prepareRecording: Preparation successful.")
-                        promise.resolve(true)
-                    } else {
-                        Logger.error("AudioStudioModule", "prepareRecording: streamManager.prepareRecording returned false.")
-                        promise.reject("ERROR", "Failed to prepare recording.")
+                    Logger.debug("AudioStudioModule", "prepareRecording: Settings parsed. Dispatching to serial audio queue.")
+                    // Serial queue prevents concurrent AVAudioEngine mutation if
+                    // prepare/start/stop overlap. Off-main keeps UI responsive.
+                    self.audioLifecycleQueue.async {
+                        let ok = self.streamManager.prepareRecording(settings: settings)
+                        DispatchQueue.main.async {
+                            if ok {
+                                Logger.info("AudioStudioModule", "prepareRecording: Preparation successful.")
+                                promise.resolve(true)
+                            } else {
+                                Logger.error("AudioStudioModule", "prepareRecording: streamManager.prepareRecording returned false.")
+                                promise.reject("ERROR", "Failed to prepare recording.")
+                            }
+                        }
                     }
-                    
+
                 case .failure(let error):
                     promise.reject("INVALID_SETTINGS", error.localizedDescription)
                 }
@@ -314,36 +336,43 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
         ///   - promise: A promise to resolve with the recording result or reject with an error.
         AsyncFunction("stopRecording") { (promise: Promise) in
             Logger.debug("AudioStudioModule", "stopRecording called.")
-            
-            if let recordingResult = self.streamManager.stopRecording() {
-                var resultDict: [String: Any] = [
-                    "fileUri": recordingResult.fileUri,
-                    "filename": recordingResult.filename,
-                    "durationMs": recordingResult.duration,
-                    "size": recordingResult.size,
-                    "channels": recordingResult.channels,
-                    "bitDepth": recordingResult.bitDepth,
-                    "sampleRate": recordingResult.sampleRate,
-                    "mimeType": recordingResult.mimeType,
-                    "createdAt": Date().timeIntervalSince1970 * 1000,
-                ]
-                
-                // Add compression info if available
-                if let compression = recordingResult.compression {
-                    resultDict["compression"] = [
-                        "compressedFileUri": compression.compressedFileUri,
-                        "mimeType": compression.mimeType,
-                        "bitrate": compression.bitrate,
-                        "format": compression.format,
-                        "size": compression.size
-                    ]
+
+            // Serialize on lifecycle queue: stop flushes file handles and
+            // tears down AVAudioEngine; must not race with start/prepare and
+            // must not block the JS/UI thread.
+            self.audioLifecycleQueue.async {
+                let recordingResult = self.streamManager.stopRecording()
+                DispatchQueue.main.async {
+                    if let recordingResult = recordingResult {
+                        var resultDict: [String: Any] = [
+                            "fileUri": recordingResult.fileUri,
+                            "filename": recordingResult.filename,
+                            "durationMs": recordingResult.duration,
+                            "size": recordingResult.size,
+                            "channels": recordingResult.channels,
+                            "bitDepth": recordingResult.bitDepth,
+                            "sampleRate": recordingResult.sampleRate,
+                            "mimeType": recordingResult.mimeType,
+                            "createdAt": Date().timeIntervalSince1970 * 1000,
+                        ]
+
+                        if let compression = recordingResult.compression {
+                            resultDict["compression"] = [
+                                "compressedFileUri": compression.compressedFileUri,
+                                "mimeType": compression.mimeType,
+                                "bitrate": compression.bitrate,
+                                "format": compression.format,
+                                "size": compression.size
+                            ]
+                        }
+
+                        Logger.info("AudioStudioModule", "stopRecording: Recording stopped successfully. fileUri: \(recordingResult.fileUri), size: \(recordingResult.size)")
+                        promise.resolve(resultDict)
+                    } else {
+                        Logger.error("AudioStudioModule", "stopRecording: streamManager.stopRecording returned nil.")
+                        promise.reject("ERROR", "Failed to stop recording or no recording in progress.")
+                    }
                 }
-                
-                Logger.info("AudioStudioModule", "stopRecording: Recording stopped successfully. fileUri: \(recordingResult.fileUri), size: \(recordingResult.size)")
-                promise.resolve(resultDict)
-            } else {
-                Logger.error("AudioStudioModule", "stopRecording: streamManager.stopRecording returned nil.")
-                promise.reject("ERROR", "Failed to stop recording or no recording in progress.")
             }
         }
         
@@ -609,95 +638,89 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
                 return
             }
 
-            do {
-                let audioFile = try AVAudioFile(forReading: url)
-                let format = audioFile.processingFormat
-                let sampleRate = format.sampleRate
-                let channels = Int(format.channelCount)
-                let bitDepth = audioFile.fileFormat.settings[AVLinearPCMBitDepthKey] as? Int ?? 16
+            // File decode + frame read can take 100s of ms on large files.
+            // Move off main to keep JS/UI responsive.
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let audioFile = try AVAudioFile(forReading: url)
+                    let format = audioFile.processingFormat
+                    let sampleRate = format.sampleRate
+                    let channels = Int(format.channelCount)
+                    let bitDepth = audioFile.fileFormat.settings[AVLinearPCMBitDepthKey] as? Int ?? 16
 
-                // Calculate frame positions
-                let startFrame: AVAudioFramePosition
-                let endFrame: AVAudioFramePosition
+                    let startFrame: AVAudioFramePosition
+                    let endFrame: AVAudioFramePosition
 
-                if hasTimeRange {
-                    startFrame = AVAudioFramePosition(startTimeMs! * sampleRate / 1000.0)
-                    endFrame = AVAudioFramePosition(endTimeMs! * sampleRate / 1000.0)
-                } else {
-                    // Convert byte position to frame position
-                    let bytesPerFrame = Int64(channels * (bitDepth / 8))
-                    startFrame = AVAudioFramePosition(position!) / bytesPerFrame
-                    endFrame = startFrame + (AVAudioFramePosition(length!) / bytesPerFrame)
-                }
+                    if hasTimeRange {
+                        startFrame = AVAudioFramePosition(startTimeMs! * sampleRate / 1000.0)
+                        endFrame = AVAudioFramePosition(endTimeMs! * sampleRate / 1000.0)
+                    } else {
+                        let bytesPerFrame = Int64(channels * (bitDepth / 8))
+                        startFrame = AVAudioFramePosition(position!) / bytesPerFrame
+                        endFrame = startFrame + (AVAudioFramePosition(length!) / bytesPerFrame)
+                    }
 
-                // Validate frame range
-                guard startFrame >= 0 && endFrame <= audioFile.length && startFrame < endFrame else {
-                    promise.reject("INVALID_RANGE", "Invalid range specified")
-                    return
-                }
+                    guard startFrame >= 0 && endFrame <= audioFile.length && startFrame < endFrame else {
+                        promise.reject("INVALID_RANGE", "Invalid range specified")
+                        return
+                    }
 
-                let frameCount = AVAudioFrameCount(endFrame - startFrame)
-                
-                
-                // Pass both options separately - normalizeAudio from decodingOptions, and includeNormalizedData as is
-                let decodingConfig = DecodingConfig.fromDictionary(decodingOptions)
-                
-                let (pcmData, normalizedData, base64Data) = try extractRawAudioData(
-                    from: url,
-                    startFrame: startFrame,
-                    frameCount: frameCount,
-                    format: format,
-                    decodingConfig: decodingConfig,
-                    includeNormalizedData: includeNormalizedData,
-                    includeBase64Data: includeBase64Data
-                )
+                    let frameCount = AVAudioFrameCount(endFrame - startFrame)
 
-                var resultDict: [String: Any] = [:]
-                
-                if includeWavHeader {
-                    // Create WAV header and prepend it to the PCM data
-                    let wavData = createWavHeader(
-                        pcmData: pcmData,
-                        sampleRate: Int(sampleRate),
-                        channels: channels,
-                        bitDepth: bitDepth
+                    let decodingConfig = DecodingConfig.fromDictionary(decodingOptions)
+
+                    let (pcmData, normalizedData, base64Data) = try extractRawAudioData(
+                        from: url,
+                        startFrame: startFrame,
+                        frameCount: frameCount,
+                        format: format,
+                        decodingConfig: decodingConfig,
+                        includeNormalizedData: includeNormalizedData,
+                        includeBase64Data: includeBase64Data
                     )
-                    resultDict["pcmData"] = wavData
-                    resultDict["hasWavHeader"] = true
-                } else {
-                    resultDict["pcmData"] = pcmData
-                    resultDict["hasWavHeader"] = false
-                }
-                
-                // Add the rest of the data
-                resultDict["sampleRate"] = Int(sampleRate)
-                resultDict["channels"] = channels
-                resultDict["bitDepth"] = bitDepth
-                resultDict["durationMs"] = Int(Double(frameCount) * 1000.0 / sampleRate)
-                resultDict["format"] = "pcm_\(bitDepth)bit"
-                resultDict["samples"] = Int(frameCount) * channels
-                
-                // Add normalized data if requested, regardless of normalization setting
-                if includeNormalizedData {
-                    resultDict["normalizedData"] = normalizedData
-                }
-                
-                // Add checksum if requested
-                if options["computeChecksum"] as? Bool == true {
-                    let checksum = calculateCRC32(data: pcmData)
-                    resultDict["checksum"] = Int(checksum)
-                    
-                    Logger.debug("AudioStudioModule", "Computed CRC32 checksum: \(checksum)")
-                }
-                
-                if let includeBase64Data = options["includeBase64Data"] as? Bool, includeBase64Data {
-                    resultDict["base64Data"] = base64Data
-                }
-                
-                promise.resolve(resultDict)
 
-            } catch {
-                promise.reject("PROCESSING_ERROR", "Failed to process audio file: \(error.localizedDescription)")
+                    var resultDict: [String: Any] = [:]
+
+                    if includeWavHeader {
+                        let wavData = createWavHeader(
+                            pcmData: pcmData,
+                            sampleRate: Int(sampleRate),
+                            channels: channels,
+                            bitDepth: bitDepth
+                        )
+                        resultDict["pcmData"] = wavData
+                        resultDict["hasWavHeader"] = true
+                    } else {
+                        resultDict["pcmData"] = pcmData
+                        resultDict["hasWavHeader"] = false
+                    }
+
+                    resultDict["sampleRate"] = Int(sampleRate)
+                    resultDict["channels"] = channels
+                    resultDict["bitDepth"] = bitDepth
+                    resultDict["durationMs"] = Int(Double(frameCount) * 1000.0 / sampleRate)
+                    resultDict["format"] = "pcm_\(bitDepth)bit"
+                    resultDict["samples"] = Int(frameCount) * channels
+
+                    if includeNormalizedData {
+                        resultDict["normalizedData"] = normalizedData
+                    }
+
+                    if options["computeChecksum"] as? Bool == true {
+                        let checksum = calculateCRC32(data: pcmData)
+                        resultDict["checksum"] = Int(checksum)
+                        Logger.debug("AudioStudioModule", "Computed CRC32 checksum: \(checksum)")
+                    }
+
+                    if let includeBase64Data = options["includeBase64Data"] as? Bool, includeBase64Data {
+                        resultDict["base64Data"] = base64Data
+                    }
+
+                    promise.resolve(resultDict)
+
+                } catch {
+                    promise.reject("PROCESSING_ERROR", "Failed to process audio file: \(error.localizedDescription)")
+                }
             }
         }
         
@@ -710,90 +733,90 @@ public class AudioStudioModule: Module, AudioStreamManagerDelegate, AudioDeviceM
         ///   - promise: A promise to resolve with the extracted mel spectrogram data or reject with an error.
         /// - Returns: Promise to be resolved with mel spectrogram data.
         AsyncFunction("extractMelSpectrogram") { (options: [String: Any], promise: Promise) in
-            do {
-                guard let fileUri = options["fileUri"] as? String else {
-                    throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "fileUri is required"])
-                }
-                guard let windowSizeMs = options["windowSizeMs"] as? Double else {
-                    throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "windowSizeMs is required"])
-                }
-                guard let hopLengthMs = options["hopLengthMs"] as? Double else {
-                    throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "hopLengthMs is required"])
-                }
-                guard let nMels = options["nMels"] as? Int ?? (options["nMels"] as? Double).map({ Int($0) }) else {
-                    throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "nMels is required"])
-                }
-
-                let fMin = Float(options["fMin"] as? Double ?? 0.0)
-                let fMaxParam = options["fMax"] as? Double
-                let windowType = options["windowType"] as? String ?? "hann"
-                let logScale = options["logScale"] as? Bool ?? true
-                let normalize = options["normalize"] as? Bool ?? false
-                let startTimeMs = options["startTimeMs"] as? Double
-                let endTimeMs = options["endTimeMs"] as? Double
-
-                // Load audio file to PCM float samples
-                let audioData = try loadAudioFile(fileUri)
-                let sampleRate = audioData.sampleRate
-                var samples = audioData.samples
-
-                // Apply time range trimming if specified
-                if let startMs = startTimeMs {
-                    let startSample = Int(startMs * Double(sampleRate) / 1000.0)
-                    let endSample: Int
-                    if let endMs = endTimeMs {
-                        endSample = min(Int(endMs * Double(sampleRate) / 1000.0), samples.count)
-                    } else {
-                        endSample = samples.count
+            // Heavy DSP: file decode + STFT + mel projection. Multi-second on
+            // large files. Move off main to keep JS/UI responsive.
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    guard let fileUri = options["fileUri"] as? String else {
+                        throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "fileUri is required"])
                     }
-                    if startSample < endSample && startSample < samples.count {
-                        samples = Array(samples[startSample..<endSample])
+                    guard let windowSizeMs = options["windowSizeMs"] as? Double else {
+                        throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "windowSizeMs is required"])
                     }
+                    guard let hopLengthMs = options["hopLengthMs"] as? Double else {
+                        throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "hopLengthMs is required"])
+                    }
+                    guard let nMels = options["nMels"] as? Int ?? (options["nMels"] as? Double).map({ Int($0) }) else {
+                        throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "nMels is required"])
+                    }
+
+                    let fMin = Float(options["fMin"] as? Double ?? 0.0)
+                    let fMaxParam = options["fMax"] as? Double
+                    let windowType = options["windowType"] as? String ?? "hann"
+                    let logScale = options["logScale"] as? Bool ?? true
+                    let normalize = options["normalize"] as? Bool ?? false
+                    let startTimeMs = options["startTimeMs"] as? Double
+                    let endTimeMs = options["endTimeMs"] as? Double
+
+                    let audioData = try loadAudioFile(fileUri)
+                    let sampleRate = audioData.sampleRate
+                    var samples = audioData.samples
+
+                    if let startMs = startTimeMs {
+                        let startSample = Int(startMs * Double(sampleRate) / 1000.0)
+                        let endSample: Int
+                        if let endMs = endTimeMs {
+                            endSample = min(Int(endMs * Double(sampleRate) / 1000.0), samples.count)
+                        } else {
+                            endSample = samples.count
+                        }
+                        if startSample < endSample && startSample < samples.count {
+                            samples = Array(samples[startSample..<endSample])
+                        }
+                    }
+
+                    let fMax = fMaxParam.map { Float($0) } ?? Float(sampleRate) / 2.0
+
+                    let windowSizeSamples = Int(windowSizeMs * Double(sampleRate) / 1000.0)
+                    let hopLengthSamples = Int(hopLengthMs * Double(sampleRate) / 1000.0)
+
+                    let windowTypeInt: Int32 = windowType.lowercased() == "hamming" ? 1 : 0
+
+                    guard let result = samples.withUnsafeBufferPointer({ bufferPtr -> [AnyHashable: Any]? in
+                        guard let baseAddress = bufferPtr.baseAddress else { return nil }
+                        return MelSpectrogramWrapper.compute(
+                            withSamples: baseAddress,
+                            numSamples: Int32(samples.count),
+                            sampleRate: Int32(sampleRate),
+                            fftLength: 2048,
+                            windowSizeSamples: Int32(windowSizeSamples),
+                            hopLengthSamples: Int32(hopLengthSamples),
+                            nMels: Int32(nMels),
+                            fMin: fMin,
+                            fMax: fMax,
+                            windowType: windowTypeInt,
+                            logScale: logScale,
+                            normalize: normalize
+                        )
+                    }) else {
+                        throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "Audio data is too short for spectrogram analysis"])
+                    }
+
+                    let timeSteps = result["timeSteps"] as! Int
+                    let durationMs = Double(samples.count) / Double(sampleRate) * 1000.0
+
+                    let output: [String: Any] = [
+                        "spectrogram": result["spectrogram"]!,
+                        "sampleRate": sampleRate,
+                        "nMels": nMels,
+                        "timeSteps": timeSteps,
+                        "durationMs": durationMs
+                    ]
+
+                    promise.resolve(output)
+                } catch {
+                    promise.reject("SPECTROGRAM_ERROR", "Failed to extract mel spectrogram: \(error.localizedDescription)")
                 }
-
-                let fMax = fMaxParam.map { Float($0) } ?? Float(sampleRate) / 2.0
-
-                // Convert ms to samples
-                let windowSizeSamples = Int(windowSizeMs * Double(sampleRate) / 1000.0)
-                let hopLengthSamples = Int(hopLengthMs * Double(sampleRate) / 1000.0)
-
-                let windowTypeInt: Int32 = windowType.lowercased() == "hamming" ? 1 : 0
-
-                // Call shared C++ implementation via ObjC++ wrapper
-                guard let result = samples.withUnsafeBufferPointer({ bufferPtr -> [AnyHashable: Any]? in
-                    guard let baseAddress = bufferPtr.baseAddress else { return nil }
-                    return MelSpectrogramWrapper.compute(
-                        withSamples: baseAddress,
-                        numSamples: Int32(samples.count),
-                        sampleRate: Int32(sampleRate),
-                        fftLength: 2048,
-                        windowSizeSamples: Int32(windowSizeSamples),
-                        hopLengthSamples: Int32(hopLengthSamples),
-                        nMels: Int32(nMels),
-                        fMin: fMin,
-                        fMax: fMax,
-                        windowType: windowTypeInt,
-                        logScale: logScale,
-                        normalize: normalize
-                    )
-                }) else {
-                    throw NSError(domain: "AudioStudio", code: -1, userInfo: [NSLocalizedDescriptionKey: "Audio data is too short for spectrogram analysis"])
-                }
-
-                let timeSteps = result["timeSteps"] as! Int
-                let durationMs = Double(samples.count) / Double(sampleRate) * 1000.0
-
-                let output: [String: Any] = [
-                    "spectrogram": result["spectrogram"]!,
-                    "sampleRate": sampleRate,
-                    "nMels": nMels,
-                    "timeSteps": timeSteps,
-                    "durationMs": durationMs
-                ]
-
-                promise.resolve(output)
-            } catch {
-                promise.reject("SPECTROGRAM_ERROR", "Failed to extract mel spectrogram: \(error.localizedDescription)")
             }
         }
         


### PR DESCRIPTION
## Summary

Three commits on `fix/prepare-recording-threading-v2`:

1. **Android — dispatch module ops to `Dispatchers.IO`** (`c6acfc0d`)
   `prepareRecording`, `trimAudio`, `extractMelSpectrogram`, `extractAudioAnalysis`, and `extractAudioData` now run inside the module-tied `coroutineScope` on `Dispatchers.IO`. The shared scope is upgraded with `SupervisorJob` so a single failing call cannot tear down siblings.

2. **iOS — dispatch lifecycle off main + collapse redundant session work** (`1c4c76fd`)
   `prepareRecording`, `startRecording`, `stopRecording` now run on a serial `audioLifecycleQueue` (off main, serialized against each other for AVAudioEngine safety). `extractAudioData` and `extractMelSpectrogram` move to `DispatchQueue.global(qos: .userInitiated)`. Promise resolution hops back to main. In `AudioStreamManager.prepareRecording`, `Thread.sleep(0.1)` + the redundant double `setActive(true)` + the duplicate `audioEngine.prepare()` are removed.

3. **iOS — serialize `accumulatedData` access** (`b8e863c7`, fixes #314)
   The audio render thread appended to `accumulatedData` / `accumulatedAnalysisData` while emission, pause, stop, and device-fallback paths read and cleared them with no synchronization. The race could trap inside `Data.base64EncodedString` during the `stopRecording` flush (issue #314 EXC_BREAKPOINT) and could also drop short writes that landed between snapshot and clear. An `NSLock` now guards both buffers; every access goes through `appendAccumulated` / `takeAccumulatedSnapshot` / `takeAccumulatedAnalysisSnapshot` / `resetAccumulated`.

Fixes #361, fixes #314, supersedes #362.

## Validation

**Android (physical device, cold start, fresh app data):**

| Path | Off-main? | Time |
|------|-----------|------|
| `prepareRecording` cold | ✅ tid 1777 (worker) | **195ms** (was 5-8s) |
| `startRecording` | ✅ | 61ms |
| `stopRecording` | ✅ tid 1895 | 37ms |
| `extractMelSpectrogram` | ✅ | ~1s, 486 timeSteps |
| `extractAudioData` | ✅ | ~1s |
| `trimAudio` | ✅ | ~1s |

UI probes during `extractMelSpectrogram`: 8 probes round-tripped successfully, RTT in CDP-overhead range. Process pid 1747; all heavy work confirmed on worker tids, never on main.

**iOS (simulator, cold start):**

| Path | Result | Time |
|------|--------|------|
| `prepareRecording` cold | success | **389ms** (was 5-8s) |
| `startRecording` | success | 1ms |
| `stopRecording` (#314 critical path) | success, 496KB WAV | 15ms |
| `extractMelSpectrogram` | success, 498 timeSteps | ~5s |

`xcodebuild` succeeded against `iPhone 16 Pro Max`. The previously crashing `stopRecording` flush ran clean.

## Test plan

- [ ] Cold-launch Android playground → call `prepareRecording` → UI stays responsive, returns < 500ms
- [ ] Cold-launch iOS playground → same
- [ ] Record → stop → repeat several times to surface any race regressions in `stopRecording` flush
- [ ] Run `extractMelSpectrogram` and `trimAudio` on a recorded file on both platforms
- [ ] Device-disconnect / fallback path on iOS (covered by `accumulatedData` rework, exercise via Bluetooth or wired-headset removal during recording)