### PR TITLE
Fix Android event emission and stale call-state resume

### DIFF
--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
@@ -1417,17 +1417,7 @@ class AudioRecorderManager(
                        "audioManager.mode=${audioManager.mode}, " +
                        "audioManager.isBluetoothScoOn=${audioManager.isBluetoothScoOn}")
             
-            // Trust phone state more than audio manager state
-            if (callState == TelephonyManager.CALL_STATE_RINGING || 
-                callState == TelephonyManager.CALL_STATE_OFFHOOK) {
-                return true
-            }
-            
-            // Only check audio manager mode as secondary indicator
-            return audioManager.mode == AudioManager.MODE_IN_CALL || 
-                   audioManager.mode == AudioManager.MODE_IN_COMMUNICATION
-            
-            // Remove audioManager.isBluetoothScoOn check as it can be erroneously true after disconnection
+            return AndroidCallState.isOngoingCall(callState, audioManager.mode)
         } catch (e: Exception) {
             LogUtils.e(CLASS_NAME, "Error checking call state: ${e.message}")
             return false
@@ -2166,6 +2156,22 @@ class AudioRecorderManager(
             cleanup()
             isPrepared = false
             return false
+        }
+    }
+}
+
+internal object AndroidCallState {
+    /**
+     * Telephony call state wins when known. AudioManager mode is only a fallback
+     * for unknown state because some Android devices leave it stale after calls.
+     */
+    fun isOngoingCall(callState: Int?, audioMode: Int): Boolean {
+        return when (callState) {
+            TelephonyManager.CALL_STATE_RINGING,
+            TelephonyManager.CALL_STATE_OFFHOOK -> true
+            TelephonyManager.CALL_STATE_IDLE -> false
+            else -> audioMode == AudioManager.MODE_IN_CALL ||
+                audioMode == AudioManager.MODE_IN_COMMUNICATION
         }
     }
 }

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioStudioModule.kt
@@ -413,7 +413,7 @@ class AudioStudioModule : Module(), EventSender {
 
                     val progressListener = object : AudioTrimmer.ProgressListener {
                         override fun onProgress(progress: Float, bytesProcessed: Long, totalBytes: Long) {
-                            sendEvent(Constants.TRIM_PROGRESS_EVENT, mapOf(
+                            safeSendEvent(Constants.TRIM_PROGRESS_EVENT, mapOf(
                                 "progress" to progress,
                                 "bytesProcessed" to bytesProcessed,
                                 "totalBytes" to totalBytes
@@ -989,7 +989,7 @@ class AudioStudioModule : Module(), EventSender {
                         }
                         
                         // Notify JS about the disconnection
-                        sendEvent(Constants.DEVICE_CHANGED_EVENT, bundleOf(
+                        safeSendEvent(Constants.DEVICE_CHANGED_EVENT, bundleOf(
                             "type" to "deviceDisconnected",
                             "deviceId" to deviceId
                         ))
@@ -1004,7 +1004,7 @@ class AudioStudioModule : Module(), EventSender {
         audioDeviceManager.onDeviceConnected = { deviceId ->
             LogUtils.d(CLASS_NAME, "📱 Device connected: $deviceId")
             // Notify JS about the connection
-            sendEvent(Constants.DEVICE_CHANGED_EVENT, bundleOf(
+            safeSendEvent(Constants.DEVICE_CHANGED_EVENT, bundleOf(
                 "type" to "deviceConnected",
                 "deviceId" to deviceId
             ))
@@ -1014,7 +1014,7 @@ class AudioStudioModule : Module(), EventSender {
         audioDeviceManager.onDeviceDisconnected = { deviceId ->
             LogUtils.d(CLASS_NAME, "📱 Device disconnected: $deviceId")
             // Notify JS about the disconnection
-            sendEvent(Constants.DEVICE_CHANGED_EVENT, bundleOf(
+            safeSendEvent(Constants.DEVICE_CHANGED_EVENT, bundleOf(
                 "type" to "deviceDisconnected",
                 "deviceId" to deviceId
             ))
@@ -1023,6 +1023,18 @@ class AudioStudioModule : Module(), EventSender {
         audioProcessor = AudioProcessor(filesDir)
     }
     
+    private fun safeSendEvent(eventName: String, params: Bundle) {
+        AndroidEventEmitter.safeSend(CLASS_NAME, eventName) {
+            sendEvent(eventName, params)
+        }
+    }
+
+    private fun safeSendEvent(eventName: String, params: Map<String, Any?>) {
+        AndroidEventEmitter.safeSend(CLASS_NAME, eventName) {
+            sendEvent(eventName, params)
+        }
+    }
+
     /**
      * Handles audio device disconnection based on the recording configuration
      */
@@ -1055,7 +1067,7 @@ class AudioStudioModule : Module(), EventSender {
                         
                         // Notify JS about fallback
                         LogUtils.d(CLASS_NAME, "📱 Sending deviceFallback event to JS")
-                        sendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
+                        safeSendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                             "reason" to "deviceFallback",
                             "isPaused" to false,
                             "deviceId" to deviceId
@@ -1070,7 +1082,7 @@ class AudioStudioModule : Module(), EventSender {
                                 // Notify AudioRecorderManager to handle device change while paused
                                 audioRecorderManager.handleDeviceChange()
                                 
-                                sendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
+                                safeSendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                                     "reason" to "deviceSwitchFailed",
                                     "isPaused" to true
                                 ))
@@ -1090,7 +1102,7 @@ class AudioStudioModule : Module(), EventSender {
                             // Notify AudioRecorderManager to handle device change while paused
                             audioRecorderManager.handleDeviceChange()
                             
-                            sendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
+                            safeSendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                                 "reason" to "deviceDisconnected",
                                 "isPaused" to true
                             ))
@@ -1112,7 +1124,7 @@ class AudioStudioModule : Module(), EventSender {
                         // Notify AudioRecorderManager to handle device change while paused
                         audioRecorderManager.handleDeviceChange()
                         
-                        sendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
+                        safeSendEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                             "reason" to "deviceDisconnected",
                             "isPaused" to true
                         ))
@@ -1128,6 +1140,18 @@ class AudioStudioModule : Module(), EventSender {
 
     override fun sendExpoEvent(eventName: String, params: Bundle) {
         LogUtils.d(CLASS_NAME, "Sending event: $eventName")
-        this@AudioStudioModule.sendEvent(eventName, params)
+        safeSendEvent(eventName, params)
+    }
+}
+
+internal object AndroidEventEmitter {
+    fun safeSend(className: String, eventName: String, send: () -> Unit): Boolean {
+        return try {
+            send()
+            true
+        } catch (e: Exception) {
+            LogUtils.e(className, "Failed to send event $eventName: ${e.message}", e)
+            false
+        }
     }
 }

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/EventSender.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/EventSender.kt
@@ -3,5 +3,11 @@ package net.siteed.audiostudio
 import android.os.Bundle
 
 interface EventSender {
+    /**
+     * Best-effort event delivery to JavaScript.
+     *
+     * Native recording/device callbacks must not crash if Expo rejects an event
+     * while the module is not ready to emit.
+     */
     fun sendExpoEvent(eventName: String, params: Bundle)
 }

--- a/packages/audio-studio/android/src/test/java/net/siteed/audiostudio/AndroidCallStateTest.kt
+++ b/packages/audio-studio/android/src/test/java/net/siteed/audiostudio/AndroidCallStateTest.kt
@@ -1,0 +1,37 @@
+package net.siteed.audiostudio
+
+import android.media.AudioManager
+import android.telephony.TelephonyManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidCallStateTest {
+    @Test
+    fun idleCallStateWinsOverStaleInCallAudioMode() {
+        val result = AndroidCallState.isOngoingCall(
+            TelephonyManager.CALL_STATE_IDLE,
+            AudioManager.MODE_IN_CALL
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun ringingAndOffhookAreOngoingCalls() {
+        assertTrue(AndroidCallState.isOngoingCall(
+            TelephonyManager.CALL_STATE_RINGING,
+            AudioManager.MODE_NORMAL
+        ))
+        assertTrue(AndroidCallState.isOngoingCall(
+            TelephonyManager.CALL_STATE_OFFHOOK,
+            AudioManager.MODE_NORMAL
+        ))
+    }
+
+    @Test
+    fun unknownCallStateFallsBackToAudioMode() {
+        assertTrue(AndroidCallState.isOngoingCall(null, AudioManager.MODE_IN_COMMUNICATION))
+        assertFalse(AndroidCallState.isOngoingCall(null, AudioManager.MODE_NORMAL))
+    }
+}

--- a/packages/audio-studio/android/src/test/java/net/siteed/audiostudio/AndroidEventEmitterTest.kt
+++ b/packages/audio-studio/android/src/test/java/net/siteed/audiostudio/AndroidEventEmitterTest.kt
@@ -1,0 +1,28 @@
+package net.siteed.audiostudio
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidEventEmitterTest {
+    @Test
+    fun safeSendReturnsTrueWhenEventIsSent() {
+        var sent = false
+
+        val result = AndroidEventEmitter.safeSend("Test", "event") {
+            sent = true
+        }
+
+        assertTrue(result)
+        assertTrue(sent)
+    }
+
+    @Test
+    fun safeSendCatchesEmitterExceptions() {
+        val result = AndroidEventEmitter.safeSend("Test", "event") {
+            throw IllegalArgumentException("module not ready")
+        }
+
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
## Summary
- wraps Android `sendEvent` paths behind a safe emitter so device connect/disconnect callbacks cannot crash the app if Expo rejects event emission
- makes `TelephonyManager.CALL_STATE_IDLE` authoritative in `isOngoingCall()` so stale `AudioManager.MODE_IN_CALL` values do not block `resumeRecording()`
- adds Android unit coverage for emitter exception handling and call-state precedence

Closes #367
Closes #368

## Root cause / approach
- #367: Android device callbacks could call `sendEvent` outside the existing guarded delegate path. Expo can throw when the module is not ready to emit, so native event delivery should be best-effort instead of crash-capable.
- #368: `AudioManager.mode` can remain stuck in an in-call mode after a call ends on some Android devices. When `TelephonyManager` reports `CALL_STATE_IDLE`, that fresher call-state signal should win; audio mode remains a fallback only when call state is unknown.

## Validation
- `cd apps/playground/android && ./gradlew :siteed-audio-studio:testDebugUnitTest`
- `cd apps/playground/android && APP_VARIANT=development NODE_ENV=development ./gradlew :siteed-audio-studio:assembleDebug :app:installDebug`
- CDP on the physical Android target reported by `yarn status` as `platform: android` / `targetType: physical` (CDP label: `device:Arthur’s iPhone`; native logs identify the test phone as Pixel 6a):
  - launched the Android development build
  - `getDevices` returned Android input devices successfully
  - `startRecording` → `pauseRecording` → `resumeRecording` → `stopRecording` completed successfully
- Android log scan after validation returned no matches for crash/resume failure patterns:
  - `AndroidRuntime`
  - `FATAL EXCEPTION`
  - `IllegalArgumentException`
  - `Failed to send event`
  - `ONGOING_CALL`
  - `Cannot resume recording during an ongoing call`

## Notes / non-goals
- The iOS simulator was present in `yarn status`, but this PR changes Android native code only and the CDP validation above was on the Android physical target.
- #369 is intentionally not included; distinguishing user-initiated pause from system pause is a broader behavior/feature change.
- I could not reproduce Samsung's stale `AudioManager.mode` directly on this Pixel device; unit coverage locks the requested Android precedence rule and the CDP run verifies normal Android resume still works.
- I did not physically trigger a connect/disconnect race while the Expo module was unavailable; the emitter unit test directly exercises the crash condition by throwing `IllegalArgumentException`, and the safe wrapper catches it.
