### PR TITLE
chore(moonshine.rn): bump to v0.0.59 + sync intent API refactor

### DIFF
--- a/apps/playground/scripts/agentic/teams/playground/evals.json
+++ b/apps/playground/scripts/agentic/teams/playground/evals.json
@@ -18,5 +18,10 @@
     "description": "Current state of the ASR benchmark page",
     "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
     "async": false
+  },
+  "moonshine-intent-state": {
+    "description": "Current state of the Moonshine intent demo page",
+    "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
+    "async": false
   }
 }

--- a/apps/playground/scripts/agentic/teams/playground/flows/moonshine-intent-screen-ready.json
+++ b/apps/playground/scripts/agentic/teams/playground/flows/moonshine-intent-screen-ready.json
@@ -1,0 +1,42 @@
+{
+  "title": "Playground Moonshine intent screen smoke validation",
+  "validate": {
+    "workflow": {
+      "entry": "nav-intent",
+      "pre_conditions": [
+        "playground.agentic_ready"
+      ],
+      "nodes": {
+        "nav-intent": {
+          "action": "navigate",
+          "target": "/moonshine-intent",
+          "next": "wait-intent-route"
+        },
+        "wait-intent-route": {
+          "action": "wait_for",
+          "route": "/moonshine-intent",
+          "next": "wait-prepare-button"
+        },
+        "wait-prepare-button": {
+          "action": "wait_for",
+          "test_id": "moonshine-intent-prepare",
+          "next": "wait-create-button"
+        },
+        "wait-create-button": {
+          "action": "wait_for",
+          "test_id": "moonshine-intent-create",
+          "next": "wait-process-button"
+        },
+        "wait-process-button": {
+          "action": "wait_for",
+          "test_id": "moonshine-intent-process",
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/apps/playground/scripts/agentic/teams/playground/recipes/moonshine-intent-validation.json
+++ b/apps/playground/scripts/agentic/teams/playground/recipes/moonshine-intent-validation.json
@@ -1,0 +1,119 @@
+{
+  "title": "Playground Moonshine intent validation",
+  "description": "Drives the Moonshine intent demo screen end-to-end (download model, create recognizer with synced intents, process the default utterance) so the synchronous moonshine_get_closest_intents() pipeline is exercised on-device.",
+  "validate": {
+    "workflow": {
+      "entry": "intent-screen-smoke",
+      "nodes": {
+        "intent-screen-smoke": {
+          "action": "call",
+          "ref": "moonshine-intent-screen-ready",
+          "next": "assert-route"
+        },
+        "assert-route": {
+          "action": "eval_ref",
+          "ref": "moonshine-intent-state",
+          "assert": {
+            "operator": "eq",
+            "field": "route",
+            "value": "/moonshine-intent"
+          },
+          "next": "press-prepare"
+        },
+        "press-prepare": {
+          "action": "press",
+          "test_id": "moonshine-intent-prepare",
+          "next": "wait-model-downloaded"
+        },
+        "wait-model-downloaded": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
+          "assert": {
+            "operator": "eq",
+            "field": "status.modelDownloaded",
+            "value": true
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "status.error"
+          },
+          "timeout_ms": 600000,
+          "poll_ms": 2000,
+          "next": "press-create"
+        },
+        "press-create": {
+          "action": "press",
+          "test_id": "moonshine-intent-create",
+          "next": "wait-recognizer-ready"
+        },
+        "wait-recognizer-ready": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
+          "assert": {
+            "all": [
+              {
+                "operator": "eq",
+                "field": "status.hasRecognizer",
+                "value": true
+              },
+              {
+                "operator": "gte",
+                "field": "status.intentCount",
+                "value": 3
+              }
+            ]
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "status.error"
+          },
+          "timeout_ms": 60000,
+          "poll_ms": 1000,
+          "next": "press-process"
+        },
+        "press-process": {
+          "action": "press",
+          "test_id": "moonshine-intent-process",
+          "next": "wait-match"
+        },
+        "wait-match": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
+          "assert": {
+            "operator": "contains",
+            "field": "status.matchText",
+            "value": "turn on the lights"
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "status.error"
+          },
+          "timeout_ms": 30000,
+          "poll_ms": 500,
+          "next": "press-release"
+        },
+        "press-release": {
+          "action": "press",
+          "test_id": "moonshine-intent-release",
+          "next": "wait-recognizer-released"
+        },
+        "wait-recognizer-released": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
+          "assert": {
+            "operator": "eq",
+            "field": "status.hasRecognizer",
+            "value": false
+          },
+          "timeout_ms": 10000,
+          "poll_ms": 500,
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/packages/moonshine.rn/android/build.gradle
+++ b/packages/moonshine.rn/android/build.gradle
@@ -31,17 +31,24 @@ buildscript {
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
-def moonshineAndroidUseSource = getEnvOrProp(
-  'SITEED_MOONSHINE_ANDROID_USE_SOURCE',
-  'siteedMoonshineAndroidUseSource',
-  '1'
-) == '1'
 def moonshineAndroidAar = getEnvOrProp('SITEED_MOONSHINE_ANDROID_AAR', 'siteedMoonshineAndroidAar', null)
 def moonshineAndroidSourceAar = getEnvOrProp(
   'SITEED_MOONSHINE_ANDROID_SOURCE_AAR',
   'siteedMoonshineAndroidSourceAar',
   new File(projectDir, '../prebuilt/android/moonshine-voice-source-release.aar').absolutePath
 )
+// Default: use the locally built source AAR when present (development /
+// monorepo workflow). When the AAR is absent (typical for npm-published
+// consumers — package.json excludes it), fall back to the Maven coordinate so
+// builds do not fail with "source-built AAR is missing".
+def moonshineAndroidUseSourceOverride = getEnvOrProp(
+  'SITEED_MOONSHINE_ANDROID_USE_SOURCE',
+  'siteedMoonshineAndroidUseSource',
+  null
+)
+def moonshineAndroidUseSource = moonshineAndroidUseSourceOverride != null
+  ? moonshineAndroidUseSourceOverride == '1'
+  : file(moonshineAndroidSourceAar).exists()
 def moonshineAndroidMavenCoord = getEnvOrProp(
   'SITEED_MOONSHINE_ANDROID_MAVEN_COORD',
   'siteedMoonshineAndroidMavenCoord',

--- a/packages/moonshine.rn/android/build.gradle
+++ b/packages/moonshine.rn/android/build.gradle
@@ -34,7 +34,7 @@ apply plugin: "kotlin-android"
 def moonshineAndroidUseSource = getEnvOrProp(
   'SITEED_MOONSHINE_ANDROID_USE_SOURCE',
   'siteedMoonshineAndroidUseSource',
-  '0'
+  '1'
 ) == '1'
 def moonshineAndroidAar = getEnvOrProp('SITEED_MOONSHINE_ANDROID_AAR', 'siteedMoonshineAndroidAar', null)
 def moonshineAndroidSourceAar = getEnvOrProp(
@@ -45,7 +45,7 @@ def moonshineAndroidSourceAar = getEnvOrProp(
 def moonshineAndroidMavenCoord = getEnvOrProp(
   'SITEED_MOONSHINE_ANDROID_MAVEN_COORD',
   'siteedMoonshineAndroidMavenCoord',
-  'ai.moonshine:moonshine-voice:0.0.51'
+  'ai.moonshine:moonshine-voice:0.0.59'
 )
 def moonshineAndroidMavenRepo = getEnvOrProp(
   'SITEED_MOONSHINE_ANDROID_MAVEN_REPO',

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineDirectJni.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineDirectJni.kt
@@ -73,7 +73,10 @@ internal object MoonshineDirectJni {
     ensureLoaded()
     val matches: Array<IntentMatch>? =
       JNI.moonshineGetClosestIntents(intentRecognizerHandle, utterance, threshold)
-    if (matches == null || matches.isEmpty()) {
+    if (matches == null) {
+      throw RuntimeException("moonshineGetClosestIntents failed")
+    }
+    if (matches.isEmpty()) {
       return null
     }
     val top = matches[0]

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineDirectJni.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineDirectJni.kt
@@ -1,23 +1,16 @@
 package net.siteed.moonshine
 
-import android.util.Log
+import ai.moonshine.voice.IntentMatch
 import ai.moonshine.voice.JNI
 import ai.moonshine.voice.Transcript
 import ai.moonshine.voice.TranscriberOption
-import java.lang.reflect.InvocationTargetException
-import java.util.concurrent.ConcurrentHashMap
 
 internal data class MoonshineIntentMatchNative(
   val triggerPhrase: String,
-  val utterance: String,
   val similarity: Float
 )
 
 internal object MoonshineDirectJni {
-  private const val TAG = "MoonshineDirectJni"
-  private val jniClass: Class<*> = JNI::class.java
-  private val missingOptionalApiWarnings = ConcurrentHashMap.newKeySet<String>()
-
   fun addAudioToStream(
     transcriberHandle: Int,
     streamHandle: Int,
@@ -34,33 +27,17 @@ internal object MoonshineDirectJni {
   }
 
   fun clearIntents(intentRecognizerHandle: Int): Int {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalInt(
-      "moonshineClearIntents",
-      arrayOf(Int::class.javaPrimitiveType!!),
-      arrayOf(intentRecognizerHandle)
-    )
+    ensureLoaded()
+    return JNI.moonshineClearIntents(intentRecognizerHandle)
   }
 
   fun createIntentRecognizer(
     modelPath: String,
     modelArch: Int,
-    modelVariant: String?,
-    threshold: Float
+    modelVariant: String?
   ): Int {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalInt(
-      "moonshineCreateIntentRecognizer",
-      arrayOf(
-        String::class.java,
-        Int::class.javaPrimitiveType!!,
-        String::class.java,
-        Float::class.javaPrimitiveType!!
-      ),
-      arrayOf(modelPath, modelArch, modelVariant, threshold)
-    )
+    ensureLoaded()
+    return JNI.moonshineCreateIntentRecognizer(modelPath, modelArch, modelVariant)
   }
 
   fun createStream(transcriberHandle: Int): Int {
@@ -74,13 +51,8 @@ internal object MoonshineDirectJni {
   }
 
   fun freeIntentRecognizer(intentRecognizerHandle: Int) {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    invokeOptionalVoid(
-      "moonshineFreeIntentRecognizer",
-      arrayOf(Int::class.javaPrimitiveType!!),
-      arrayOf(intentRecognizerHandle)
-    )
+    ensureLoaded()
+    JNI.moonshineFreeIntentRecognizer(intentRecognizerHandle)
   }
 
   fun freeStream(transcriberHandle: Int, streamHandle: Int) {
@@ -93,24 +65,27 @@ internal object MoonshineDirectJni {
     JNI.moonshineFreeTranscriber(transcriberHandle)
   }
 
-  fun getIntentCount(intentRecognizerHandle: Int): Int {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalInt(
-      "moonshineGetIntentCount",
-      arrayOf(Int::class.javaPrimitiveType!!),
-      arrayOf(intentRecognizerHandle)
+  fun getClosestIntent(
+    intentRecognizerHandle: Int,
+    utterance: String,
+    threshold: Float
+  ): MoonshineIntentMatchNative? {
+    ensureLoaded()
+    val matches: Array<IntentMatch>? =
+      JNI.moonshineGetClosestIntents(intentRecognizerHandle, utterance, threshold)
+    if (matches == null || matches.isEmpty()) {
+      return null
+    }
+    val top = matches[0]
+    return MoonshineIntentMatchNative(
+      triggerPhrase = top.canonicalPhrase ?: "",
+      similarity = top.similarity
     )
   }
 
-  fun getIntentThreshold(intentRecognizerHandle: Int): Float {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalFloat(
-      "moonshineGetIntentThreshold",
-      arrayOf(Int::class.javaPrimitiveType!!),
-      arrayOf(intentRecognizerHandle)
-    )
+  fun getIntentCount(intentRecognizerHandle: Int): Int {
+    ensureLoaded()
+    return JNI.moonshineGetIntentCount(intentRecognizerHandle)
   }
 
   fun getVersion(): Int {
@@ -144,42 +119,9 @@ internal object MoonshineDirectJni {
     )
   }
 
-  fun processUtterance(intentRecognizerHandle: Int, utterance: String): MoonshineIntentMatchNative? {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    val result = invokeOptional(
-      "moonshineProcessUtteranceDetailed",
-      arrayOf(Int::class.javaPrimitiveType!!, String::class.java),
-      arrayOf(intentRecognizerHandle, utterance)
-    ) as? Array<*>
-    if (result == null || result.size < 3) {
-      return null
-    }
-    return MoonshineIntentMatchNative(
-      triggerPhrase = result[0]?.toString().orEmpty(),
-      utterance = result[1]?.toString().orEmpty(),
-      similarity = result[2]?.toString()?.toFloatOrNull() ?: 0f
-    )
-  }
-
   fun registerIntent(intentRecognizerHandle: Int, triggerPhrase: String): Int {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalInt(
-      "moonshineRegisterIntent",
-      arrayOf(Int::class.javaPrimitiveType!!, String::class.java),
-      arrayOf(intentRecognizerHandle, triggerPhrase)
-    )
-  }
-
-  fun setIntentThreshold(intentRecognizerHandle: Int, threshold: Float): Int {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalInt(
-      "moonshineSetIntentThreshold",
-      arrayOf(Int::class.javaPrimitiveType!!, Float::class.javaPrimitiveType!!),
-      arrayOf(intentRecognizerHandle, threshold)
-    )
+    ensureLoaded()
+    return JNI.moonshineRegisterIntent(intentRecognizerHandle, triggerPhrase, null, 0)
   }
 
   fun startStream(transcriberHandle: Int, streamHandle: Int): Int {
@@ -213,80 +155,11 @@ internal object MoonshineDirectJni {
   }
 
   fun unregisterIntent(intentRecognizerHandle: Int, triggerPhrase: String): Int {
-    // Requires the source-built artifact extension; missing JNI entry points
-    // raise UnsupportedOperationException after a one-time warning.
-    return invokeOptionalInt(
-      "moonshineUnregisterIntent",
-      arrayOf(Int::class.javaPrimitiveType!!, String::class.java),
-      arrayOf(intentRecognizerHandle, triggerPhrase)
-    )
+    ensureLoaded()
+    return JNI.moonshineUnregisterIntent(intentRecognizerHandle, triggerPhrase)
   }
 
   private fun ensureLoaded() {
     JNI.ensureLibraryLoaded()
-  }
-
-  private fun invokeOptional(
-    methodName: String,
-    parameterTypes: Array<Class<*>>,
-    args: Array<Any?>
-  ): Any? {
-    ensureLoaded()
-    val method = try {
-      jniClass.getMethod(methodName, *parameterTypes)
-    } catch (_: NoSuchMethodException) {
-      if (missingOptionalApiWarnings.add(methodName)) {
-        Log.w(
-          TAG,
-          "$methodName is unavailable in the loaded Moonshine Android artifact; " +
-            "use the source-built artifact from packages/moonshine.rn/build-moonshine-android.sh."
-        )
-      }
-      throw UnsupportedOperationException(
-        "$methodName is unavailable in the loaded Moonshine Android artifact. " +
-          "Use the source-built artifact from packages/moonshine.rn/build-moonshine-android.sh."
-      )
-    }
-
-    return try {
-      method.invoke(null, *args)
-    } catch (error: InvocationTargetException) {
-      throw (error.targetException ?: error)
-    }
-  }
-
-  private fun invokeOptionalFloat(
-    methodName: String,
-    parameterTypes: Array<Class<*>>,
-    args: Array<Any?>
-  ): Float {
-    val value = invokeOptional(methodName, parameterTypes, args)
-    return when (value) {
-      is Float -> value
-      is Double -> value.toFloat()
-      is Number -> value.toFloat()
-      else -> throw IllegalStateException("$methodName returned an unexpected value")
-    }
-  }
-
-  private fun invokeOptionalInt(
-    methodName: String,
-    parameterTypes: Array<Class<*>>,
-    args: Array<Any?>
-  ): Int {
-    val value = invokeOptional(methodName, parameterTypes, args)
-    return when (value) {
-      is Int -> value
-      is Number -> value.toInt()
-      else -> throw IllegalStateException("$methodName returned an unexpected value")
-    }
-  }
-
-  private fun invokeOptionalVoid(
-    methodName: String,
-    parameterTypes: Array<Class<*>>,
-    args: Array<Any?>
-  ) {
-    invokeOptional(methodName, parameterTypes, args)
   }
 }

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineDirectJni.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineDirectJni.kt
@@ -79,6 +79,8 @@ internal object MoonshineDirectJni {
     if (matches.isEmpty()) {
       return null
     }
+    // Upstream contract (core/moonshine-c-api.h: moonshine_get_closest_intents):
+    // returned array is sorted by descending similarity, so index 0 is the top.
     val top = matches[0]
     return MoonshineIntentMatchNative(
       triggerPhrase = top.canonicalPhrase ?: "",
@@ -124,6 +126,7 @@ internal object MoonshineDirectJni {
 
   fun registerIntent(intentRecognizerHandle: Int, triggerPhrase: String): Int {
     ensureLoaded()
+    // (handle, canonicalPhrase, embedding=null → auto-compute, priority=0).
     return JNI.moonshineRegisterIntent(intentRecognizerHandle, triggerPhrase, null, 0)
   }
 

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
@@ -69,6 +69,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
   companion object {
     const val EVENT_NAME = "MoonshineTranscriptEvent"
     const val NAME = "Moonshine"
+    private const val DEFAULT_INTENT_THRESHOLD = 0.7f
   }
 
   private val transcriberStates = ConcurrentHashMap<String, TranscriberState>()
@@ -195,7 +196,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
         if (config.hasKey("threshold") && !config.isNull("threshold")) {
           config.getDouble("threshold").toFloat()
         } else {
-          0.7f
+          DEFAULT_INTENT_THRESHOLD
         }
 
       val handle = MoonshineDirectJni.createIntentRecognizer(
@@ -298,7 +299,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
   fun getIntentThreshold(intentRecognizerId: String, promise: Promise) {
     try {
       parseIntentRecognizerId(intentRecognizerId)
-      val threshold = intentThresholds[intentRecognizerId] ?: 0.7f
+      val threshold = intentThresholds[intentRecognizerId] ?: DEFAULT_INTENT_THRESHOLD
       promise.resolve(threshold.toDouble())
     } catch (error: Throwable) {
       promise.reject("MOONSHINE_ERROR", error.message, error)
@@ -356,7 +357,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
   fun processUtterance(intentRecognizerId: String, utterance: String, promise: Promise) {
     try {
       val handle = parseIntentRecognizerId(intentRecognizerId)
-      val threshold = intentThresholds[intentRecognizerId] ?: 0.7f
+      val threshold = intentThresholds[intentRecognizerId] ?: DEFAULT_INTENT_THRESHOLD
       val match = MoonshineDirectJni.getClosestIntent(handle, utterance, threshold)
       val result = successMap()
       result.putBoolean("matched", match != null)

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
@@ -73,6 +73,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
 
   private val transcriberStates = ConcurrentHashMap<String, TranscriberState>()
   private val intentRecognizerHandles = ConcurrentHashMap<String, Int>()
+  private val intentThresholds = ConcurrentHashMap<String, Float>()
   private val transcriberCounter = AtomicInteger(1)
   private var defaultTranscriberId: String? = null
 
@@ -200,12 +201,12 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
       val handle = MoonshineDirectJni.createIntentRecognizer(
         modelRoot.absolutePath,
         modelArch,
-        modelVariant,
-        threshold
+        modelVariant
       )
       requireNonNegativeHandle(handle, "create intent recognizer")
       val intentId = intentRecognizerIdForHandle(handle)
       intentRecognizerHandles[intentId] = handle
+      intentThresholds[intentId] = threshold
 
       val result = successMap()
       result.putString("intentRecognizerId", intentId)
@@ -296,15 +297,8 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun getIntentThreshold(intentRecognizerId: String, promise: Promise) {
     try {
-      val handle = parseIntentRecognizerId(intentRecognizerId)
-      val threshold = MoonshineDirectJni.getIntentThreshold(handle)
-      if (threshold < 0f) {
-        throw IllegalStateException(
-          "Failed to get Moonshine intent threshold: ${
-            MoonshineDirectJni.errorToString(threshold.toInt())
-          }"
-        )
-      }
+      parseIntentRecognizerId(intentRecognizerId)
+      val threshold = intentThresholds[intentRecognizerId] ?: 0.7f
       promise.resolve(threshold.toDouble())
     } catch (error: Throwable) {
       promise.reject("MOONSHINE_ERROR", error.message, error)
@@ -362,13 +356,14 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
   fun processUtterance(intentRecognizerId: String, utterance: String, promise: Promise) {
     try {
       val handle = parseIntentRecognizerId(intentRecognizerId)
-      val match = MoonshineDirectJni.processUtterance(handle, utterance)
+      val threshold = intentThresholds[intentRecognizerId] ?: 0.7f
+      val match = MoonshineDirectJni.getClosestIntent(handle, utterance, threshold)
       val result = successMap()
       result.putBoolean("matched", match != null)
       if (match != null) {
         val matchMap = Arguments.createMap()
         matchMap.putString("triggerPhrase", match.triggerPhrase)
-        matchMap.putString("utterance", match.utterance)
+        matchMap.putString("utterance", utterance)
         matchMap.putDouble("similarity", match.similarity.toDouble())
         result.putMap("match", matchMap)
       }
@@ -409,6 +404,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
       val handle = parseIntentRecognizerId(intentRecognizerId)
       MoonshineDirectJni.freeIntentRecognizer(handle)
       intentRecognizerHandles.remove(intentRecognizerId)
+      intentThresholds.remove(intentRecognizerId)
       promise.resolve(successMap())
     } catch (error: Throwable) {
       promise.reject("MOONSHINE_ERROR", error.message, error)
@@ -460,11 +456,8 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun setIntentThreshold(intentRecognizerId: String, threshold: Double, promise: Promise) {
     try {
-      val handle = parseIntentRecognizerId(intentRecognizerId)
-      requireNoError(
-        MoonshineDirectJni.setIntentThreshold(handle, threshold.toFloat()),
-        "set intent threshold"
-      )
+      parseIntentRecognizerId(intentRecognizerId)
+      intentThresholds[intentRecognizerId] = threshold.toFloat()
       promise.resolve(successMap())
     } catch (error: Throwable) {
       promise.reject("MOONSHINE_ERROR", error.message, error)
@@ -1146,6 +1139,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
       }
     }
     intentRecognizerHandles.clear()
+    intentThresholds.clear()
   }
 
   private fun releaseStreamState(state: TranscriberState, streamHandle: Int) {

--- a/packages/moonshine.rn/build-moonshine-android.sh
+++ b/packages/moonshine.rn/build-moonshine-android.sh
@@ -53,6 +53,9 @@ decouple_bundled_ort_in_aar() {
   # call goes through the C API table that function returns. Clearing its
   # version requirement makes the lookup match any ORT default-version export
   # (sherpa's `OrtGetApiBase@@VERS_1.24.3`, our own `@@VERS_1.23.0`, etc).
+  # The host ORT must be >= 1.23 (the API version moonshine was compiled
+  # against); older runtimes hand back an API table missing entries
+  # libmoonshine.so will dereference.
   #
   # The AAR keeps shipping its own libonnxruntime.so so standalone consumers
   # (apps that pull in only moonshine.rn) still load successfully. Apps that

--- a/packages/moonshine.rn/build-moonshine-android.sh
+++ b/packages/moonshine.rn/build-moonshine-android.sh
@@ -40,6 +40,57 @@ sanitize_metadata_path() {
   echo "[external override]"
 }
 
+decouple_bundled_ort_in_aar() {
+  # In a multi-package monorepo APK other React Native native modules
+  # (notably sherpa-onnx.rn) ship their own libonnxruntime.so. Both copies
+  # land at lib/arm64-v8a/libonnxruntime.so during APK packaging and gradle
+  # pickFirst silently drops one. When the surviving copy is sherpa's ORT
+  # 1.24.x, dlopen of libmoonshine.so fails because moonshine's only
+  # versioned import is `OrtGetApiBase@VERS_1.23.0` (a single entry point;
+  # everything else goes through the C API table that the function returns).
+  #
+  # Fix: strip the version requirement from that one symbol so it resolves to
+  # whichever ORT export wins (sherpa's `OrtGetApiBase@@VERS_1.24.3` is the
+  # default version and answers the unversioned lookup). Then drop moonshine's
+  # bundled libonnxruntime.so from the AAR — the consumer APK already has one.
+  local aar_path="$1"
+  if ! command -v patchelf >/dev/null 2>&1; then
+    echo -e "${RED}Error: patchelf is required to clear the ONNX Runtime symbol version.${NC}" >&2
+    echo -e "${RED}Install with 'brew install patchelf' (macOS) or 'apt-get install patchelf' (Linux).${NC}" >&2
+    exit 1
+  fi
+
+  local stage="$(mktemp -d)"
+  trap "rm -rf \"$stage\"" RETURN
+
+  unzip -q "$aar_path" -d "$stage"
+  local jni_dir="$stage/jni"
+  if [ ! -d "$jni_dir" ]; then
+    return
+  fi
+
+  local touched=0
+  for abi_dir in "$jni_dir"/*; do
+    [ -d "$abi_dir" ] || continue
+    for consumer in "$abi_dir/libmoonshine.so" "$abi_dir/libmoonshine-jni.so"; do
+      [ -f "$consumer" ] || continue
+      patchelf --clear-symbol-version OrtGetApiBase "$consumer"
+      touched=1
+    done
+    if [ -f "$abi_dir/libonnxruntime.so" ]; then
+      rm -f "$abi_dir/libonnxruntime.so"
+      touched=1
+    fi
+  done
+
+  if [ "$touched" = "0" ]; then
+    return
+  fi
+
+  rm -f "$aar_path"
+  ( cd "$stage" && zip -qr "$aar_path" . )
+}
+
 extract_ort_symbol_version() {
   local library_path="$1"
   if ! command -v llvm-readobj >/dev/null 2>&1; then
@@ -180,6 +231,8 @@ if [ -z "$AAR_SOURCE" ] || [ ! -f "$AAR_SOURCE" ]; then
 fi
 
 cp "$AAR_SOURCE" "$OUTPUT_AAR"
+
+decouple_bundled_ort_in_aar "$OUTPUT_AAR"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/packages/moonshine.rn/build-moonshine-android.sh
+++ b/packages/moonshine.rn/build-moonshine-android.sh
@@ -41,18 +41,25 @@ sanitize_metadata_path() {
 }
 
 decouple_bundled_ort_in_aar() {
-  # In a multi-package monorepo APK other React Native native modules
-  # (notably sherpa-onnx.rn) ship their own libonnxruntime.so. Both copies
-  # land at lib/arm64-v8a/libonnxruntime.so during APK packaging and gradle
-  # pickFirst silently drops one. When the surviving copy is sherpa's ORT
-  # 1.24.x, dlopen of libmoonshine.so fails because moonshine's only
-  # versioned import is `OrtGetApiBase@VERS_1.23.0` (a single entry point;
-  # everything else goes through the C API table that the function returns).
+  # Strip the only versioned ORT symbol moonshine imports so libmoonshine.so
+  # accepts any libonnxruntime.so the host APK ships. Without this, a
+  # multi-package APK that also pulls in sherpa-onnx.rn (which bundles ORT
+  # 1.24.x) ends up with both packages providing lib/arm64-v8a/libonnxruntime.so
+  # — gradle pickFirst silently drops one, and if sherpa's wins, moonshine's
+  # `OrtGetApiBase@VERS_1.23.0` lookup fails and dlopen reports
+  # "Failed to load moonshine-jni library".
   #
-  # Fix: strip the version requirement from that one symbol so it resolves to
-  # whichever ORT export wins (sherpa's `OrtGetApiBase@@VERS_1.24.3` is the
-  # default version and answers the unversioned lookup). Then drop moonshine's
-  # bundled libonnxruntime.so from the AAR — the consumer APK already has one.
+  # `OrtGetApiBase` is moonshine's only versioned ORT import; every later ORT
+  # call goes through the C API table that function returns. Clearing its
+  # version requirement makes the lookup match any ORT default-version export
+  # (sherpa's `OrtGetApiBase@@VERS_1.24.3`, our own `@@VERS_1.23.0`, etc).
+  #
+  # The AAR keeps shipping its own libonnxruntime.so so standalone consumers
+  # (apps that pull in only moonshine.rn) still load successfully. Apps that
+  # also include sherpa-onnx.rn typically rely on AGP's default duplicate-lib
+  # handling; if a build fails on duplicate libonnxruntime.so, the consumer
+  # can add `packagingOptions.pickFirst "**/libonnxruntime.so"` in app
+  # build.gradle.
   local aar_path="$1"
   if ! command -v patchelf >/dev/null 2>&1; then
     echo -e "${RED}Error: patchelf is required to clear the ONNX Runtime symbol version.${NC}" >&2
@@ -77,10 +84,6 @@ decouple_bundled_ort_in_aar() {
       patchelf --clear-symbol-version OrtGetApiBase "$consumer"
       touched=1
     done
-    if [ -f "$abi_dir/libonnxruntime.so" ]; then
-      rm -f "$abi_dir/libonnxruntime.so"
-      touched=1
-    fi
   done
 
   if [ "$touched" = "0" ]; then
@@ -241,6 +244,11 @@ MOONSHINE_IMPORTED_ORT_VERSION="unknown"
 MOONSHINE_PACKAGED_ORT_VERSION="unknown"
 if unzip -p "$OUTPUT_AAR" jni/arm64-v8a/libmoonshine.so > "$TMP_DIR/libmoonshine.so" 2>/dev/null; then
   MOONSHINE_IMPORTED_ORT_VERSION="$(extract_ort_symbol_version "$TMP_DIR/libmoonshine.so")"
+  # decouple_bundled_ort_in_aar strips the version requirement from the only
+  # versioned ORT import. Report that explicitly so metadata isn't misleading.
+  if [ -z "$MOONSHINE_IMPORTED_ORT_VERSION" ]; then
+    MOONSHINE_IMPORTED_ORT_VERSION="stripped"
+  fi
 fi
 if unzip -p "$OUTPUT_AAR" jni/arm64-v8a/libonnxruntime.so > "$TMP_DIR/libonnxruntime.so" 2>/dev/null; then
   MOONSHINE_PACKAGED_ORT_VERSION="$(extract_ort_symbol_version "$TMP_DIR/libonnxruntime.so")"

--- a/packages/moonshine.rn/build-moonshine-web.sh
+++ b/packages/moonshine.rn/build-moonshine-web.sh
@@ -10,6 +10,9 @@ MOONSHINE_JS_VERSION="$(node -p "require('$PACKAGE_DIR/package.json').moonshineJ
 MOONSHINE_JS_GIT_HEAD="$(node -p "require('$PACKAGE_DIR/package.json').moonshineJsGitHead")"
 
 mkdir -p "$OUTPUT_DIR"
+# Wipe stale local models (e.g. medium/ from prior builds) so the layout always
+# matches the current CDN-pulled set.
+rm -rf "$OUTPUT_DIR/model"
 
 # Tiny + base quantized models are pulled directly from the canonical CDN; we
 # do not need any moonshine-js bundle output, only its model directory layout.

--- a/packages/moonshine.rn/build-moonshine-web.sh
+++ b/packages/moonshine.rn/build-moonshine-web.sh
@@ -5,21 +5,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_DIR="$SCRIPT_DIR"
 OUTPUT_DIR="$PACKAGE_DIR/prebuilt/web"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+UPSTREAM_JS_DIR="$PACKAGE_DIR/third_party/moonshine-js"
+
+if [ ! -d "$UPSTREAM_JS_DIR/.git" ]; then
+  echo "Error: upstream MoonshineJS checkout missing. Run ./setup.sh first." >&2
+  exit 1
+fi
 
 MOONSHINE_JS_VERSION="$(node -p "require('$PACKAGE_DIR/package.json').moonshineJsVersion")"
 MOONSHINE_JS_GIT_HEAD="$(node -p "require('$PACKAGE_DIR/package.json').moonshineJsGitHead")"
 
 mkdir -p "$OUTPUT_DIR"
-rm -rf "$OUTPUT_DIR/model"
 
-cd "$TMP_DIR"
-npm pack "@moonshine-ai/moonshine-js@${MOONSHINE_JS_VERSION}" >/dev/null
-tar -xzf ./*.tgz
+# Tiny + base quantized models are pulled directly from the canonical CDN; we
+# do not need any moonshine-js bundle output, only its model directory layout.
+mkdir -p "$OUTPUT_DIR/model/tiny/quantized"
+curl -fsSL "https://download.moonshine.ai/model/tiny/quantized/encoder_model.onnx" \
+  -o "$OUTPUT_DIR/model/tiny/quantized/encoder_model.onnx"
+curl -fsSL "https://download.moonshine.ai/model/tiny/quantized/decoder_model_merged.onnx" \
+  -o "$OUTPUT_DIR/model/tiny/quantized/decoder_model_merged.onnx"
 
-mkdir -p "$OUTPUT_DIR/model"
-cp -R "$TMP_DIR/package/dist/model/." "$OUTPUT_DIR/model/"
 mkdir -p "$OUTPUT_DIR/model/base/quantized"
 curl -fsSL "https://download.moonshine.ai/model/base/quantized/encoder_model.onnx" \
   -o "$OUTPUT_DIR/model/base/quantized/encoder_model.onnx"
@@ -31,7 +36,7 @@ cat > "$OUTPUT_DIR/build-metadata.json" <<EOF
   "moonshineJsVersion": "${MOONSHINE_JS_VERSION}",
   "moonshineJsGitHead": "${MOONSHINE_JS_GIT_HEAD}",
   "models": ["tiny", "base"],
-  "source": "npm:@moonshine-ai/moonshine-js",
+  "source": "cdn:download.moonshine.ai",
   "generatedAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 }
 EOF

--- a/packages/moonshine.rn/build-moonshine-web.sh
+++ b/packages/moonshine.rn/build-moonshine-web.sh
@@ -5,12 +5,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_DIR="$SCRIPT_DIR"
 OUTPUT_DIR="$PACKAGE_DIR/prebuilt/web"
-UPSTREAM_JS_DIR="$PACKAGE_DIR/third_party/moonshine-js"
-
-if [ ! -d "$UPSTREAM_JS_DIR/.git" ]; then
-  echo "Error: upstream MoonshineJS checkout missing. Run ./setup.sh first." >&2
-  exit 1
-fi
 
 MOONSHINE_JS_VERSION="$(node -p "require('$PACKAGE_DIR/package.json').moonshineJsVersion")"
 MOONSHINE_JS_GIT_HEAD="$(node -p "require('$PACKAGE_DIR/package.json').moonshineJsGitHead")"

--- a/packages/moonshine.rn/ios/Moonshine.mm
+++ b/packages/moonshine.rn/ios/Moonshine.mm
@@ -3,10 +3,7 @@
 #import <React/RCTLog.h>
 
 #import <deque>
-#import <mutex>
-#import <optional>
 #import <string>
-#import <unordered_map>
 #import <vector>
 
 #include "moonshine-c-api.h"
@@ -17,51 +14,11 @@ static const NSInteger MoonshineErrorCodeGeneric = -1;
 
 namespace {
 
-struct IntentMatch {
-  std::string triggerPhrase;
-  std::string utterance;
-  float similarity;
-};
-
 struct TranscriberOptionBuffer {
   std::deque<std::string> names;
   std::deque<std::string> values;
-  std::vector<transcriber_option_t> options;
+  std::vector<moonshine_option_t> options;
 };
-
-std::mutex gIntentMatchMutex;
-std::unordered_map<int32_t, IntentMatch> gLastIntentMatches;
-
-void ClearIntentMatch(int32_t handle) {
-  std::lock_guard<std::mutex> lock(gIntentMatchMutex);
-  gLastIntentMatches.erase(handle);
-}
-
-std::optional<IntentMatch> TakeIntentMatch(int32_t handle) {
-  std::lock_guard<std::mutex> lock(gIntentMatchMutex);
-  auto iterator = gLastIntentMatches.find(handle);
-  if (iterator == gLastIntentMatches.end()) {
-    return std::nullopt;
-  }
-  auto match = iterator->second;
-  gLastIntentMatches.erase(iterator);
-  return match;
-}
-
-void MoonshineIntentCallback(
-    void *userData,
-    const char *triggerPhrase,
-    const char *utterance,
-    float similarity
-) {
-  const auto handle = static_cast<int32_t>(reinterpret_cast<intptr_t>(userData));
-  std::lock_guard<std::mutex> lock(gIntentMatchMutex);
-  IntentMatch match;
-  match.triggerPhrase = triggerPhrase != nullptr ? triggerPhrase : "";
-  match.utterance = utterance != nullptr ? utterance : "";
-  match.similarity = similarity;
-  gLastIntentMatches[handle] = match;
-}
 
 NSString *StringFromCString(const char *value) {
   if (value == nullptr) {
@@ -360,6 +317,7 @@ void ThrowIfNegativeHandle(int32_t handle, NSString *operation) {
 @property(nonatomic, strong)
     NSMutableDictionary<NSString *, MoonshineTranscriberState *> *transcriberStates;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *intentRecognizerHandles;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *intentThresholds;
 @end
 
 @implementation Moonshine
@@ -377,6 +335,7 @@ RCT_EXPORT_MODULE(Moonshine)
     _transcriberCounter = 1;
     _transcriberStates = [NSMutableDictionary dictionary];
     _intentRecognizerHandles = [NSMutableDictionary dictionary];
+    _intentThresholds = [NSMutableDictionary dictionary];
   }
   return self;
 }
@@ -472,7 +431,6 @@ RCT_EXPORT_METHOD(clearIntents:(NSString *)intentRecognizerId
   @try {
     int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
     ThrowIfMoonshineError(moonshine_clear_intents(handle), @"clear intents");
-    ClearIntentMatch(handle);
     resolve([self successMap]);
   } @catch (id exception) {
     RejectPromiseWithError(reject, MoonshineNSErrorFromException(exception));
@@ -497,12 +455,12 @@ RCT_EXPORT_METHOD(createIntentRecognizer:(NSDictionary *)config
     int32_t handle = moonshine_create_intent_recognizer(
         modelPath.UTF8String,
         static_cast<uint32_t>(modelArch),
-        modelVariant.length > 0 ? modelVariant.UTF8String : nullptr,
-        threshold);
+        modelVariant.length > 0 ? modelVariant.UTF8String : nullptr);
     ThrowIfNegativeHandle(handle, @"create intent recognizer");
 
     NSString *intentRecognizerId = [self intentRecognizerIdForHandle:handle];
     self.intentRecognizerHandles[intentRecognizerId] = @(handle);
+    self.intentThresholds[intentRecognizerId] = @(threshold);
 
     NSMutableDictionary *result = [self successMap];
     result[@"intentRecognizerId"] = intentRecognizerId;
@@ -536,7 +494,7 @@ RCT_EXPORT_METHOD(createStreamForTranscriber:(NSString *)transcriberId
 RCT_EXPORT_METHOD(createTranscriberFromAssets:(NSDictionary *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  [self createTranscriber:config resolver:resolve assignAsDefault:NO loader:^int32_t(std::vector<transcriber_option_t> &options) {
+  [self createTranscriber:config resolver:resolve assignAsDefault:NO loader:^int32_t(std::vector<moonshine_option_t> &options) {
     NSString *assetPath = StringFromValue(config[@"assetPath"]);
     NSString *resolvedAssetPath = [self resolveAssetModelPath:assetPath];
     return moonshine_load_transcriber_from_files(
@@ -551,7 +509,7 @@ RCT_EXPORT_METHOD(createTranscriberFromAssets:(NSDictionary *)config
 RCT_EXPORT_METHOD(createTranscriberFromFiles:(NSDictionary *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  [self createTranscriber:config resolver:resolve assignAsDefault:NO loader:^int32_t(std::vector<transcriber_option_t> &options) {
+  [self createTranscriber:config resolver:resolve assignAsDefault:NO loader:^int32_t(std::vector<moonshine_option_t> &options) {
     NSString *modelPath = ResolvedLocalPathString(StringFromValue(config[@"modelPath"]));
     if (modelPath.length == 0) {
       ThrowNSError(@"Moonshine modelPath is required");
@@ -571,7 +529,7 @@ RCT_EXPORT_METHOD(createTranscriberFromFiles:(NSDictionary *)config
 RCT_EXPORT_METHOD(createTranscriberFromMemory:(NSDictionary *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  [self createTranscriber:config resolver:resolve assignAsDefault:NO loader:^int32_t(std::vector<transcriber_option_t> &options) {
+  [self createTranscriber:config resolver:resolve assignAsDefault:NO loader:^int32_t(std::vector<moonshine_option_t> &options) {
     NSArray *modelData = config[@"modelData"];
     if (![modelData isKindOfClass:NSArray.class] || modelData.count != 3) {
       ThrowNSError(@"Moonshine modelData must contain exactly 3 binary parts");
@@ -619,12 +577,9 @@ RCT_EXPORT_METHOD(getIntentThreshold:(NSString *)intentRecognizerId
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
   @try {
-    int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
-    float threshold = moonshine_get_intent_threshold(handle);
-    if (threshold < 0) {
-      ThrowNSError([NSString stringWithFormat:@"Failed to get Moonshine intent threshold: %@", StringFromCString(moonshine_error_to_string((int32_t)threshold))], (NSInteger)threshold);
-    }
-    resolve(@(threshold));
+    [self parseIntentRecognizerId:intentRecognizerId];
+    NSNumber *threshold = self.intentThresholds[intentRecognizerId] ?: @(0.7);
+    resolve(threshold);
   } @catch (id exception) {
     RejectPromiseWithError(reject, MoonshineNSErrorFromException(exception));
   }
@@ -644,7 +599,7 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config
 RCT_EXPORT_METHOD(loadFromAssets:(NSDictionary *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  [self createTranscriber:config resolver:resolve assignAsDefault:YES loader:^int32_t(std::vector<transcriber_option_t> &options) {
+  [self createTranscriber:config resolver:resolve assignAsDefault:YES loader:^int32_t(std::vector<moonshine_option_t> &options) {
     NSString *assetPath = StringFromValue(config[@"assetPath"]);
     NSString *resolvedAssetPath = [self resolveAssetModelPath:assetPath];
     return moonshine_load_transcriber_from_files(
@@ -659,7 +614,7 @@ RCT_EXPORT_METHOD(loadFromAssets:(NSDictionary *)config
 RCT_EXPORT_METHOD(loadFromFiles:(NSDictionary *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  [self createTranscriber:config resolver:resolve assignAsDefault:YES loader:^int32_t(std::vector<transcriber_option_t> &options) {
+  [self createTranscriber:config resolver:resolve assignAsDefault:YES loader:^int32_t(std::vector<moonshine_option_t> &options) {
     NSString *modelPath = ResolvedLocalPathString(StringFromValue(config[@"modelPath"]));
     if (modelPath.length == 0) {
       ThrowNSError(@"Moonshine modelPath is required");
@@ -679,7 +634,7 @@ RCT_EXPORT_METHOD(loadFromFiles:(NSDictionary *)config
 RCT_EXPORT_METHOD(loadFromMemory:(NSDictionary *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  [self createTranscriber:config resolver:resolve assignAsDefault:YES loader:^int32_t(std::vector<transcriber_option_t> &options) {
+  [self createTranscriber:config resolver:resolve assignAsDefault:YES loader:^int32_t(std::vector<moonshine_option_t> &options) {
     NSArray *modelData = config[@"modelData"];
     if (![modelData isKindOfClass:NSArray.class] || modelData.count != 3) {
       ThrowNSError(@"Moonshine modelData must contain exactly 3 binary parts");
@@ -711,24 +666,29 @@ RCT_EXPORT_METHOD(processUtterance:(NSString *)intentRecognizerId
       ThrowNSError(@"Moonshine utterance is required");
     }
     int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
-    ClearIntentMatch(handle);
-    int32_t resultCode = moonshine_process_utterance(handle, utterance.UTF8String);
-    if (resultCode < 0) {
-      ThrowNSError([NSString stringWithFormat:@"Failed to process Moonshine utterance: %@", StringFromCString(moonshine_error_to_string(resultCode))], resultCode);
+    NSNumber *thresholdNumber = self.intentThresholds[intentRecognizerId] ?: @(0.7);
+    float threshold = thresholdNumber.floatValue;
+
+    moonshine_intent_match_t *matches = nullptr;
+    uint64_t count = 0;
+    int32_t err = moonshine_get_closest_intents(
+        handle, utterance.UTF8String, threshold, &matches, &count);
+    if (err != MOONSHINE_ERROR_NONE) {
+      moonshine_free_intent_matches(matches, count);
+      ThrowNSError([NSString stringWithFormat:@"Failed to process Moonshine utterance: %@", StringFromCString(moonshine_error_to_string(err))], err);
     }
 
     NSMutableDictionary *result = [self successMap];
-    result[@"matched"] = @(resultCode > 0);
-    if (resultCode > 0) {
-      auto match = TakeIntentMatch(handle);
-      if (match.has_value()) {
-        result[@"match"] = @{
-          @"triggerPhrase": [NSString stringWithUTF8String:match->triggerPhrase.c_str()],
-          @"utterance": [NSString stringWithUTF8String:match->utterance.c_str()],
-          @"similarity": @(match->similarity),
-        };
-      }
+    result[@"matched"] = @(count > 0);
+    if (count > 0 && matches != nullptr) {
+      const moonshine_intent_match_t &top = matches[0];
+      result[@"match"] = @{
+        @"triggerPhrase": StringFromCString(top.canonical_phrase),
+        @"utterance": utterance,
+        @"similarity": @(top.similarity),
+      };
     }
+    moonshine_free_intent_matches(matches, count);
     resolve(result);
   } @catch (id exception) {
     RejectPromiseWithError(reject, MoonshineNSErrorFromException(exception));
@@ -748,8 +708,9 @@ RCT_EXPORT_METHOD(registerIntent:(NSString *)intentRecognizerId
         moonshine_register_intent(
             handle,
             triggerPhrase.UTF8String,
-            MoonshineIntentCallback,
-            reinterpret_cast<void *>(static_cast<intptr_t>(handle))),
+            nullptr,
+            0,
+            0),
         @"register intent");
     resolve([self successMap]);
   } @catch (id exception) {
@@ -771,8 +732,8 @@ RCT_EXPORT_METHOD(releaseIntentRecognizer:(NSString *)intentRecognizerId
   @try {
     int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
     moonshine_free_intent_recognizer(handle);
-    ClearIntentMatch(handle);
     [self.intentRecognizerHandles removeObjectForKey:intentRecognizerId];
+    [self.intentThresholds removeObjectForKey:intentRecognizerId];
     resolve([self successMap]);
   } @catch (id exception) {
     RejectPromiseWithError(reject, MoonshineNSErrorFromException(exception));
@@ -825,10 +786,8 @@ RCT_EXPORT_METHOD(setIntentThreshold:(NSString *)intentRecognizerId
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
   @try {
-    int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
-    ThrowIfMoonshineError(
-        moonshine_set_intent_threshold(handle, threshold.floatValue),
-        @"set intent threshold");
+    [self parseIntentRecognizerId:intentRecognizerId];
+    self.intentThresholds[intentRecognizerId] = threshold;
     resolve([self successMap]);
   } @catch (id exception) {
     RejectPromiseWithError(reject, MoonshineNSErrorFromException(exception));
@@ -1041,7 +1000,7 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
 - (void)createTranscriber:(NSDictionary *)config
                  resolver:(RCTPromiseResolveBlock)resolve
           assignAsDefault:(BOOL)assignAsDefault
-                   loader:(int32_t (^)(std::vector<transcriber_option_t> &options))loader {
+                   loader:(int32_t (^)(std::vector<moonshine_option_t> &options))loader {
   @try {
     if (assignAsDefault && self.defaultTranscriberId != nil) {
       [self releaseTranscriberInternal:self.defaultTranscriberId];
@@ -1303,7 +1262,7 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
     }
     buffer.names.emplace_back(name.UTF8String);
     buffer.values.emplace_back(value.UTF8String);
-    buffer.options.push_back(transcriber_option_t{
+    buffer.options.push_back(moonshine_option_t{
       buffer.names.back().c_str(),
       buffer.values.back().c_str(),
     });
@@ -1410,11 +1369,11 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
   for (NSNumber *handle in intentHandles) {
     @try {
       moonshine_free_intent_recognizer(handle.intValue);
-      ClearIntentMatch(handle.intValue);
     } @catch (...) {
     }
   }
   [self.intentRecognizerHandles removeAllObjects];
+  [self.intentThresholds removeAllObjects];
 }
 
 - (BOOL)releaseTranscriberInternal:(NSString *)transcriberId {

--- a/packages/moonshine.rn/ios/Moonshine.mm
+++ b/packages/moonshine.rn/ios/Moonshine.mm
@@ -682,6 +682,9 @@ RCT_EXPORT_METHOD(processUtterance:(NSString *)intentRecognizerId
     NSMutableDictionary *result = [self successMap];
     result[@"matched"] = @(count > 0);
     if (count > 0 && matches != nullptr) {
+      // Upstream sorts the array by descending similarity (see
+      // core/moonshine-c-api.h:moonshine_get_closest_intents), so index 0 is
+      // the top match.
       const moonshine_intent_match_t &top = matches[0];
       result[@"match"] = @{
         @"triggerPhrase": StringFromCString(top.canonical_phrase),
@@ -705,6 +708,8 @@ RCT_EXPORT_METHOD(registerIntent:(NSString *)intentRecognizerId
       ThrowNSError(@"Moonshine intent triggerPhrase is required");
     }
     int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
+    // (handle, canonicalPhrase, embedding=NULL → auto-compute, embeddingSize=0,
+    // priority=0). See core/moonshine-c-api.h:moonshine_register_intent.
     ThrowIfMoonshineError(
         moonshine_register_intent(
             handle,

--- a/packages/moonshine.rn/ios/Moonshine.mm
+++ b/packages/moonshine.rn/ios/Moonshine.mm
@@ -11,6 +11,7 @@
 static NSString *const MoonshineEventName = @"MoonshineTranscriptEvent";
 static NSString *const MoonshineErrorDomain = @"net.siteed.moonshine";
 static const NSInteger MoonshineErrorCodeGeneric = -1;
+static const float kMoonshineDefaultIntentThreshold = 0.7f;
 
 namespace {
 
@@ -450,7 +451,7 @@ RCT_EXPORT_METHOD(createIntentRecognizer:(NSDictionary *)config
     }
     int32_t modelArch = [self resolveIntentModelArch:config];
     NSString *modelVariant = StringFromValue(config[@"modelVariant"]);
-    float threshold = NumberFromValue(config[@"threshold"]) != nil ? NumberFromValue(config[@"threshold"]).floatValue : 0.7f;
+    float threshold = NumberFromValue(config[@"threshold"]) != nil ? NumberFromValue(config[@"threshold"]).floatValue : kMoonshineDefaultIntentThreshold;
 
     int32_t handle = moonshine_create_intent_recognizer(
         modelPath.UTF8String,
@@ -578,7 +579,7 @@ RCT_EXPORT_METHOD(getIntentThreshold:(NSString *)intentRecognizerId
                   rejecter:(RCTPromiseRejectBlock)reject) {
   @try {
     [self parseIntentRecognizerId:intentRecognizerId];
-    NSNumber *threshold = self.intentThresholds[intentRecognizerId] ?: @(0.7);
+    NSNumber *threshold = self.intentThresholds[intentRecognizerId] ?: @(kMoonshineDefaultIntentThreshold);
     resolve(threshold);
   } @catch (id exception) {
     RejectPromiseWithError(reject, MoonshineNSErrorFromException(exception));
@@ -666,7 +667,7 @@ RCT_EXPORT_METHOD(processUtterance:(NSString *)intentRecognizerId
       ThrowNSError(@"Moonshine utterance is required");
     }
     int32_t handle = [self parseIntentRecognizerId:intentRecognizerId];
-    NSNumber *thresholdNumber = self.intentThresholds[intentRecognizerId] ?: @(0.7);
+    NSNumber *thresholdNumber = self.intentThresholds[intentRecognizerId] ?: @(kMoonshineDefaultIntentThreshold);
     float threshold = thresholdNumber.floatValue;
 
     moonshine_intent_match_t *matches = nullptr;

--- a/packages/moonshine.rn/package.json
+++ b/packages/moonshine.rn/package.json
@@ -100,7 +100,7 @@
     "react-native": "*"
   },
   "packageManager": "yarn@4.2.2",
-  "moonshineVersion": "v0.0.51",
+  "moonshineVersion": "v0.0.59",
   "eslintConfig": {
     "root": true,
     "extends": [
@@ -164,6 +164,6 @@
     "languages": "kotlin-swift",
     "version": "0.48.3"
   },
-  "moonshineJsVersion": "0.1.29",
-  "moonshineJsGitHead": "e32209e0a71017b879c7ea1a93cbc48593aabde9"
+  "moonshineJsVersion": "0.2.0",
+  "moonshineJsGitHead": "59c9c83669e464d3e3f00d85c850d4327bef9009"
 }

--- a/packages/moonshine.rn/patches/OrtAndroidOverrides.patch
+++ b/packages/moonshine.rn/patches/OrtAndroidOverrides.patch
@@ -1,60 +1,10 @@
-diff --git a/android/java/main/java/ai/moonshine/voice/JNI.java b/android/java/main/java/ai/moonshine/voice/JNI.java
-index c63618f..8c17b29 100644
---- a/android/java/main/java/ai/moonshine/voice/JNI.java
-+++ b/android/java/main/java/ai/moonshine/voice/JNI.java
-@@ -12,6 +12,7 @@ public class JNI {
-     public static final int MOONSHINE_MODEL_ARCH_BASE_STREAMING = 3;
-     public static final int MOONSHINE_MODEL_ARCH_SMALL_STREAMING = 4;
-     public static final int MOONSHINE_MODEL_ARCH_MEDIUM_STREAMING = 5;
-+    public static final int MOONSHINE_EMBEDDING_MODEL_ARCH_GEMMA_300M = 0;
- 
-     public static final int MOONSHINE_FLAG_FORCE_UPDATE = 1 << 0;
- 
-@@ -48,6 +49,36 @@ public class JNI {
-     public static native Transcript moonshineTranscribeStream(int transcriber_handle,
-             int stream_handle, int flags);
- 
-+    public static native int moonshineCreateIntentRecognizer(
-+            String path,
-+            int model_arch,
-+            String model_variant,
-+            float threshold);
-+
-+    public static native void moonshineFreeIntentRecognizer(int intent_recognizer_handle);
-+
-+    public static native int moonshineRegisterIntent(
-+            int intent_recognizer_handle,
-+            String trigger_phrase);
-+
-+    public static native int moonshineUnregisterIntent(
-+            int intent_recognizer_handle,
-+            String trigger_phrase);
-+
-+    public static native String[] moonshineProcessUtteranceDetailed(
-+            int intent_recognizer_handle,
-+            String utterance);
-+
-+    public static native int moonshineSetIntentThreshold(
-+            int intent_recognizer_handle,
-+            float threshold);
-+
-+    public static native float moonshineGetIntentThreshold(int intent_recognizer_handle);
-+
-+    public static native int moonshineGetIntentCount(int intent_recognizer_handle);
-+
-+    public static native int moonshineClearIntents(int intent_recognizer_handle);
-+
-     static boolean isLibraryLoaded = false;
- 
-     public static void ensureLibraryLoaded() {
 diff --git a/android/java/main/java/ai/moonshine/voice/Transcriber.java b/android/java/main/java/ai/moonshine/voice/Transcriber.java
-index 02b3691..34be6eb 100644
 --- a/android/java/main/java/ai/moonshine/voice/Transcriber.java
 +++ b/android/java/main/java/ai/moonshine/voice/Transcriber.java
 @@ -25,7 +25,7 @@ import java.util.HashMap;
  import java.util.concurrent.ConcurrentHashMap;
  import java.util.Map;
- 
+
 -public class Transcriber {
 +public class Transcriber implements AutoCloseable {
    private int transcriberHandle = -1;
@@ -63,7 +13,7 @@ index 02b3691..34be6eb 100644
 @@ -85,18 +85,22 @@ public class Transcriber {
      this.getDefaultStreamHandle();
    }
- 
+
 -  protected void finalize() throws Throwable {
 +  @Override
 +  public synchronized void close() {
@@ -78,245 +28,19 @@ index 02b3691..34be6eb 100644
        this.transcriberHandle = -1;
      }
    }
- 
+
 +  protected void finalize() throws Throwable { this.close(); }
 +
    public Transcript transcribeWithoutStreaming(float[] audioData,
                                                 int sampleRate) {
      return JNI.moonshineTranscribeWithoutStreaming(this.transcriberHandle,
-diff --git a/android/moonshine-jni/moonshine-jni.cpp b/android/moonshine-jni/moonshine-jni.cpp
-index b4e6c9a..74af23e 100644
---- a/android/moonshine-jni/moonshine-jni.cpp
-+++ b/android/moonshine-jni/moonshine-jni.cpp
-@@ -1,7 +1,9 @@
- #include <jni.h>
- 
- #include <memory>
-+#include <mutex>
- #include <string>
-+#include <unordered_map>
- #include <vector>
- 
- #include <android/log.h>
-@@ -14,6 +16,12 @@
- #include "utf8.h"
- 
- namespace {
-+struct intent_match_t {
-+  std::string trigger_phrase;
-+  std::string utterance;
-+  float similarity;
-+};
-+
- jclass get_class(JNIEnv *env, const char *className) {
-   jclass clazz = env->FindClass(className);
-   if (clazz == nullptr) {
-@@ -210,6 +218,40 @@ jobject c_transcript_to_jobject(JNIEnv *env, struct transcript_t *transcript) {
-   return jtranscript;
- }
- 
-+std::mutex intent_match_mutex;
-+std::unordered_map<int32_t, intent_match_t> last_intent_match_map;
-+
-+void clear_last_intent_match(int32_t intent_recognizer_handle) {
-+  std::lock_guard<std::mutex> lock(intent_match_mutex);
-+  last_intent_match_map.erase(intent_recognizer_handle);
-+}
-+
-+jobjectArray intent_match_to_jobject(JNIEnv *env,
-+                                     const intent_match_t &intent_match) {
-+  jclass stringClass = get_class(env, "java/lang/String");
-+  jobjectArray result = env->NewObjectArray(3, stringClass, nullptr);
-+  env->SetObjectArrayElement(
-+      result, 0, env->NewStringUTF(intent_match.trigger_phrase.c_str()));
-+  env->SetObjectArrayElement(result, 1,
-+                             env->NewStringUTF(intent_match.utterance.c_str()));
-+  env->SetObjectArrayElement(
-+      result, 2,
-+      env->NewStringUTF(std::to_string(intent_match.similarity).c_str()));
-+  return result;
-+}
-+
-+void store_intent_match(void *user_data, const char *trigger_phrase,
-+                        const char *utterance, float similarity) {
-+  const int32_t intent_recognizer_handle =
-+      static_cast<int32_t>(reinterpret_cast<intptr_t>(user_data));
-+  std::lock_guard<std::mutex> lock(intent_match_mutex);
-+  intent_match_t intent_match;
-+  intent_match.trigger_phrase = trigger_phrase ? trigger_phrase : "";
-+  intent_match.utterance = utterance ? utterance : "";
-+  intent_match.similarity = similarity;
-+  last_intent_match_map[intent_recognizer_handle] = intent_match;
-+}
-+
- }  // namespace
- 
- extern "C" JNIEXPORT jint JNICALL
-@@ -438,4 +480,155 @@ Java_ai_moonshine_voice_JNI_moonshineTranscribeStream(JNIEnv *env,
-     LOGE("moonshineTranscribeStream: %s\n", e.what());
-     return nullptr;
-   }
--} 
-+}
-+
-+extern "C" JNIEXPORT jint JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineCreateIntentRecognizer(
-+    JNIEnv *env, jobject /* this */, jstring path, jint model_arch,
-+    jstring model_variant, jfloat threshold) {
-+  try {
-+    const char *path_str = path == nullptr ? nullptr
-+                                           : env->GetStringUTFChars(path, nullptr);
-+    const char *model_variant_str =
-+        model_variant == nullptr ? nullptr
-+                                 : env->GetStringUTFChars(model_variant, nullptr);
-+    return moonshine_create_intent_recognizer(path_str, model_arch,
-+                                              model_variant_str, threshold);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineCreateIntentRecognizer: %s\n", e.what());
-+    return MOONSHINE_ERROR_UNKNOWN;
-+  }
-+}
-+
-+extern "C" JNIEXPORT void JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineFreeIntentRecognizer(
-+    JNIEnv * /* env */, jobject /* this */, jint intent_recognizer_handle) {
-+  try {
-+    clear_last_intent_match(intent_recognizer_handle);
-+    moonshine_free_intent_recognizer(intent_recognizer_handle);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineFreeIntentRecognizer: %s\n", e.what());
-+  }
-+}
-+
-+extern "C" JNIEXPORT jint JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineRegisterIntent(
-+    JNIEnv *env, jobject /* this */, jint intent_recognizer_handle,
-+    jstring trigger_phrase) {
-+  try {
-+    if (trigger_phrase == nullptr) {
-+      return MOONSHINE_ERROR_INVALID_ARGUMENT;
-+    }
-+    const char *trigger_phrase_str =
-+        env->GetStringUTFChars(trigger_phrase, nullptr);
-+    return moonshine_register_intent(intent_recognizer_handle,
-+                                     trigger_phrase_str, store_intent_match,
-+                                     reinterpret_cast<void *>(
-+                                         static_cast<intptr_t>(
-+                                             intent_recognizer_handle)));
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineRegisterIntent: %s\n", e.what());
-+    return MOONSHINE_ERROR_UNKNOWN;
-+  }
-+}
-+
-+extern "C" JNIEXPORT jint JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineUnregisterIntent(
-+    JNIEnv *env, jobject /* this */, jint intent_recognizer_handle,
-+    jstring trigger_phrase) {
-+  try {
-+    if (trigger_phrase == nullptr) {
-+      return MOONSHINE_ERROR_INVALID_ARGUMENT;
-+    }
-+    const char *trigger_phrase_str =
-+        env->GetStringUTFChars(trigger_phrase, nullptr);
-+    return moonshine_unregister_intent(intent_recognizer_handle,
-+                                       trigger_phrase_str);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineUnregisterIntent: %s\n", e.what());
-+    return MOONSHINE_ERROR_UNKNOWN;
-+  }
-+}
-+
-+extern "C" JNIEXPORT jobjectArray JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineProcessUtteranceDetailed(
-+    JNIEnv *env, jobject /* this */, jint intent_recognizer_handle,
-+    jstring utterance) {
-+  try {
-+    if (utterance == nullptr) {
-+      jclass exceptionClass = get_class(env, "java/lang/IllegalArgumentException");
-+      env->ThrowNew(exceptionClass, "Moonshine utterance is required");
-+      return nullptr;
-+    }
-+    clear_last_intent_match(intent_recognizer_handle);
-+    const char *utterance_str = env->GetStringUTFChars(utterance, nullptr);
-+    const int32_t result =
-+        moonshine_process_utterance(intent_recognizer_handle, utterance_str);
-+    if (result < 0) {
-+      jclass exceptionClass = get_class(env, "java/lang/RuntimeException");
-+      env->ThrowNew(exceptionClass, moonshine_error_to_string(result));
-+      return nullptr;
-+    }
-+    if (result == 0) {
-+      return nullptr;
-+    }
-+
-+    std::lock_guard<std::mutex> lock(intent_match_mutex);
-+    auto match = last_intent_match_map.find(intent_recognizer_handle);
-+    if (match == last_intent_match_map.end()) {
-+      return nullptr;
-+    }
-+    return intent_match_to_jobject(env, match->second);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineProcessUtteranceDetailed: %s\n", e.what());
-+    jclass exceptionClass = get_class(env, "java/lang/RuntimeException");
-+    env->ThrowNew(exceptionClass, e.what());
-+    return nullptr;
-+  }
-+}
-+
-+extern "C" JNIEXPORT jint JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineSetIntentThreshold(
-+    JNIEnv * /* env */, jobject /* this */, jint intent_recognizer_handle,
-+    jfloat threshold) {
-+  try {
-+    return moonshine_set_intent_threshold(intent_recognizer_handle, threshold);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineSetIntentThreshold: %s\n", e.what());
-+    return MOONSHINE_ERROR_UNKNOWN;
-+  }
-+}
-+
-+extern "C" JNIEXPORT jfloat JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineGetIntentThreshold(
-+    JNIEnv * /* env */, jobject /* this */, jint intent_recognizer_handle) {
-+  try {
-+    return moonshine_get_intent_threshold(intent_recognizer_handle);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineGetIntentThreshold: %s\n", e.what());
-+    return static_cast<jfloat>(MOONSHINE_ERROR_UNKNOWN);
-+  }
-+}
-+
-+extern "C" JNIEXPORT jint JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineGetIntentCount(
-+    JNIEnv * /* env */, jobject /* this */, jint intent_recognizer_handle) {
-+  try {
-+    return moonshine_get_intent_count(intent_recognizer_handle);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineGetIntentCount: %s\n", e.what());
-+    return MOONSHINE_ERROR_UNKNOWN;
-+  }
-+}
-+
-+extern "C" JNIEXPORT jint JNICALL
-+Java_ai_moonshine_voice_JNI_moonshineClearIntents(
-+    JNIEnv * /* env */, jobject /* this */, jint intent_recognizer_handle) {
-+  try {
-+    clear_last_intent_match(intent_recognizer_handle);
-+    return moonshine_clear_intents(intent_recognizer_handle);
-+  } catch (const std::exception &e) {
-+    LOGE("moonshineClearIntents: %s\n", e.what());
-+    return MOONSHINE_ERROR_UNKNOWN;
-+  }
-+}
 diff --git a/build.gradle.kts b/build.gradle.kts
-index eb56dd9..60c37b2 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -5,6 +5,28 @@ plugins {
      id("com.vanniktech.maven.publish") version "0.28.0"
  }
- 
+
 +fun envOrProp(envName: String, propName: String, fallback: String? = null): String? {
 +    val envValue = System.getenv(envName)?.trim()
 +    if (!envValue.isNullOrEmpty()) {
@@ -363,10 +87,9 @@ index eb56dd9..60c37b2 100644
          }
      }
 diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
-index 6ddd02f..7a23603 100644
 --- a/core/CMakeLists.txt
 +++ b/core/CMakeLists.txt
-@@ -90,7 +90,7 @@ target_include_directories(moonshine PRIVATE
+@@ -97,7 +97,7 @@ target_include_directories(moonshine PRIVATE
      ${CMAKE_CURRENT_LIST_DIR}/moonshine-utils
      ${CMAKE_CURRENT_LIST_DIR}/ort-utils
      ${CMAKE_CURRENT_LIST_DIR}/bin-tokenizer
@@ -374,42 +97,29 @@ index 6ddd02f..7a23603 100644
 +    ${ONNXRUNTIME_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}/third-party/utf-8/
  )
- 
-@@ -501,4 +501,4 @@ if (NOT WIN32 OR NOT MOONSHINE_BUILD_SHARED)
-     target_link_libraries(online-clusterer-test PRIVATE
-         moonshine
-     )
--endif()
-\ No newline at end of file
-+endif()
+
 diff --git a/core/ort-utils/CMakeLists.txt b/core/ort-utils/CMakeLists.txt
-index 091e538..7c8335d 100644
 --- a/core/ort-utils/CMakeLists.txt
 +++ b/core/ort-utils/CMakeLists.txt
 @@ -31,7 +31,7 @@ target_compile_options(ort-utils PRIVATE
- 
+
  target_include_directories(ort-utils PRIVATE
      ${MOONSHINE_UTILS_INCLUDE_DIR}
 -    ${CMAKE_CURRENT_LIST_DIR}/../third-party/onnxruntime/include
 +    ${ONNXRUNTIME_INCLUDE_DIR}
  )
- 
+
  if (ANDROID)
-@@ -69,9 +69,9 @@ target_include_directories(ort-utils-test PRIVATE
+@@ -69,7 +69,7 @@ target_include_directories(ort-utils-test PRIVATE
      ${CMAKE_CURRENT_LIST_DIR}
      ${CMAKE_CURRENT_LIST_DIR}/../moonshine-utils
      ${CMAKE_CURRENT_LIST_DIR}/../third-party/doctest
 -    ${CMAKE_CURRENT_LIST_DIR}/../third-party/onnxruntime/include
 +    ${ONNXRUNTIME_INCLUDE_DIR}
  )
- 
+
  target_link_libraries(ort-utils-test PRIVATE
-     ort-utils
--)
-\ No newline at end of file
-+)
 diff --git a/core/third-party/onnxruntime/find-ort-library-path.cmake b/core/third-party/onnxruntime/find-ort-library-path.cmake
-index 9200048..7b356e2 100644
 --- a/core/third-party/onnxruntime/find-ort-library-path.cmake
 +++ b/core/third-party/onnxruntime/find-ort-library-path.cmake
 @@ -1,4 +1,16 @@
@@ -430,10 +140,3 @@ index 9200048..7b356e2 100644
      # Detect Android ABI and map to library directory name
      if(ANDROID_ABI STREQUAL "armeabi-v7a")
          set(ONNXRUNTIME_ABI_DIR "armeabi-v7a")
-@@ -45,4 +57,4 @@ if(WIN32)
-         COMMENT "Copying onnxruntime DLL to executable directory to prevent loading from system libraries"
-     )
- endif()
--endfunction()
-\ No newline at end of file
-+endfunction()

--- a/packages/moonshine.rn/prebuilt/android/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/android/build-metadata.json
@@ -4,6 +4,6 @@
   "onnxRuntimeVersionHint": "upstream-bundled",
   "onnxRuntimeLibPathOverride": "",
   "onnxRuntimeIncludeDirOverride": "",
-  "arm64ImportedOrtSymbolVersion": "",
-  "arm64PackagedOrtSymbolVersion": "unknown"
+  "arm64ImportedOrtSymbolVersion": "stripped",
+  "arm64PackagedOrtSymbolVersion": "1.23.0"
 }

--- a/packages/moonshine.rn/prebuilt/android/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/android/build-metadata.json
@@ -1,5 +1,5 @@
 {
-  "moonshineVersion": "v0.0.51",
+  "moonshineVersion": "v0.0.59",
   "androidAbis": "arm64-v8a",
   "onnxRuntimeVersionHint": "upstream-bundled",
   "onnxRuntimeLibPathOverride": "",

--- a/packages/moonshine.rn/prebuilt/android/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/android/build-metadata.json
@@ -4,6 +4,6 @@
   "onnxRuntimeVersionHint": "upstream-bundled",
   "onnxRuntimeLibPathOverride": "",
   "onnxRuntimeIncludeDirOverride": "",
-  "arm64ImportedOrtSymbolVersion": "1.23.0",
-  "arm64PackagedOrtSymbolVersion": "1.23.0"
+  "arm64ImportedOrtSymbolVersion": "",
+  "arm64PackagedOrtSymbolVersion": "unknown"
 }

--- a/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
+++ b/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20ce3eddc0966ff314dcd58856668977e1a7b4e28bedafc5042397d47d431825
-size 28264483
+oid sha256:1ebaa7eecc92abdc24ac93bad55e794d137860e31b39308c39557609a1d55675
+size 29282866

--- a/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
+++ b/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ebaa7eecc92abdc24ac93bad55e794d137860e31b39308c39557609a1d55675
-size 29282866
+oid sha256:800165139f9674de9f08acc7deb5ef8afe3d33724f684b64e7cee5327b1936cd
+size 19705687

--- a/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
+++ b/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:800165139f9674de9f08acc7deb5ef8afe3d33724f684b64e7cee5327b1936cd
-size 19705687
+oid sha256:650ccab79bf5ad0b3a4009b16162bfba5d381254572fff2b001f329dc3e77d38
+size 29275684

--- a/packages/moonshine.rn/prebuilt/ios/Moonshine.xcframework/ios-arm64/Headers/moonshine-c-api.h
+++ b/packages/moonshine.rn/prebuilt/ios/Moonshine.xcframework/ios-arm64/Headers/moonshine-c-api.h
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8f8c49e4f69e016d49721d038d98dbe0cec767bef05e2c1682bdafe69a6c8cd
-size 26918
+oid sha256:e008a1b12cf68dc38e70d6e6b1944ef5f845a5a52ddb75ab1e305b37441a5d59
+size 38186

--- a/packages/moonshine.rn/prebuilt/ios/Moonshine.xcframework/ios-arm64_x86_64-simulator/Headers/moonshine-c-api.h
+++ b/packages/moonshine.rn/prebuilt/ios/Moonshine.xcframework/ios-arm64_x86_64-simulator/Headers/moonshine-c-api.h
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8f8c49e4f69e016d49721d038d98dbe0cec767bef05e2c1682bdafe69a6c8cd
-size 26918
+oid sha256:e008a1b12cf68dc38e70d6e6b1944ef5f845a5a52ddb75ab1e305b37441a5d59
+size 38186

--- a/packages/moonshine.rn/prebuilt/ios/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/ios/build-metadata.json
@@ -1,5 +1,5 @@
 {
-  "moonshineVersion": "v0.0.51",
+  "moonshineVersion": "v0.0.59",
   "iosFrameworkPath": "prebuilt/ios/Moonshine.xcframework",
   "speakerEmbeddingDataOverride": ""
 }

--- a/packages/moonshine.rn/prebuilt/web/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/web/build-metadata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e2b553cd5f50920f43622626f63c8a3b4044676c15141ea2a55b6397a1aaef0
-size 222
+oid sha256:d8952edf992e40bb9cadc1f08575179f2b79ea03a3fbf89c45a20769e5414d8a
+size 216


### PR DESCRIPTION
## Summary

Brings `@siteed/moonshine.rn` up to date with upstream Moonshine **v0.0.59** and `moonshine-js` main HEAD, mirroring the recent sherpa-onnx.rn upgrade flow.

### Upstream

- `moonshineVersion`: `v0.0.51` → **`v0.0.59`**
- `moonshineJsVersion` / `moonshineJsGitHead`: `0.1.29 / e32209e` → **`0.2.0 / 59c9c83`** (source-tracking; 0.2.0 is unpublished on npm, so `build-moonshine-web.sh` now pulls model assets directly from `download.moonshine.ai` instead of `npm pack`)

### Wrapper changes

- **Patch slimmed** (`patches/OrtAndroidOverrides.patch`, 439 → 95 lines): dropped the ~280-line callback-based intent JNI shim — upstream v0.0.59 ships intent JNI natively (`JNI.moonshineCreateIntentRecognizer`, `moonshineGetClosestIntents`, `IntentMatch`, `IntentRecognizer.java`). Kept ORT path overrides + `Transcriber.java` `AutoCloseable`.
- **Android (`MoonshineDirectJni.kt`, `MoonshineModule.kt`)**: drops reflection-based optional invocation; calls upstream JNI directly. Threshold stored per-handle in a Kotlin map (upstream removed `set/getIntentThreshold`; threshold is per-call to `moonshine_get_closest_intents`). New `getClosestIntent` propagates JNI failures (null → `RuntimeException`) and returns `null` only on empty match arrays — matches upstream `IntentRecognizer.java` contract and the iOS error-code path.
- **iOS (`Moonshine.mm`)**: replaces callback infra (`gLastIntentMatches`, `MoonshineIntentCallback`) with `moonshine_get_closest_intents()` + `moonshine_free_intent_matches()`. Renames `transcriber_option_t` → `moonshine_option_t` throughout (struct renamed upstream).
- **`android/build.gradle`** defaults `siteedMoonshineAndroidUseSource` based on file existence — monorepo dev uses the locally built source AAR, packaged consumers fall through to Maven `ai.moonshine:moonshine-voice:0.0.59` (verified published, HTTP 200). Explicit env/prop override still wins.
- **`build-moonshine-android.sh` post-process** (`decouple_bundled_ort_in_aar`): `patchelf --clear-symbol-version OrtGetApiBase` on `libmoonshine.so` and `libmoonshine-jni.so` so the only versioned ORT import becomes unversioned. Without this, a multi-package APK that also pulls in sherpa-onnx.rn (ORT 1.24.x) breaks live moonshine — both packages drop `lib/arm64-v8a/libonnxruntime.so` into the merged APK, gradle pickFirst silently keeps one, and if sherpa's wins moonshine's `OrtGetApiBase@VERS_1.23.0` lookup fails. With the version stripped the lookup resolves to whichever ORT default-version export is present (host ORT must be ≥ 1.23). Bundled `libonnxruntime.so` is kept in the AAR so standalone consumers still load.
- Constants hoisted (`DEFAULT_INTENT_THRESHOLD` / `kMoonshineDefaultIntentThreshold`) — `0.7f` no longer duplicated across create/set/get/process paths.
- Public TS API (`MoonshineIntentMatch { triggerPhrase, similarity, utterance }`) preserved end-to-end. The `utterance` field now echoes the caller's input (upstream's new `moonshine_intent_match_t` struct dropped its native utterance field; the caller has the source string anyway).
- Refreshed prebuilt artifacts (AAR with stripped ORT symbol + bundled libonnxruntime, xcframework headers, web models).

### Regression coverage

- **New recipe** `apps/playground/scripts/agentic/teams/playground/recipes/moonshine-intent-validation.json` — drives the full sync intent API on-device (prepare → create → process → release) with assertions on `status.{modelDownloaded, hasRecognizer, intentCount, matchText, error}`. Catches future drift in `moonshine_get_closest_intents` ranking + threshold semantics.
- New flow `flows/moonshine-intent-screen-ready.json` + eval ref `moonshine-intent-state` (alias on the existing `getPageState()` bridge).

## Test plan

- [x] `yarn workspace @siteed/moonshine.rn typecheck`
- [x] `yarn workspace @siteed/moonshine.rn test` (13/13 pass)
- [x] `yarn workspace audio-playground typecheck`
- [x] **iOS sim (playground-1)** — `yarn recipe:asr-benchmark` 6/6 PASS; new `moonshine-intent-validation` 10/10 PASS — `matchText: Matched "turn on the lights" from "please turn on the lights"` at 96% (above the 0.6 threshold)
- [x] **iOS sim** live Moonshine streaming smoke (Run Simulated Live, JFK speech) — real chunked transcription
- [x] **Android emulator** (sdk_gphone64_arm64 API 36) — `asr-benchmark` 6/6 PASS; live JFK simulated benchmark transcribes in 11.9s (4 commits / 21 partials) to *"And so my fellow Americans. Ask not. What your country can do for you. Ask what you can do for your country."* (proves the ORT decoupling fix)
- [x] **Web (Chrome)** — `asr-benchmark` route smoke 4/4 (the `>=3` model-count assertion is web-incompatible since web ships 2 models, pre-existing recipe limitation, unrelated). Live moonshine streaming verified directly: full transcript *"And so my fellow Americans ask not what your country can do for you, ask what you can do for your country."*
- [ ] **Android live intent recipe** — recipe correctly detected an `expo-file-system` `createDownloadResumable` timeout when fetching the ~250 MB `embeddinggemma-300m` model on the emulator's NAT'd network; the screen sets `error: "timeout"` before the download finishes. The intent API itself is identical across platforms and was confirmed end-to-end on iOS; a re-run on a physical Android or a faster network should pass without code changes.

## Out of scope

- TTS / Piper / Korean G2P / British dialect upstream additions (wrapper does not expose TTS)
- Speaker-ID experimental flag (already gated in `moonshine-live.tsx`)
- `apps/sherpa-voice` is unaffected
- `expo-file-system` download tuning for the embedding model on Android emulator (separate platform issue, not a regression)