### PR TITLE
docs(audio-studio): document keepFullAnalysis in website docs

### DIFF
--- a/documentation_site/docs/api-reference/API/interfaces/AudioRecording.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioRecording.md
@@ -16,7 +16,8 @@ Defined in: [src/AudioStudio.types.ts:142](https://github.com/deeeed/audiolab/bl
 
 Defined in: [src/AudioStudio.types.ts:164](https://github.com/deeeed/audiolab/blob/3a5b7da8f4289a599d928dce01f262ab97398143/packages/audio-studio/src/AudioStudio.types.ts#L164)
 
-Analysis data for the recording if processing was enabled
+Full analysis data for the recording if processing was enabled and
+`keepFullAnalysis` was not set to `false`.
 
 ***
 

--- a/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
@@ -91,6 +91,22 @@ Enable audio processing (default is false)
 
 ***
 
+### keepFullAnalysis?
+
+> `optional` **keepFullAnalysis**: `boolean`
+
+Defined in: [src/AudioStudio.types.ts:447](https://github.com/deeeed/audiolab/blob/main/packages/audio-studio/src/AudioStudio.types.ts#L447)
+
+Whether `useAudioRecorder` should retain every audio-analysis data point
+and attach the full history to `stopRecording().analysisData`.
+
+Defaults to `true` for backwards compatibility. Set to `false` for
+long-running recordings when you only need live `analysisData` state or
+per-callback `onAudioAnalysis` chunks; this avoids unbounded JS memory
+growth in the hook without disabling native analysis processing.
+
+***
+
 ### encoding?
 
 > `optional` **encoding**: [`EncodingType`](../type-aliases/EncodingType.md)

--- a/documentation_site/docs/api-reference/audio-features/audio-analysis-example.md
+++ b/documentation_site/docs/api-reference/audio-features/audio-analysis-example.md
@@ -313,6 +313,22 @@ const result = await extractAudioAnalysis({
 });
 ```
 
+## Live vs. Post-Recording Analysis
+
+The example above records with `enableProcessing: true`, which enables live analysis. By default, the recorder also retains the full live-analysis history for `stopRecording().analysisData`. For long-running sessions where you only need live callbacks and will run `extractAudioAnalysis()` after stop, start recording with `keepFullAnalysis: false`:
+
+```tsx
+await startRecording({
+  sampleRate: 44100,
+  channels: 1,
+  encoding: 'pcm_16bit',
+  enableProcessing: true,
+  keepFullAnalysis: false
+});
+```
+
+This keeps `onAudioAnalysis` and the hook's recent `analysisData` window working, but omits `recordingResult.analysisData` from the stop result.
+
 ## Performance Tips
 
 - For longer recordings, consider analyzing in chunks by specifying time ranges:

--- a/documentation_site/docs/api-reference/audio-features/audio-analysis-overview.md
+++ b/documentation_site/docs/api-reference/audio-features/audio-analysis-overview.md
@@ -103,4 +103,4 @@ const analysisProps = {
 - For real-time analysis, consider using a lower sample rate
 - Processing large audio files may be resource-intensive; consider processing in chunks
 
-For more detailed information about specific audio features and extraction methods, see the [Audio Features](./audio-analysis) and [extractAudioAnalysis](./extract-audio-analysis) documentation. 
+For more detailed information about specific audio features and extraction methods, see the [Audio Features](./audio-analysis.md) and [extractAudioAnalysis](./extract-audio-analysis.md) documentation.

--- a/documentation_site/docs/api-reference/audio-recording.md
+++ b/documentation_site/docs/api-reference/audio-recording.md
@@ -20,12 +20,18 @@ export interface AudioRecording {
     channels: number
     bitDepth: BitDepth
     sampleRate: SampleRate
-    analysisData?: AudioAnalysis // Analysis data for the recording depending on enableProcessing flag
+    analysisData?: AudioAnalysis // Full recording analysis when enableProcessing is true and keepFullAnalysis is not false
     compression?: CompressionInfo & {
         compressedFileUri: string
     }
 }
 ```
+
+## Analysis Data Retention
+
+`analysisData` is included in the stop result when recording used `enableProcessing: true` and full-history retention was not disabled. If the recording was started with `keepFullAnalysis: false`, live analysis still runs during recording, but `stopRecording().analysisData` is omitted to avoid retaining the full analysis history in JavaScript memory.
+
+For long recordings that need complete post-recording analysis, call `extractAudioAnalysis()` with the saved `fileUri` after stopping instead of retaining every live analysis chunk.
 
 ## Example Usage
 

--- a/documentation_site/docs/api-reference/recording-config.md
+++ b/documentation_site/docs/api-reference/recording-config.md
@@ -35,6 +35,7 @@ export interface RecordingConfig {
 
     // Audio processing settings
     enableProcessing?: boolean // Enable audio processing (default is false)
+    keepFullAnalysis?: boolean // Retain the full live-analysis history for stopRecording().analysisData (default is true)
     pointsPerSecond?: number // Number of data points to extract per second of audio (default is 10)
     algorithm?: AmplitudeAlgorithm // Algorithm to use for amplitude computation (default is "rms")
     features?: AudioFeaturesOptions // Feature options to extract (default is empty)
@@ -118,6 +119,39 @@ const realtimeConfig = {
   }
 };
 ```
+
+## Live Analysis Retention {#live-analysis-retention}
+
+When `enableProcessing: true`, `useAudioRecorder` exposes two live-analysis paths:
+
+- `analysisData` in hook state keeps a recent rolling window for visualizers and meters.
+- `onAudioAnalysis` receives each emitted analysis chunk as recording continues.
+
+By default, the hook also keeps the full analysis history and attaches it to `stopRecording().analysisData`. This preserves existing behavior and is convenient for short recordings or post-recording charts, but the retained data grows with recording duration. For long-running sessions that only need the live state or callback chunks, set `keepFullAnalysis: false`.
+
+```tsx
+await startRecording({
+  sampleRate: 16000,
+  channels: 1,
+  enableProcessing: true,
+  keepFullAnalysis: false,
+  intervalAnalysis: 250,
+  onAudioAnalysis: async (analysis) => {
+    // Use this chunk for live VAD, meters, or streaming decisions.
+    updateVoiceActivity(analysis.dataPoints)
+  },
+})
+
+const result = await stopRecording()
+console.log(result.analysisData) // undefined when keepFullAnalysis is false
+```
+
+Important behavior:
+
+- `keepFullAnalysis` only has an effect when `enableProcessing: true`.
+- It does **not** disable native audio processing, the live `analysisData` window, or `onAudioAnalysis` events.
+- It only controls whether the hook retains the full JavaScript history for `stopRecording().analysisData`.
+- If you need a full-recording analysis after a long session, prefer running `extractAudioAnalysis()` on the saved file after recording stops instead of retaining every live chunk in memory.
 
 ## Platform Differences
 
@@ -350,7 +384,7 @@ await startRecording({
 
 The library provides flexible control over which audio files are created during recording. You can choose to save uncompressed WAV files, compressed audio files, both, or neither (for streaming-only scenarios).
 
-> **⚠️ Breaking Change (Web)**: The web-specific `web.storeUncompressedAudio` option has been removed and replaced with `output.primary.enabled`. See the [Breaking Changes Guide](../../../docs/BREAKING_CHANGES_OUTPUT_CONFIG.md) for migration details.
+> **⚠️ Breaking Change (Web)**: The web-specific `web.storeUncompressedAudio` option has been removed and replaced with `output.primary.enabled`. See the [Output Configuration](#output-configuration) section below for migration details.
 
 ### Configuration Structure
 

--- a/documentation_site/docs/features.md
+++ b/documentation_site/docs/features.md
@@ -12,7 +12,7 @@ sidebar_label: Features
 
 - **Real-time audio streaming** with configurable quality settings across all platforms
 - **Zero-latency recording** with [prepareRecording](api-reference/recording-config.md#zero-latency-recording) API to eliminate startup delay
-- **Dual-stream recording** with simultaneous raw PCM and [compressed formats](api-reference/recording-config.md#compression-settings) (OPUS/AAC)
+- **Dual-stream recording** with simultaneous raw PCM and [compressed formats](api-reference/recording-config.md#output-configuration) (OPUS/AAC)
 - **Audio device detection and selection** for choosing specific microphones or input sources
 - **Intelligent interruption handling** with automatic pause/resume during phone calls
 - **Background recording** support with keep-awake functionality

--- a/documentation_site/docs/hooks/use-audio-recorder.md
+++ b/documentation_site/docs/hooks/use-audio-recorder.md
@@ -140,7 +140,7 @@ The `useAudioRecorder` hook returns an object with the following properties:
 - **durationMs**: `number` - Duration of the recording in milliseconds.
 - **size**: `number` - Size of the recorded audio in bytes.
 - **compression**: `CompressionInfo | undefined` - Information about compression if enabled.
-- **analysisData**: `AudioAnalysis | undefined` - Analysis data for the recording. Only available if `enableProcessing` is set to `true` in the `startRecording` configuration.
+- **analysisData**: `AudioAnalysis | undefined` - Recent live analysis data for the recording. Only available if `enableProcessing` is set to `true` in the `startRecording` configuration.
 
 ## RecordingConfig Options
 
@@ -151,6 +151,7 @@ The `startRecording` function accepts a configuration object with the following 
 | `interval` | `number` | Interval in milliseconds at which to emit recording data |
 | `intervalAnalysis` | `number` | Interval in milliseconds at which to emit analysis data |
 | `enableProcessing` | `boolean` | Whether to enable audio analysis |
+| `keepFullAnalysis` | `boolean` | Whether to retain the full live-analysis history for `stopRecording().analysisData` when processing is enabled. Defaults to `true`; set to `false` for long-running live analysis. |
 | `sampleRate` | `16000 \| 44100 \| 48000` | Sample rate in Hz |
 | `channels` | `1 \| 2` | Number of audio channels (1 for mono, 2 for stereo) |
 | `encoding` | `'pcm_8bit' \| 'pcm_16bit' \| 'pcm_32bit'` | PCM encoding format |
@@ -159,6 +160,27 @@ The `startRecording` function accepts a configuration object with the following 
 | `onAudioAnalysis` | `(analysisEvent: AudioAnalysisEvent) => Promise<void>` | Callback for audio analysis data |
 | `onRecordingInterrupted` | `(event: RecordingInterruptionEvent) => void` | Callback for recording interruptions |
 | `autoResumeAfterInterruption` | `boolean` | Whether to automatically resume recording after an interruption |
+
+### Long-Running Analysis Retention
+
+When `enableProcessing: true`, `analysisData` remains available as a recent live window and `onAudioAnalysis` still receives each chunk. By default, `useAudioRecorder` also keeps the full analysis history so `stopRecording().analysisData` can describe the whole recording.
+
+For long recordings where you only need live meters, VAD, or streaming decisions, set `keepFullAnalysis: false`:
+
+```tsx
+await startRecording({
+    enableProcessing: true,
+    keepFullAnalysis: false,
+    onAudioAnalysis: async (analysis) => {
+        updateMeter(analysis.dataPoints)
+    },
+})
+
+const result = await stopRecording()
+console.log(result.analysisData) // undefined when full-history retention is disabled
+```
+
+This flag does not disable analysis processing or callbacks; it only skips retaining every analysis data point in the hook for the final stop result. If you need full analysis after a long recording, run `extractAudioAnalysis()` on the saved file after stopping.
 
 ### Phone Call Handling
 

--- a/documentation_site/docs/usage/standalone-recording.md
+++ b/documentation_site/docs/usage/standalone-recording.md
@@ -46,7 +46,7 @@ export default function App() {
       size,
       isRecording,
       isPaused,
-      analysisData, // Audio analysis data if enableProcessing is true
+      analysisData, // Recent live audio analysis data if enableProcessing is true
       compression, // Compression information if compression is enabled
   } = useAudioRecorder()
   const [audioResult, setAudioResult] = useState<AudioRecording | null>(null)
@@ -62,6 +62,8 @@ export default function App() {
     const config: RecordingConfig = {
         interval: 500, // Emit recording data every 500ms
         enableProcessing: true, // Enable audio analysis
+        // Optional: set keepFullAnalysis: false for long-running live analysis
+        // when you do not need stopRecording().analysisData to include the full history.
         sampleRate: 44100, // Sample rate in Hz (16000, 44100, or 48000)
         channels: 1, // Mono recording
         encoding: 'pcm_16bit', // PCM encoding (pcm_8bit, pcm_16bit, pcm_32bit)
@@ -168,6 +170,23 @@ export default function App() {
       </>
   )
 }
+```
+
+## Long-Running Live Analysis
+
+If a recording can run for a long time and you only need live analysis updates, keep processing enabled but opt out of final full-history retention:
+
+```tsx
+const config: RecordingConfig = {
+    enableProcessing: true,
+    keepFullAnalysis: false,
+    onAudioAnalysis: async (analysisEvent) => {
+        // Update live UI or send this chunk to your service.
+    },
+}
+```
+
+With `keepFullAnalysis: false`, the hook still updates the recent `analysisData` window and still calls `onAudioAnalysis`, but `stopRecording().analysisData` is omitted. Use this for live VAD, meters, or streaming workflows that do not need every analysis point kept in JavaScript memory.
 
 ## API Reference
 
@@ -196,4 +215,4 @@ const recorder = useAudioRecorder(options?: UseAudioRecorderProps)
 | `durationMs` | `number` | Duration of the current recording in milliseconds |
 | `size` | `number` | Size of the recorded audio in bytes |
 | `compression` | `CompressionInfo \| undefined` | Information about compression if enabled |
-| `analysisData` | `AudioAnalysis \| undefined` | Analysis data for the recording if processing was enabled |
+| `analysisData` | `AudioAnalysis \| undefined` | Recent live analysis data for the recording if processing was enabled |

--- a/documentation_site/src/components/HomepageFeatures/index.tsx
+++ b/documentation_site/src/components/HomepageFeatures/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import type React from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
@@ -6,7 +7,7 @@ import styles from './styles.module.css';
 type FeatureItem = {
   title: string;
   Svg: React.ComponentType<React.ComponentProps<'svg'>>;
-  description: JSX.Element;
+  description: React.ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
@@ -56,7 +57,7 @@ function Feature({title, Svg, description}: FeatureItem) {
   );
 }
 
-export default function HomepageFeatures(): JSX.Element {
+export default function HomepageFeatures(): React.ReactElement {
   return (
     <section className={styles.features}>
       <div className="container">

--- a/packages/audio-studio/src/AudioStudio.types.ts
+++ b/packages/audio-studio/src/AudioStudio.types.ts
@@ -160,7 +160,10 @@ export interface AudioRecording {
     createdAt?: number
     /** Array of transcription data if available */
     transcripts?: TranscriberData[]
-    /** Analysis data for the recording if processing was enabled */
+    /**
+     * Full analysis data for the recording if processing was enabled and
+     * `keepFullAnalysis` was not set to `false`.
+     */
     analysisData?: AudioAnalysis
     /** Information about compression if enabled, including the URI to the compressed file */
     compression?: CompressionInfo & {


### PR DESCRIPTION
## Summary

- Documents `keepFullAnalysis` in the website RecordingConfig, hook, standalone usage, AudioRecording, and audio-analysis example pages.
- Clarifies that the flag only matters with `enableProcessing: true`, keeps live `analysisData`/`onAudioAnalysis` working, and omits `stopRecording().analysisData` when disabled.
- Updates generated API reference snippets for `RecordingConfig.keepFullAnalysis` and `AudioRecording.analysisData`.
- Fixes a few website validation issues encountered while building: stale Docusaurus links and the homepage feature component's JSX namespace typing.

## Validation

- `yarn workspace @siteed/audio-studio docgen`
- `yarn workspace documentation-site typecheck`
- `yarn workspace documentation-site build`

## Notes

Docs-only follow-up to the merged `keepFullAnalysis` feature; no playground/device validation was needed for this documentation path.