### PR TITLE
Fix iOS AAC compression below 44.1 kHz

### DIFF
--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -14,6 +14,7 @@ import UserNotifications
 
 // Constants
 internal let WAV_HEADER_SIZE: Int64 = 44  // Standard WAV header is 44 bytes
+internal let MIN_AAC_COMPRESSED_SAMPLE_RATE: Double = 44100.0
 
 // Helper to convert to little-endian byte array
 extension UInt32 {
@@ -166,6 +167,28 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     // Performance optimization: Cache file sizes during recording
     private var cachedWavFileSize: Int64 = 0
     private var cachedCompressedFileSize: Int64 = 0
+
+    /// Returns an AVAudioRecorder-compatible sample rate for AAC sidecar files.
+    ///
+    /// The primary WAV path can resample emitted PCM to `settings.sampleRate`,
+    /// but the compressed sidecar is produced by AVAudioRecorder directly from
+    /// the active audio session. AVAudioRecorder fails to prepare AAC/M4A files
+    /// below 44.1 kHz, so keep valid requested rates and otherwise use the
+    /// active session rate when available, falling back to 44.1 kHz.
+    internal static func compatibleAACCompressedSampleRate(
+        requestedSampleRate: Double,
+        sessionSampleRate: Double
+    ) -> Double {
+        if requestedSampleRate >= MIN_AAC_COMPRESSED_SAMPLE_RATE {
+            return requestedSampleRate
+        }
+
+        if sessionSampleRate.isFinite && sessionSampleRate >= MIN_AAC_COMPRESSED_SAMPLE_RATE {
+            return sessionSampleRate
+        }
+
+        return MIN_AAC_COMPRESSED_SAMPLE_RATE
+    }
 
     /// Initializes the AudioStreamManager
     override init() {
@@ -995,10 +1018,27 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
 
             // Setup compressed recording if enabled
             if settings.output.compressed.enabled {
+                let isAACCompressedOutput = settings.output.compressed.format == "aac"
+                let compressedSampleRate: Double
+                if isAACCompressedOutput {
+                    compressedSampleRate = Self.compatibleAACCompressedSampleRate(
+                        requestedSampleRate: settings.sampleRate,
+                        sessionSampleRate: session.sampleRate
+                    )
+                } else {
+                    compressedSampleRate = settings.sampleRate
+                }
+                if isAACCompressedOutput && compressedSampleRate != settings.sampleRate {
+                    Logger.debug(
+                        "AudioStreamManager",
+                        "Adjusted compressed AAC sample rate from \(settings.sampleRate)Hz to \(compressedSampleRate)Hz for AVAudioRecorder compatibility"
+                    )
+                }
+
                 // Create compressed settings
                 let compressedSettings: [String: Any] = [
-                    AVFormatIDKey: settings.output.compressed.format == "aac" ? kAudioFormatMPEG4AAC : kAudioFormatOpus,
-                    AVSampleRateKey: Float64(settings.sampleRate),
+                    AVFormatIDKey: isAACCompressedOutput ? kAudioFormatMPEG4AAC : kAudioFormatOpus,
+                    AVSampleRateKey: compressedSampleRate,
                     AVNumberOfChannelsKey: settings.numberOfChannels,
                     AVEncoderBitRateKey: settings.output.compressed.bitrate,
                     AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,

--- a/packages/audio-studio/ios/AudioStudioTests/CompressedOnlyOutputTests.swift
+++ b/packages/audio-studio/ios/AudioStudioTests/CompressedOnlyOutputTests.swift
@@ -22,6 +22,46 @@ class CompressedOnlyOutputTests: XCTestCase {
     }
     
     // MARK: - Test Compressed-Only Output (Issue #244)
+
+    func testAACCompressedSampleRateFallsBackForLowRequestedRate() {
+        XCTAssertEqual(
+            AudioStreamManager.compatibleAACCompressedSampleRate(
+                requestedSampleRate: 16000,
+                sessionSampleRate: 48000
+            ),
+            48000,
+            "Low requested sample rates should use the active session rate when it is AAC-compatible"
+        )
+
+        XCTAssertEqual(
+            AudioStreamManager.compatibleAACCompressedSampleRate(
+                requestedSampleRate: 16000,
+                sessionSampleRate: 0
+            ),
+            44100,
+            "Low requested sample rates should never be passed directly to AVAudioRecorder for AAC"
+        )
+    }
+
+    func testAACCompressedSampleRateKeepsCompatibleRequestedRate() {
+        XCTAssertEqual(
+            AudioStreamManager.compatibleAACCompressedSampleRate(
+                requestedSampleRate: 44100,
+                sessionSampleRate: 48000
+            ),
+            44100,
+            "Already-compatible requested sample rates should preserve existing behavior"
+        )
+
+        XCTAssertEqual(
+            AudioStreamManager.compatibleAACCompressedSampleRate(
+                requestedSampleRate: 48000,
+                sessionSampleRate: 44100
+            ),
+            48000,
+            "High requested sample rates should not be reduced to the session rate"
+        )
+    }
     
     func testCompressedOnlyOutputWithAAC() {
         // Given: Recording settings with primary disabled and compressed enabled (AAC)


### PR DESCRIPTION
## Summary

Fixes #365 by preventing iOS AAC compressed sidecar recording from being configured with sample rates below 44.1 kHz.

## Root cause

The primary WAV/PCM path can resample to the requested `settings.sampleRate`, but the compressed AAC sidecar is produced by `AVAudioRecorder` directly from the active audio session. When `AVAudioRecorder` is configured for AAC below 44.1 kHz, it fails to prepare and the app silently returns no compressed output.

## Changes

- Add an AAC-only compatibility helper for compressed sidecar sample rates.
- Keep requested AAC rates when they are already >= 44.1 kHz.
- For lower requested AAC rates, use the active session rate when compatible, otherwise fall back to 44.1 kHz.
- Preserve non-AAC compressed settings and primary output sample-rate behavior.
- Add iOS unit coverage for low-rate fallback and compatible-rate preservation.

## Validation

- Rebuilt and installed the unpatched playground app on iOS simulator `playground-1`, then reproduced the issue via CDP with `sampleRate: 16000` and compressed-only AAC output: no `compression` object and `stream-only` stop result.
- Rebuilt and installed the patched playground app on `playground-1`, then reran the same CDP scenario: `compressedFileUri` was present and the `.m4a` file existed with nonzero size (`86561` bytes).
- Ran a 44.1 kHz AAC compressed-only regression check via CDP: `.m4a` file existed with nonzero size (`73858` bytes).
- Ran `xcodebuild -workspace AudioDevPlayground.xcworkspace -scheme AudioDevPlayground -destination 'platform=iOS Simulator,name=iPhone 17' build`: succeeded.

## Notes

`yarn workspace @siteed/audio-studio test:ios` could not run as-is because it targets an unavailable local `iPhone 15` simulator destination.