### PR TITLE
fix(audio-studio): preserve pause intent across interruptions

### DIFF
--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
@@ -118,6 +118,7 @@ class AudioRecorderManager(
     private var audioFocusRequest: Any? = null  // Type Any to handle both old and new APIs
     private var phoneStateListener: PhoneStateListener? = null
     private var telephonyCallback: Any? = null  // TelephonyCallback for API 31+, typed as Any to avoid class verification issues on older APIs
+    private var pausedBySystemInterruption = false
     private var telephonyManager: TelephonyManager? = null
         get() {
             if (field == null) {
@@ -408,7 +409,7 @@ class AudioRecorderManager(
                 if (_isRecording.get() && !isPaused.get()) {
                     LogUtils.d(CLASS_NAME, "Pausing recording due to incoming/ongoing call")
                     mainHandler.post {
-                        pauseRecording(object : Promise {
+                        pauseRecordingForSystemInterruption(object : Promise {
                             override fun resolve(value: Any?) {
                                 LogUtils.d(CLASS_NAME, "Successfully paused recording due to call")
                                 eventSender.sendExpoEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
@@ -426,8 +427,14 @@ class AudioRecorderManager(
             TelephonyManager.CALL_STATE_IDLE -> {
                 if (_isRecording.get() && isPaused.get()) {
                     val autoResume = if (::recordingConfig.isInitialized) recordingConfig.autoResumeAfterInterruption else false
-                    LogUtils.d(CLASS_NAME, "Call ended, handling auto-resume (enabled: $autoResume)")
-                    if (autoResume) {
+                    val shouldAutoResume = InterruptionAutoResumePolicy.shouldAutoResume(
+                        autoResumeAfterInterruption = autoResume,
+                        isRecording = _isRecording.get(),
+                        isPaused = isPaused.get(),
+                        pausedBySystemInterruption = pausedBySystemInterruption
+                    )
+                    LogUtils.d(CLASS_NAME, "Call ended, handling auto-resume (enabled: $autoResume, pausedBySystemInterruption: $pausedBySystemInterruption)")
+                    if (shouldAutoResume) {
                         mainHandler.post {
                             resumeRecording(object : Promise {
                                 override fun resolve(value: Any?) {
@@ -443,7 +450,7 @@ class AudioRecorderManager(
                             })
                         }
                     } else {
-                        LogUtils.d(CLASS_NAME, "Auto-resume disabled, staying paused")
+                        LogUtils.d(CLASS_NAME, "Auto-resume not permitted, staying paused")
                         eventSender.sendExpoEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                             "reason" to "phoneCallEnded",
                             "isPaused" to true
@@ -954,6 +961,7 @@ class AudioRecorderManager(
 
             audioRecord?.startRecording()
             isPaused.set(false)
+            pausedBySystemInterruption = false
             isFirstChunk = true
             recordingStartTime = System.currentTimeMillis()
 
@@ -1174,6 +1182,7 @@ class AudioRecorderManager(
                 // Reset the timing variables
                 _isRecording.set(false)
                 isPaused.set(false)
+                pausedBySystemInterruption = false
                 totalRecordedTime = 0
                 pausedDuration = 0
             } catch (e: Exception) {
@@ -1258,6 +1267,7 @@ class AudioRecorderManager(
             }
             
             LogUtils.d(CLASS_NAME, "⏺️ Recording resumed successfully")
+            pausedBySystemInterruption = false
             promise.resolve("Recording resumed")
         } catch (e: Exception) {
             LogUtils.e(CLASS_NAME, "⏺️ Failed to resume recording: ${e.message}", e)
@@ -1267,12 +1277,21 @@ class AudioRecorderManager(
     }
 
     fun pauseRecording(promise: Promise) {
+        pauseRecording(promise, isSystemInterruption = false)
+    }
+
+    private fun pauseRecordingForSystemInterruption(promise: Promise) {
+        pauseRecording(promise, isSystemInterruption = true)
+    }
+
+    private fun pauseRecording(promise: Promise, isSystemInterruption: Boolean) {
         if (_isRecording.get() && !isPaused.get()) {
             audioRecord?.stop()
             compressedRecorder?.pause()
             
             lastPauseTime = System.currentTimeMillis()
             isPaused.set(true)
+            pausedBySystemInterruption = isSystemInterruption
 
             if (recordingConfig.showNotification) {
                 notificationManager.pauseUpdates()
@@ -1747,6 +1766,7 @@ class AudioRecorderManager(
                 
                 _isRecording.set(false)
                 isPaused.set(false)
+                pausedBySystemInterruption = false
                 isPrepared = false  // Reset prepared state
                 
                 if (::recordingConfig.isInitialized && recordingConfig.showNotification) {
@@ -1909,9 +1929,8 @@ class AudioRecorderManager(
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
                     if (_isRecording.get() && !isPaused.get()) {
                         mainHandler.post {
-                            pauseRecording(object : Promise {
+                            pauseRecordingForSystemInterruption(object : Promise {
                                 override fun resolve(value: Any?) {
-                                    isPaused.set(true)
                                     eventSender.sendExpoEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                                         "reason" to "audioFocusLoss",
                                         "isPaused" to true
@@ -1926,7 +1945,12 @@ class AudioRecorderManager(
                 }
                 AudioManager.AUDIOFOCUS_GAIN -> {
                     val autoResume = if (::recordingConfig.isInitialized) recordingConfig.autoResumeAfterInterruption else false
-                    if (_isRecording.get() && isPaused.get() && autoResume) {
+                    if (InterruptionAutoResumePolicy.shouldAutoResume(
+                            autoResumeAfterInterruption = autoResume,
+                            isRecording = _isRecording.get(),
+                            isPaused = isPaused.get(),
+                            pausedBySystemInterruption = pausedBySystemInterruption
+                        )) {
                         mainHandler.post {
                             resumeRecording(object : Promise {
                                 override fun resolve(value: Any?) {
@@ -1975,9 +1999,8 @@ class AudioRecorderManager(
                     // Only pause for permanent focus loss (like phone calls)
                     if (_isRecording.get() && !isPaused.get()) {
                         mainHandler.post {
-                            pauseRecording(object : Promise {
+                            pauseRecordingForSystemInterruption(object : Promise {
                                 override fun resolve(value: Any?) {
-                                    isPaused.set(true)
                                     eventSender.sendExpoEvent(Constants.RECORDING_INTERRUPTED_EVENT_NAME, bundleOf(
                                         "reason" to "audioFocusLoss",
                                         "isPaused" to true
@@ -1996,7 +2019,12 @@ class AudioRecorderManager(
                 }
                 AudioManager.AUDIOFOCUS_GAIN -> {
                     val autoResume = if (::recordingConfig.isInitialized) recordingConfig.autoResumeAfterInterruption else false
-                    if (_isRecording.get() && isPaused.get() && autoResume) {
+                    if (InterruptionAutoResumePolicy.shouldAutoResume(
+                            autoResumeAfterInterruption = autoResume,
+                            isRecording = _isRecording.get(),
+                            isPaused = isPaused.get(),
+                            pausedBySystemInterruption = pausedBySystemInterruption
+                        )) {
                         mainHandler.post {
                             resumeRecording(object : Promise {
                                 override fun resolve(value: Any?) {
@@ -2173,5 +2201,23 @@ internal object AndroidCallState {
             else -> audioMode == AudioManager.MODE_IN_CALL ||
                 audioMode == AudioManager.MODE_IN_COMMUNICATION
         }
+    }
+}
+
+internal object InterruptionAutoResumePolicy {
+    /**
+     * Auto-resume is only allowed when the pause was caused by a system interruption.
+     * User-initiated pauses must stay paused even after phone/audio focus interruptions end.
+     */
+    fun shouldAutoResume(
+        autoResumeAfterInterruption: Boolean,
+        isRecording: Boolean,
+        isPaused: Boolean,
+        pausedBySystemInterruption: Boolean
+    ): Boolean {
+        return autoResumeAfterInterruption &&
+            isRecording &&
+            isPaused &&
+            pausedBySystemInterruption
     }
 }

--- a/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
+++ b/packages/audio-studio/android/src/main/java/net/siteed/audiostudio/AudioRecorderManager.kt
@@ -118,7 +118,7 @@ class AudioRecorderManager(
     private var audioFocusRequest: Any? = null  // Type Any to handle both old and new APIs
     private var phoneStateListener: PhoneStateListener? = null
     private var telephonyCallback: Any? = null  // TelephonyCallback for API 31+, typed as Any to avoid class verification issues on older APIs
-    private var pausedBySystemInterruption = false
+    private val pausedBySystemInterruption = AtomicBoolean(false)
     private var telephonyManager: TelephonyManager? = null
         get() {
             if (field == null) {
@@ -431,9 +431,9 @@ class AudioRecorderManager(
                         autoResumeAfterInterruption = autoResume,
                         isRecording = _isRecording.get(),
                         isPaused = isPaused.get(),
-                        pausedBySystemInterruption = pausedBySystemInterruption
+                        pausedBySystemInterruption = pausedBySystemInterruption.get()
                     )
-                    LogUtils.d(CLASS_NAME, "Call ended, handling auto-resume (enabled: $autoResume, pausedBySystemInterruption: $pausedBySystemInterruption)")
+                    LogUtils.d(CLASS_NAME, "Call ended, handling auto-resume (enabled: $autoResume, pausedBySystemInterruption: ${pausedBySystemInterruption.get()})")
                     if (shouldAutoResume) {
                         mainHandler.post {
                             resumeRecording(object : Promise {
@@ -961,7 +961,7 @@ class AudioRecorderManager(
 
             audioRecord?.startRecording()
             isPaused.set(false)
-            pausedBySystemInterruption = false
+            pausedBySystemInterruption.set(false)
             isFirstChunk = true
             recordingStartTime = System.currentTimeMillis()
 
@@ -1182,7 +1182,7 @@ class AudioRecorderManager(
                 // Reset the timing variables
                 _isRecording.set(false)
                 isPaused.set(false)
-                pausedBySystemInterruption = false
+                pausedBySystemInterruption.set(false)
                 totalRecordedTime = 0
                 pausedDuration = 0
             } catch (e: Exception) {
@@ -1267,7 +1267,7 @@ class AudioRecorderManager(
             }
             
             LogUtils.d(CLASS_NAME, "⏺️ Recording resumed successfully")
-            pausedBySystemInterruption = false
+            pausedBySystemInterruption.set(false)
             promise.resolve("Recording resumed")
         } catch (e: Exception) {
             LogUtils.e(CLASS_NAME, "⏺️ Failed to resume recording: ${e.message}", e)
@@ -1291,7 +1291,7 @@ class AudioRecorderManager(
             
             lastPauseTime = System.currentTimeMillis()
             isPaused.set(true)
-            pausedBySystemInterruption = isSystemInterruption
+            pausedBySystemInterruption.set(isSystemInterruption)
 
             if (recordingConfig.showNotification) {
                 notificationManager.pauseUpdates()
@@ -1766,7 +1766,7 @@ class AudioRecorderManager(
                 
                 _isRecording.set(false)
                 isPaused.set(false)
-                pausedBySystemInterruption = false
+                pausedBySystemInterruption.set(false)
                 isPrepared = false  // Reset prepared state
                 
                 if (::recordingConfig.isInitialized && recordingConfig.showNotification) {
@@ -1949,7 +1949,7 @@ class AudioRecorderManager(
                             autoResumeAfterInterruption = autoResume,
                             isRecording = _isRecording.get(),
                             isPaused = isPaused.get(),
-                            pausedBySystemInterruption = pausedBySystemInterruption
+                            pausedBySystemInterruption = pausedBySystemInterruption.get()
                         )) {
                         mainHandler.post {
                             resumeRecording(object : Promise {
@@ -2023,7 +2023,7 @@ class AudioRecorderManager(
                             autoResumeAfterInterruption = autoResume,
                             isRecording = _isRecording.get(),
                             isPaused = isPaused.get(),
-                            pausedBySystemInterruption = pausedBySystemInterruption
+                            pausedBySystemInterruption = pausedBySystemInterruption.get()
                         )) {
                         mainHandler.post {
                             resumeRecording(object : Promise {

--- a/packages/audio-studio/android/src/test/java/net/siteed/audiostudio/InterruptionAutoResumePolicyTest.kt
+++ b/packages/audio-studio/android/src/test/java/net/siteed/audiostudio/InterruptionAutoResumePolicyTest.kt
@@ -1,0 +1,49 @@
+package net.siteed.audiostudio
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InterruptionAutoResumePolicyTest {
+    @Test
+    fun autoResumesOnlyWhenSystemInterruptionPausedRecording() {
+        assertTrue(InterruptionAutoResumePolicy.shouldAutoResume(
+            autoResumeAfterInterruption = true,
+            isRecording = true,
+            isPaused = true,
+            pausedBySystemInterruption = true
+        ))
+    }
+
+    @Test
+    fun doesNotAutoResumeUserPausedRecording() {
+        assertFalse(InterruptionAutoResumePolicy.shouldAutoResume(
+            autoResumeAfterInterruption = true,
+            isRecording = true,
+            isPaused = true,
+            pausedBySystemInterruption = false
+        ))
+    }
+
+    @Test
+    fun requiresAutoResumeAndActivePausedRecording() {
+        assertFalse(InterruptionAutoResumePolicy.shouldAutoResume(
+            autoResumeAfterInterruption = false,
+            isRecording = true,
+            isPaused = true,
+            pausedBySystemInterruption = true
+        ))
+        assertFalse(InterruptionAutoResumePolicy.shouldAutoResume(
+            autoResumeAfterInterruption = true,
+            isRecording = false,
+            isPaused = true,
+            pausedBySystemInterruption = true
+        ))
+        assertFalse(InterruptionAutoResumePolicy.shouldAutoResume(
+            autoResumeAfterInterruption = true,
+            isRecording = true,
+            isPaused = false,
+            pausedBySystemInterruption = true
+        ))
+    }
+}

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -153,6 +153,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     
     // Add property to track auto-resume preference
     private var autoResumeAfterInterruption: Bool = false
+    private var pausedBySystemInterruption: Bool = false
     
     // Add these properties
     private var emissionInterval: TimeInterval = 1.0  // Default 1 second
@@ -254,7 +255,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             // Store the pause start time if not already paused
             if !wasSuspended {
                 currentPauseStart = Date()
-                pauseRecording()
+                pauseRecording(isSystemInterruption: true)
             }
             
             // Always notify delegate of interruption
@@ -280,8 +281,14 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                     Logger.debug("AudioStreamManager", "Added interruption pause duration: \(pauseDuration), total paused: \(totalPausedDuration)")
                 }
                 
-                // For phone calls, we should auto-resume if enabled, regardless of previous pause state
-                if autoResumeAfterInterruption && isRecording {
+                // Auto-resume only if this interruption paused the recording.
+                // If the user had already paused, preserve that intent.
+                if AutoResumePolicy.shouldAutoResume(
+                    autoResumeAfterInterruption: autoResumeAfterInterruption,
+                    isRecording: isRecording,
+                    isPaused: isPaused,
+                    pausedBySystemInterruption: pausedBySystemInterruption
+                ) {
                     // Add a longer delay for phone calls and ensure proper session setup
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
                         guard let self = self else { return }
@@ -507,6 +514,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
                 // If we can't restart, officially pause the recording
                 if !isPaused {
                     isPaused = true
+                    pausedBySystemInterruption = false
                     // Notify delegate
                     delegate?.audioStreamManager(self, didPauseRecording: Date())
                 }
@@ -929,6 +937,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         lastEmittedCompressedSize = 0
         lastEmittedCompressedSizeAnalysis = 0
         isPaused = false
+        pausedBySystemInterruption = false
 
         // Create recording file first (unless primary output is disabled)
         if settings.output.primary.enabled {
@@ -1175,6 +1184,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             lastEmissionTimeAnalysis = Date()
             isRecording = true
             isPaused = false
+            pausedBySystemInterruption = false
             
             // Start the audio engine
             try audioEngine.start()
@@ -1261,6 +1271,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         compressedFileURL = nil // Restore
         audioProcessor = nil // Restore
         recordingSettings = nil
+        pausedBySystemInterruption = false
         isPrepared = false // Restore
         // --- End restored lines and removed log ---
         
@@ -1268,7 +1279,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     }
 
     /// Pauses the current audio recording.
-    func pauseRecording() {
+    func pauseRecording(isSystemInterruption: Bool = false) {
         guard isRecording, !isPaused else { return }
         
         Logger.debug("Pausing recording...")
@@ -1294,6 +1305,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         
         // Update state
         isPaused = true
+        pausedBySystemInterruption = isSystemInterruption
         
         // Stop the engine but don't remove the tap
         audioEngine.pause()
@@ -1342,6 +1354,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             
             // Update state
             isPaused = false
+            pausedBySystemInterruption = false
             
             // Update notification state if enabled
             if recordingSettings?.showNotification == true {
@@ -1890,6 +1903,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         let wasRecording = isRecording
         isRecording = false
         isPaused = false
+        pausedBySystemInterruption = false
         isPrepared = false // Reset preparation state
         
         // If we were only prepared but never started recording, clean up and return nil
@@ -2389,6 +2403,22 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         try session.setCategory(category, mode: mode, options: options)
         
         Logger.debug("AudioStreamManager", "Audio session configured with category: \(category), mode: \(mode), options: \(options)")
+    }
+}
+
+internal struct AutoResumePolicy {
+    /// Auto-resume only when a system interruption caused the pause.
+    /// User-initiated pauses must remain paused after the interruption ends.
+    static func shouldAutoResume(
+        autoResumeAfterInterruption: Bool,
+        isRecording: Bool,
+        isPaused: Bool,
+        pausedBySystemInterruption: Bool
+    ) -> Bool {
+        return autoResumeAfterInterruption &&
+            isRecording &&
+            isPaused &&
+            pausedBySystemInterruption
     }
 }
 

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -272,17 +272,11 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             if let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt {
                 let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
                 Logger.debug("AudioStreamManager", "Interruption options - shouldResume: \(options.contains(.shouldResume))")
-                
-                // Calculate pause duration if we have a pause start time
-                if let pauseStart = currentPauseStart {
-                    let pauseDuration = Date().timeIntervalSince(pauseStart)
-                    totalPausedDuration += pauseDuration
-                    currentPauseStart = nil
-                    Logger.debug("AudioStreamManager", "Added interruption pause duration: \(pauseDuration), total paused: \(totalPausedDuration)")
-                }
-                
+
                 // Auto-resume only if this interruption paused the recording.
                 // If the user had already paused, preserve that intent.
+                // Keep currentPauseStart active until the actual resume so duration accounting
+                // excludes the full paused interval, including any post-interruption delay.
                 if AutoResumePolicy.shouldAutoResume(
                     autoResumeAfterInterruption: autoResumeAfterInterruption,
                     isRecording: isRecording,


### PR DESCRIPTION
## Summary
- Closes #369 by preserving user pause intent when `autoResumeAfterInterruption` is enabled.
- Tracks whether native pause was caused by a system interruption on Android and iOS.
- Gates auto-resume after phone/audio-focus/session interruptions on that system-pause origin, so a user-paused recording remains paused.
- Adds Android pure-policy unit coverage for the auto-resume decision.

## Why this shape
- No public API change: this tightens the existing `autoResumeAfterInterruption` semantics instead of adding another config flag.
- The long-term invariant is explicit in both native layers: auto-resume is only valid if the interruption itself paused an active recording.
- Docs do not need an update because this is an internal correctness fix, not a new user-facing option.

## Validation
- `cd apps/playground/android && APP_VARIANT=development NODE_ENV=development ./gradlew :siteed-audio-studio:testDebugUnitTest :siteed-audio-studio:assembleDebug :app:installDebug`
- Android physical Pixel 6a via CDP (`device:Arthur’s iPhone`): loaded dev playground, ran start → pause → resume → stop with `autoResumeAfterInterruption: true`.
- Android logcat error scan after CDP run: no `AndroidRuntime`, `FATAL EXCEPTION`, `IllegalArgumentException`, resume/pause failure signatures.
- `cd apps/playground/ios && xcodebuild -workspace AudioDevPlayground.xcworkspace -scheme AudioStudio -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`

## Not tested
- Real phone-call/audio-focus interruption simulation on physical Android/iOS. The policy branch is locked with unit tests, and the playground regression path was validated on-device.
