### PR TITLE
Add opt-out for full analysis retention

### DIFF
--- a/packages/audio-studio/README.md
+++ b/packages/audio-studio/README.md
@@ -113,6 +113,26 @@ await startRecording({
 
 ## Audio Analysis
 
+For live analysis during recording, `useAudioRecorder` keeps a recent analysis
+window in `analysisData` for visualization and, by default, also retains the
+full analysis history so `stopRecording().analysisData` can describe the whole
+recording. This option only matters when `enableProcessing: true`. For
+long-running sessions that only need live callbacks, disable the full-history
+retention to avoid unbounded JS memory growth:
+
+```typescript
+await startRecording({
+  sampleRate: 16000,
+  channels: 1,
+  enableProcessing: true,
+  keepFullAnalysis: false,
+  onAudioAnalysis: async (analysis) => {
+    // Consume each analysis chunk without retaining the full recording history.
+    updateVoiceActivity(analysis.dataPoints);
+  },
+});
+```
+
 ```typescript
 import { extractAudioAnalysis, extractPreview, extractMelSpectrogram, trimAudio } from '@siteed/audio-studio';
 

--- a/packages/audio-studio/docs/OOM_ANALYSIS.md
+++ b/packages/audio-studio/docs/OOM_ANALYSIS.md
@@ -86,6 +86,29 @@ if (shouldProcessAnalysis) {
 - `processAudioData()` method is now deprecated and not called during recording
 - Kept for potential future use but documented as unused
 
+## JavaScript Analysis Retention
+
+`useAudioRecorder` also maintains a full analysis history in JavaScript so
+`stopRecording().analysisData` can include every analysis data point. This is
+useful for short recordings and post-recording visualization, but it grows with
+recording duration. For long-running sessions that consume `onAudioAnalysis`
+chunks or only need the hook's recent live `analysisData` window, set
+`keepFullAnalysis: false` in `RecordingConfig`. This flag only has an effect
+when `enableProcessing: true`.
+
+This option does not disable native analysis processing or per-callback
+analysis events; it only skips the full-history array retained by the hook.
+
+```ts
+await startRecording({
+  enableProcessing: true,
+  keepFullAnalysis: false,
+  onAudioAnalysis: async (analysis) => {
+    // Use this chunk for live VAD, meters, or streaming decisions.
+  },
+})
+```
+
 ## Testing Recommendations
 
 1. **Long Recording Test**

--- a/packages/audio-studio/src/AudioStudio.types.ts
+++ b/packages/audio-studio/src/AudioStudio.types.ts
@@ -432,6 +432,17 @@ export interface RecordingConfig {
     /** Enable audio processing (default is false) */
     enableProcessing?: boolean
 
+    /**
+     * Whether `useAudioRecorder` should retain every audio-analysis data point
+     * and attach the full history to `stopRecording().analysisData`.
+     *
+     * Defaults to `true` for backwards compatibility. Set to `false` for
+     * long-running recordings when you only need live `analysisData` state or
+     * per-callback `onAudioAnalysis` chunks; this avoids unbounded JS memory
+     * growth in the hook without disabling native analysis processing.
+     */
+    keepFullAnalysis?: boolean
+
     /** iOS-specific configuration */
     ios?: IOSConfig
 

--- a/packages/audio-studio/src/useAudioRecorder.tsx
+++ b/packages/audio-studio/src/useAudioRecorder.tsx
@@ -156,6 +156,10 @@ interface HandleAudioAnalysisProps {
     visualizationDuration: number
 }
 
+function shouldKeepFullAnalysis(config?: RecordingConfig | null): boolean {
+    return config?.keepFullAnalysis !== false
+}
+
 export function useAudioRecorder({
     logger,
     audioWorkletUrl,
@@ -232,10 +236,15 @@ export function useAudioRecorder({
                 ...analysis.dataPoints,
             ]
 
-            const fullCombinedDataPoints = [
-                ...(fullAnalysisRef.current?.dataPoints ?? []),
-                ...analysis.dataPoints,
-            ]
+            const keepFullAnalysis = shouldKeepFullAnalysis(
+                recordingConfigRef.current
+            )
+            const fullCombinedDataPoints = keepFullAnalysis
+                ? [
+                      ...(fullAnalysisRef.current?.dataPoints ?? []),
+                      ...analysis.dataPoints,
+                  ]
+                : undefined
 
             // Calculate the new duration
             // The number of segments is based on how many segments of segmentDurationMs can fit in visualizationDuration
@@ -257,13 +266,15 @@ export function useAudioRecorder({
                 )
             }
 
-            // Keep the full data points
-            fullAnalysisRef.current = {
-                ...fullAnalysisRef.current,
-                dataPoints: fullCombinedDataPoints,
+            // Keep the full data points when requested for stopRecording().analysisData.
+            if (keepFullAnalysis && fullCombinedDataPoints) {
+                fullAnalysisRef.current = {
+                    ...fullAnalysisRef.current,
+                    dataPoints: fullCombinedDataPoints,
+                }
+                fullAnalysisRef.current.durationMs =
+                    fullCombinedDataPoints.length * analysis.segmentDurationMs
             }
-            fullAnalysisRef.current.durationMs =
-                fullCombinedDataPoints.length * analysis.segmentDurationMs
             savedAnalysisData.dataPoints = combinedDataPoints
             savedAnalysisData.bitDepth =
                 analysis.bitDepth || savedAnalysisData.bitDepth
@@ -284,9 +295,11 @@ export function useAudioRecorder({
                 min: newMin,
                 max: newMax,
             }
-            fullAnalysisRef.current.amplitudeRange = {
-                min: newMin,
-                max: newMax,
+            if (keepFullAnalysis) {
+                fullAnalysisRef.current.amplitudeRange = {
+                    min: newMin,
+                    max: newMax,
+                }
             }
 
             logger?.debug(
@@ -523,6 +536,7 @@ export function useAudioRecorder({
                 onAudioStream,
                 onRecordingInterrupted,
                 onAudioAnalysis,
+                keepFullAnalysis: _keepFullAnalysis,
                 ...options
             } = validatedOptions
             const { enableProcessing } = options
@@ -579,6 +593,7 @@ export function useAudioRecorder({
                 onAudioStream,
                 onRecordingInterrupted,
                 onAudioAnalysis,
+                keepFullAnalysis: _keepFullAnalysis,
                 ...options
             } = recordingOptions
 
@@ -603,7 +618,14 @@ export function useAudioRecorder({
         logger?.debug(`stoping recording`)
 
         const stopResult: AudioRecording = await audioStudio.stopRecording()
-        stopResult.analysisData = fullAnalysisRef.current
+        if (shouldKeepFullAnalysis(recordingConfigRef.current)) {
+            stopResult.analysisData = fullAnalysisRef.current
+        } else {
+            // `keepFullAnalysis` is a hook-level retention policy. If a platform
+            // starts returning native analysisData in the future, keep opt-out
+            // semantics explicit and avoid leaking a full history here.
+            delete stopResult.analysisData
+        }
 
         if (analysisListenerRef.current) {
             analysisListenerRef.current.remove()


### PR DESCRIPTION
## Summary

Addresses #366 as a backwards-compatible analysis retention feature rather than a recorder correctness bug.

`useAudioRecorder` previously always retained every analysis data point in `fullAnalysisRef` so `stopRecording().analysisData` could describe the whole recording. That is useful for short recordings and post-recording visualization, but it creates unbounded JS memory growth for long-running sessions that only consume live `analysisData` state or `onAudioAnalysis` chunks.

## Changes

- Add `keepFullAnalysis?: boolean` to `RecordingConfig`.
- Preserve current behavior by default (`keepFullAnalysis !== false`).
- When `keepFullAnalysis: false`:
  - keep the recent live `analysisData` window working for visualization/state
  - keep `onAudioAnalysis` callbacks working per analysis chunk
  - skip accumulating the full `fullAnalysisRef.dataPoints` history
  - explicitly delete `stopRecording().analysisData` so future native-returned analysis cannot leak through the opt-out path
- Strip `keepFullAnalysis` before crossing the native bridge because it is a JS hook retention policy.
- Document the long-running live-analysis usage in the package README and OOM analysis docs, including that the option only matters with `enableProcessing: true`.

## Why this shape

Changing the default to bounded/recent-only retention would be a breaking behavior change for consumers that rely on full post-recording analysis. An explicit opt-out fixes the long-recording memory-pressure case without changing existing users' stop-result semantics.

## Review follow-up

Addressed review nits:

- Made opt-out semantics explicit by deleting `stopResult.analysisData` when `keepFullAnalysis: false`.
- Clarified README/docs that the flag only applies when processing is enabled.

Left as follow-ups / non-blocking:

- A dedicated hook unit-test harness does not currently exist in this package; behavior is covered by playground/CDP smoke plus package build/lint.
- Android/Web runtime matrix was not rerun for this JS-only hook option; the option is stripped before native bridge and validated by TypeScript/build.
- The default path still uses spread-based full-history accumulation. That is preserved for backwards compatibility and should be optimized separately if we want to reduce default-path O(n) copy cost.

## Validation

- `yarn workspace @siteed/audio-studio build:types`
- `yarn workspace @siteed/audio-studio build`
- `yarn workspace @siteed/audio-studio lint`
- Playground/CDP on iOS simulator `playground-1` with `keepFullAnalysis: false`: live analysis remained available (`liveAnalysisPoints: 15`) and `stopRecording()` omitted `analysisData`.
- Playground/CDP on iOS simulator `playground-1` with default retention: live analysis remained available and `stopRecording().analysisData.dataPoints` was returned (`15` points).

## Notes

I did not treat this as a bug in the existing contract because full-history retention is the current documented/observable stop-result behavior. This PR adds the missing retention policy for long-running live-analysis consumers.
