### PR TITLE
fix(audio-studio): don't start notification on prepareRecording (Android)

### DIFF
--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
@@ -954,30 +954,28 @@ class AudioRecorderManager(
 
             audioRecord?.startRecording()
             isPaused.set(false)
-            _isRecording.set(true)
             isFirstChunk = true
+            recordingStartTime = System.currentTimeMillis()
 
-            if (!isPaused.get()) {
-                recordingStartTime = System.currentTimeMillis()
-            }
-
-            // Start notification + service only when actually recording (#298)
-            // Previously these fired in initializeRecordingResources, which is also
-            // reached from prepareRecording — causing the notification timer to start
-            // on prepare. Mirrors iOS fix.
+            // Start notification + foreground service before flipping isRecording (#298, #288).
+            // Previously the notification block fired in initializeRecordingResources, which is
+            // also reached from prepareRecording, so the notification timer started on prepare.
+            // Mirrors iOS fix in AudioStreamManager.swift. Service start is shared by both
+            // showNotification and keepAwake gates and must precede _isRecording=true so
+            // getStatus() can't observe (isRecording=true && !isServiceRunning).
+            val needsService = (recordingConfig.showNotification || recordingConfig.keepAwake) &&
+                enableBackgroundAudio
             if (recordingConfig.showNotification && enableBackgroundAudio) {
                 notificationManager.initialize(recordingConfig)
                 notificationManager.startUpdates(recordingStartTime)
+            }
+            if (needsService) {
                 AudioRecordingService.startService(context)
             }
 
+            _isRecording.set(true)
             recordingThread = Thread { recordingProcess() }.apply { start() }
 
-            // Start service if keepAwake is true, but only if background audio is enabled (#288)
-            if (recordingConfig.keepAwake && enableBackgroundAudio) {
-                AudioRecordingService.startService(context)
-            }
-            
             return true
 
         } catch (e: Exception) {

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
@@ -909,12 +909,6 @@ class AudioRecorderManager(
                 LogUtils.d(CLASS_NAME, "Skipping primary file creation - primary output is disabled")
             }
 
-            if (recordingConfig.showNotification && enableBackgroundAudio) {
-                notificationManager.initialize(recordingConfig)
-                notificationManager.startUpdates(System.currentTimeMillis())
-                AudioRecordingService.startService(context)
-            }
-
             acquireWakeLock()
             audioProcessor.resetCumulativeAmplitudeRange()
             return true
@@ -967,8 +961,18 @@ class AudioRecorderManager(
                 recordingStartTime = System.currentTimeMillis()
             }
 
+            // Start notification + service only when actually recording (#298)
+            // Previously these fired in initializeRecordingResources, which is also
+            // reached from prepareRecording — causing the notification timer to start
+            // on prepare. Mirrors iOS fix.
+            if (recordingConfig.showNotification && enableBackgroundAudio) {
+                notificationManager.initialize(recordingConfig)
+                notificationManager.startUpdates(recordingStartTime)
+                AudioRecordingService.startService(context)
+            }
+
             recordingThread = Thread { recordingProcess() }.apply { start() }
-            
+
             // Start service if keepAwake is true, but only if background audio is enabled (#288)
             if (recordingConfig.keepAwake && enableBackgroundAudio) {
                 AudioRecordingService.startService(context)


### PR DESCRIPTION
## Summary
- Fixes #298 — calling `prepareRecording()` on Android caused the recording notification + foreground service to start, with the notification timer already counting before `startRecording()` was ever called.
- Root cause: notification + service start lived in `initializeRecordingResources`, which is called from both `prepareRecording` and `startRecording`.
- Move the notification/service start into `startRecordingProcess`, immediately after `recordingStartTime` is set. Mirrors the existing iOS fix in `AudioStreamManager.swift` (lines 1131 + 1147).

## Test plan
- [x] Reproduced on device pre-fix: `__AGENTIC__.prepareRecording({ showNotification: true })` → Android notification appears with `flags=ONGOING_EVENT|FOREGROUND_SERVICE` and "Pause" action.
- [x] Post-fix: same call → no notification, `dumpsys notification` shows zero entries for the package, `getStatus()` still returns `isRecording: false`.
- [x] `startRecording()` after prepare → notification appears, `durationMs` counts from start (28559ms observed), `stopRecording()` clears the notification.
- [x] Manual smoke on iOS (no behavior change expected — iOS path unchanged).