### PR TITLE
chore(moonshine.rn): publish 0.3.1 + AUDIOLAB_NPM_TOKEN wiring

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.npmjs.org/:_authToken=${AUDIOLAB_NPM_TOKEN}
+@siteed:registry=https://registry.npmjs.org

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,4 +13,4 @@ npmPublishRegistry: "https://registry.npmjs.org"
 npmRegistries:
   "https://registry.npmjs.org":
     npmAlwaysAuth: true
-    npmAuthToken: "${NPM_AUTH_TOKEN}"
+    npmAuthToken: "${AUDIOLAB_NPM_TOKEN}"

--- a/packages/moonshine.rn/package.json
+++ b/packages/moonshine.rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siteed/moonshine.rn",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React Native wrapper for Moonshine Voice on-device transcription",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Summary

- **Already published to npm** as `@siteed/moonshine.rn@0.3.1` (native `ai.moonshine:moonshine-voice:0.0.59`).
- `@beta` dist-tag retagged to `0.3.1` so `@beta` and `@latest` no longer drift.
- Adds `AUDIOLAB_NPM_TOKEN` env-var wiring (`.yarnrc.yml` + new `.npmrc`) so future publishes don't re-prompt for auth.

## Why

Native bump to `0.0.59` landed in #380 but no publish followed. `@latest` and `@beta` both still served `0.0.51`, so consumers (incl. EchoBridge) installing `@beta` got an effective downgrade. This bumps the package version, republishes, and aligns the dist-tag.

## Verification

```bash
$ curl -s https://registry.npmjs.org/@siteed/moonshine.rn | jq '."dist-tags"'
{ "latest": "0.3.1", "beta": "0.3.1" }
$ npm view @siteed/moonshine.rn@0.3.1 moonshineVersion
v0.0.59
```

## Test plan

- [x] `yarn release:beta:preflight` passes (typecheck + jest + pack dry-run, 162 entries)
- [x] `yarn npm publish --access public` succeeded
- [x] `npm dist-tag add @siteed/moonshine.rn@0.3.1 beta` succeeded
- [x] Direct registry query confirms both dist-tags point to 0.3.1