### PR TITLE
fix(native): validate Sherpa and Moonshine release prebuilts

### DIFF
--- a/packages/moonshine.rn/BETA_RELEASE_PLAN.md
+++ b/packages/moonshine.rn/BETA_RELEASE_PLAN.md
@@ -39,18 +39,13 @@ native/web artifacts at once:
 The first publishable beta was achieved by trimming repo-only / duplicate
 payloads, but package size should still be watched closely in every release.
 
-At minimum, inspect every beta tarball with:
+At minimum, run the native release validation on every beta tarball:
 
 ```bash
-npm pack --json --dry-run
+yarn validate:native-release
 ```
 
-and record:
-
-- packed size
-- unpacked size
-- largest files
-- whether each large artifact is intentionally included
+This checks that the packaged iOS xcframework contains device and simulator slices, confirms Android published consumers use the Maven fallback instead of a missing local AAR, and verifies `npm pack --json --dry-run` includes/excludes the expected native artifacts. Record packed size, unpacked size, largest files, and whether each large artifact is intentionally included.
 
 ## Beta publish flow
 

--- a/packages/moonshine.rn/package.json
+++ b/packages/moonshine.rn/package.json
@@ -52,8 +52,9 @@
     "build:web:source": "bash ./build-moonshine-web.sh",
     "prepare": "bob build",
     "pack:check": "npm pack --json --dry-run",
-    "release:beta:preflight": "yarn typecheck && yarn test && npm pack --json --dry-run",
-    "validate:offline:contract": "node ./scripts/validate-offline-contract.mjs"
+    "release:beta:preflight": "yarn typecheck && yarn test && yarn validate:native-release",
+    "validate:offline:contract": "node ./scripts/validate-offline-contract.mjs",
+    "validate:native-release": "node ./scripts/validate-native-release.mjs"
   },
   "keywords": [
     "react-native",

--- a/packages/moonshine.rn/scripts/validate-native-release.mjs
+++ b/packages/moonshine.rn/scripts/validate-native-release.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const PACKAGE_ROOT = path.resolve(SCRIPT_DIR, '..')
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8')
+)
+
+if (!packageJson.moonshineVersion) {
+  throw new Error('package.json must define moonshineVersion for native release validation')
+}
+
+function assertFile(relativePath) {
+  const absolutePath = path.join(PACKAGE_ROOT, relativePath)
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Missing required Moonshine native file: ${relativePath}`)
+  }
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+  })
+  if (result.status !== 0) {
+    throw new Error([result.stdout, result.stderr].filter(Boolean).join('\n').trim())
+  }
+  return result.stdout.trim()
+}
+
+function assertPacked(files, relativePath) {
+  if (!files.has(relativePath)) {
+    throw new Error(`npm package would miss required native file: ${relativePath}`)
+  }
+}
+
+function assertNotPacked(files, relativePath) {
+  if (files.has(relativePath)) {
+    throw new Error(`npm package unexpectedly includes repo-local artifact: ${relativePath}`)
+  }
+}
+
+const iosRequired = [
+  'prebuilt/ios/Moonshine.xcframework/Info.plist',
+  'prebuilt/ios/Moonshine.xcframework/ios-arm64/libmoonshine.a',
+  'prebuilt/ios/Moonshine.xcframework/ios-arm64/Headers/moonshine-c-api.h',
+  'prebuilt/ios/Moonshine.xcframework/ios-arm64/Headers/module.modulemap',
+  'prebuilt/ios/Moonshine.xcframework/ios-arm64_x86_64-simulator/libmoonshine.a',
+  'prebuilt/ios/Moonshine.xcframework/ios-arm64_x86_64-simulator/Headers/moonshine-c-api.h',
+  'prebuilt/ios/Moonshine.xcframework/ios-arm64_x86_64-simulator/Headers/module.modulemap',
+]
+
+for (const file of iosRequired) assertFile(file)
+
+const androidGradle = fs.readFileSync(path.join(PACKAGE_ROOT, 'android/build.gradle'), 'utf8')
+const expectedMoonshineVersion = packageJson.moonshineVersion.replace(/^v/, '')
+const expectedMavenCoord = `ai.moonshine:moonshine-voice:${expectedMoonshineVersion}`
+if (!androidGradle.includes(expectedMavenCoord)) {
+  throw new Error(
+    `Moonshine Android Maven fallback mismatch. Expected build.gradle to contain ${expectedMavenCoord}`
+  )
+}
+
+const packOutput = run('npm', ['pack', '--json', '--dry-run'])
+const jsonStart = packOutput.search(/\[\s*\{/)
+if (jsonStart === -1) {
+  throw new Error(`Unable to parse npm pack JSON output:\n${packOutput}`)
+}
+const [packInfo] = JSON.parse(packOutput.slice(jsonStart))
+const packedFiles = new Set(packInfo.files.map((file) => file.path))
+
+for (const file of iosRequired) assertPacked(packedFiles, file)
+assertNotPacked(packedFiles, 'prebuilt/ios/current/libmoonshine_core.a')
+assertNotPacked(packedFiles, 'prebuilt/android/moonshine-voice-source-release.aar')
+
+console.log('Moonshine native release validation passed.')
+console.log(`iOS xcframework slices are packaged for device and simulator.`)
+console.log(`Android uses Maven fallback for published consumers: ${expectedMavenCoord}`)
+console.log('Repo-local generated current/ and source-built AAR artifacts are intentionally excluded from npm.')

--- a/packages/sherpa-onnx.rn/CHANGELOG.md
+++ b/packages/sherpa-onnx.rn/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Release validation**: `install.js` now validates the full native prebuilt contract and fails fast in CI/EAS when the matching GitHub release asset is missing or incomplete. Added `yarn release:preflight` to verify the release asset URL, extract it, check iOS device/simulator static libraries, Android shared libraries, headers/modulemap, and simulate the podspec `prepare_command` symlinks before publishing. The legacy `SKIP_SHERPA_DOWNLOAD=1` path now warns or fails when prebuilts are incomplete; use `SITEED_SHERPA_ONNX_ALLOW_MISSING_PREBUILTS=1` for the explicit local escape hatch.
 - **ASR backends**: Qwen3-ASR + Cohere Transcribe (both new in upstream `v1.13.0`)
   - TS `AsrModelConfig.modelType` extends with `'qwen3'` and `'cohere_transcribe'`; new optional fields `hotwords`, `usePunct`, `qwen3.{maxTotalLen, maxNewTokens, temperature, topP, seed}`, `modelFiles.{convFrontend, tokenizer}`
   - iOS Swift handler + Android Kotlin handler grow matching `case "qwen3"` / `case "cohere_transcribe"` branches

--- a/packages/sherpa-onnx.rn/README.md
+++ b/packages/sherpa-onnx.rn/README.md
@@ -53,7 +53,7 @@ Android integration is handled automatically by the package.
 
 ### Native Prebuilt Libraries
 
-The package `postinstall` downloads prebuilt Android and iOS sherpa-onnx binaries for the `sherpaOnnxVersion` declared in `package.json`. If that download fails, install does not fail the whole app install; build native binaries manually with `./setup.sh && ./build-sherpa-ios.sh && ./build-sherpa-android.sh`, or set `SITEED_SHERPA_ONNX_REBUILD_ANDROID=1` when Android prebuilts must be rebuilt locally.
+The package `postinstall` downloads prebuilt Android and iOS sherpa-onnx binaries for the `sherpaOnnxVersion` declared in `package.json` and validates that iOS device/simulator libraries, Android `.so` files, and headers are complete. In CI/EAS builds, a missing or incomplete GitHub release asset fails immediately with the expected asset URL and missing file list, before CocoaPods can fail later with an opaque native-library error. For local manual builds, run `./setup.sh && ./build-sherpa-ios.sh && ./build-sherpa-android.sh`; use `SITEED_SHERPA_ONNX_ALLOW_MISSING_PREBUILTS=1` only as a developer escape hatch, or set `SITEED_SHERPA_ONNX_REBUILD_ANDROID=1` when Android prebuilts must be rebuilt locally.
 
 ### Web
 

--- a/packages/sherpa-onnx.rn/babel.config.js
+++ b/packages/sherpa-onnx.rn/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:@react-native/babel-preset'],
+};

--- a/packages/sherpa-onnx.rn/install.js
+++ b/packages/sherpa-onnx.rn/install.js
@@ -2,30 +2,36 @@
 
 /**
  * Sherpa-onnx installation script
- * 
- * This script downloads precompiled binaries for the Sherpa-onnx library
- * if they're not already available or built locally.
+ *
+ * Downloads precompiled Sherpa ONNX binaries when they are not already present.
+ * CI/EAS installs fail fast if the matching release asset is missing or
+ * incomplete so CocoaPods does not fail later with opaque missing-library errors.
  */
- 
+
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const fetch = require('node-fetch');
 const AdmZip = require('adm-zip');
 const { existsSync, mkdirSync } = require('fs');
 const { execSync } = require('child_process');
 const ProgressBar = require('progress');
+const {
+  formatValidationReport,
+  releaseAssetUrl,
+  validatePrebuiltTree,
+} = require('./scripts/sherpa-prebuilt-contract');
 
 // Configuration
 const BINARY_VERSION = require('./package.json').sherpaOnnxVersion; // Matches the bundled sherpa-onnx upstream version
 
 // URLs for precompiled binaries
-const REPO_URL = 'https://github.com/deeeed/audiolab';
-const RELEASE_URL = `${REPO_URL}/releases/download/sherpa-onnx-prebuilt-v${BINARY_VERSION}/sherpa-onnx-binaries-${BINARY_VERSION}.zip`;
+const RELEASE_URL = releaseAssetUrl(BINARY_VERSION);
 
 // Directories
 const SCRIPT_DIR = __dirname;
 const PREBUILT_DIR = path.join(SCRIPT_DIR, 'prebuilt');
-const DOWNLOAD_PATH = path.join(SCRIPT_DIR, 'sherpa-onnx-binaries.zip');
+const ALLOW_MISSING_ENV = 'SITEED_SHERPA_ONNX_ALLOW_MISSING_PREBUILTS';
 
 /**
  * Creates a directory if it doesn't exist
@@ -36,84 +42,118 @@ function ensureDirExists(dirPath) {
   }
 }
 
+function isTruthy(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || ''));
+}
+
+function isDisabled(value) {
+  return /^(0|false|no|off)$/i.test(String(value || ''));
+}
+
+function isSetAndEnabled(value) {
+  return value !== undefined && String(value).trim() !== '' && !isDisabled(value);
+}
+
+function isReleaseInstallContext() {
+  const ciEnabled = isSetAndEnabled(process.env.CI);
+  const easDetected = ['EAS_BUILD', 'EAS_BUILD_ID', 'EAS_BUILD_PLATFORM'].some((name) =>
+    isSetAndEnabled(process.env[name])
+  );
+  return ciEnabled || easDetected;
+}
+
+function logExpectedPrebuilts() {
+  console.log(`Sherpa ONNX version: ${BINARY_VERSION}`);
+  console.log(`Expected prebuilt asset: ${RELEASE_URL}`);
+}
+
+function validateExistingPrebuilts() {
+  return validatePrebuiltTree(SCRIPT_DIR);
+}
+
+function failOrWarn(message, resultOrError) {
+  console.error(message);
+
+  if (resultOrError?.missing) {
+    console.error(
+      formatValidationReport(resultOrError, {
+        rootDir: SCRIPT_DIR,
+        assetUrl: RELEASE_URL,
+      })
+    );
+  } else if (resultOrError) {
+    console.error(resultOrError.stack || resultOrError.message || resultOrError);
+  }
+
+  console.error('Manual local fallback:');
+  console.error('  ./setup.sh && ./build-sherpa-ios.sh && ./build-sherpa-android.sh');
+  console.error(`Developer-only escape hatch: ${ALLOW_MISSING_ENV}=1`);
+
+  if (isReleaseInstallContext() && !isTruthy(process.env[ALLOW_MISSING_ENV])) {
+    process.exit(1);
+  }
+
+  console.warn(
+    'Continuing because CI/EAS release mode was not detected. Native builds may fail until prebuilts are built manually.'
+  );
+}
+
 /**
  * Downloads a file from a URL
  */
 async function downloadFile(url, destPath) {
-  try {
-    console.log(`Downloading from ${url}...`);
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      throw new Error(`Failed to download: ${response.statusText}`);
-    }
-    
-    const totalSize = parseInt(response.headers.get('content-length'), 10);
-    let downloadedSize = 0;
-    
-    const bar = new ProgressBar('[:bar] :percent :etas', {
-      complete: '=',
-      incomplete: ' ',
-      width: 50,
-      total: totalSize,
-    });
-    
-    const fileStream = fs.createWriteStream(destPath);
-    
-    return new Promise((resolve, reject) => {
-      response.body.on('data', (chunk) => {
-        downloadedSize += chunk.length;
-        bar.tick(chunk.length);
-      });
-      
-      response.body.pipe(fileStream);
-      
-      fileStream.on('finish', () => {
-        fileStream.close();
-        console.log('Download completed!');
-        resolve();
-      });
-      
-      fileStream.on('error', (err) => {
-        fs.unlinkSync(destPath);
-        reject(err);
-      });
-    });
-  } catch (error) {
-    console.error('Error downloading file:', error);
-    throw error;
+  console.log(`Downloading from ${url}...`);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download prebuilt asset: HTTP ${response.status} ${response.statusText}`);
   }
+
+  const totalSize = parseInt(response.headers.get('content-length') || '0', 10);
+  const bar = totalSize
+    ? new ProgressBar('[:bar] :percent :etas', {
+        complete: '=',
+        incomplete: ' ',
+        width: 50,
+        total: totalSize,
+      })
+    : null;
+
+  const fileStream = fs.createWriteStream(destPath);
+
+  return new Promise((resolve, reject) => {
+    response.body.on('data', (chunk) => {
+      if (bar) bar.tick(chunk.length);
+    });
+
+    response.body.on('error', reject);
+    response.body.pipe(fileStream);
+
+    fileStream.on('finish', () => {
+      fileStream.close();
+      console.log('Download completed!');
+      resolve();
+    });
+
+    fileStream.on('error', (err) => {
+      try {
+        fs.unlinkSync(destPath);
+      } catch (_error) {
+        // Ignore cleanup failures.
+      }
+      reject(err);
+    });
+  });
 }
 
 /**
  * Extracts a zip file
  */
 function extractZip(zipPath, destDir) {
-  try {
-    console.log(`Extracting ${zipPath} to ${destDir}...`);
-    const zip = new AdmZip(zipPath);
-    zip.extractAllTo(destDir, true);
-    console.log('Extraction completed!');
-  } catch (error) {
-    console.error('Error extracting zip:', error);
-    throw error;
-  }
-}
-
-/**
- * Checks if prebuilt libs exist
- */
-function prebuiltLibsExist() {
-  // Check for iOS libraries
-  const iosLibsExist = existsSync(path.join(PREBUILT_DIR, 'ios', 'device', 'libsherpa-onnx-core.a'));
-
-  // Check for Android libraries (x86 not shipped; only arm64-v8a, armeabi-v7a, x86_64)
-  const androidLibsExist =
-    existsSync(path.join(PREBUILT_DIR, 'android', 'arm64-v8a', 'libsherpa-onnx-jni.so')) &&
-    existsSync(path.join(PREBUILT_DIR, 'android', 'armeabi-v7a', 'libsherpa-onnx-jni.so')) &&
-    existsSync(path.join(PREBUILT_DIR, 'android', 'x86_64', 'libsherpa-onnx-jni.so'));
-
-  return iosLibsExist && androidLibsExist;
+  console.log(`Extracting ${zipPath} to ${destDir}...`);
+  const zip = new AdmZip(zipPath);
+  zip.extractAllTo(destDir, true);
+  console.log('Extraction completed!');
 }
 
 function runLocalAndroidRebuild() {
@@ -125,65 +165,75 @@ function runLocalAndroidRebuild() {
   });
 }
 
+// Compatibility shim for older prebuilt archives that used the upstream
+// ONNX Runtime include path instead of the flattened packaged include path.
+function fixModulemapIfNeeded() {
+  const modulemapPath = path.join(PREBUILT_DIR, 'include', 'module.modulemap');
+  if (!existsSync(modulemapPath)) return;
+
+  let content = fs.readFileSync(modulemapPath, 'utf8');
+  if (content.includes('onnxruntime/core/session/onnxruntime_c_api.h')) {
+    content = content.replace(
+      'onnxruntime/core/session/onnxruntime_c_api.h',
+      'onnxruntime/onnxruntime_c_api.h'
+    );
+    fs.writeFileSync(modulemapPath, content, 'utf8');
+    console.log('Fixed module.modulemap onnxruntime header path.');
+  }
+}
+
 /**
  * Main installation function
  */
 async function install() {
   console.log('Starting Sherpa-onnx installation...');
-  
+  logExpectedPrebuilts();
+
   ensureDirExists(PREBUILT_DIR);
-  
-  // Allow explicit opt-out for developers who build locally
-  if (process.env.SKIP_SHERPA_DOWNLOAD === '1') {
-    console.log('SKIP_SHERPA_DOWNLOAD=1, skipping download.');
-    return;
-  }
 
   if (process.env.SITEED_SHERPA_ONNX_REBUILD_ANDROID === '1') {
     runLocalAndroidRebuild();
     return;
   }
 
-  // Check if prebuilt libs already exist
-  if (prebuiltLibsExist()) {
-    console.log('Prebuilt libraries already exist, skipping download.');
+  const existingPrebuilts = validateExistingPrebuilts();
+  if (existingPrebuilts.ok) {
+    console.log('All required prebuilt libraries already exist, skipping download.');
     return;
   }
-  
-  try {
-    // Download prebuilt binaries
-    await downloadFile(RELEASE_URL, DOWNLOAD_PATH);
-    
-    // Extract the zip file
-    extractZip(DOWNLOAD_PATH, SCRIPT_DIR);
 
-    // Fix modulemap if the prebuilt zip has the wrong onnxruntime header path
-    const modulemapPath = path.join(PREBUILT_DIR, 'include', 'module.modulemap');
-    if (existsSync(modulemapPath)) {
-      let content = fs.readFileSync(modulemapPath, 'utf8');
-      if (content.includes('onnxruntime/core/session/onnxruntime_c_api.h')) {
-        content = content.replace(
-          'onnxruntime/core/session/onnxruntime_c_api.h',
-          'onnxruntime/onnxruntime_c_api.h'
-        );
-        fs.writeFileSync(modulemapPath, content, 'utf8');
-        console.log('Fixed module.modulemap onnxruntime header path.');
-      }
+  // Allow explicit local opt-out for developers who build manually.
+  if (process.env.SKIP_SHERPA_DOWNLOAD === '1') {
+    failOrWarn('SKIP_SHERPA_DOWNLOAD=1 but required prebuilts are incomplete.', existingPrebuilts);
+    return;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherpa-onnx-install-'));
+  const downloadPath = path.join(tempDir, `sherpa-onnx-binaries-${BINARY_VERSION}.zip`);
+
+  try {
+    await downloadFile(RELEASE_URL, downloadPath);
+    extractZip(downloadPath, SCRIPT_DIR);
+    fixModulemapIfNeeded();
+
+    const extractedPrebuilts = validateExistingPrebuilts();
+    if (!extractedPrebuilts.ok) {
+      throw new Error(
+        formatValidationReport(extractedPrebuilts, {
+          rootDir: SCRIPT_DIR,
+          assetUrl: RELEASE_URL,
+        })
+      );
     }
 
-    // Clean up the zip file
-    fs.unlinkSync(DOWNLOAD_PATH);
-    
     console.log('Sherpa-onnx installation completed successfully!');
   } catch (error) {
-    console.error(`Installation failed — could not download prebuilt binaries from: ${RELEASE_URL}`, error);
-    console.log('If the release asset does not exist, build manually:');
-    console.log('  ./setup.sh && ./build-sherpa-ios.sh && ./build-sherpa-android.sh');
-    
-    // Don't exit with an error code, as this would cause npm/yarn to fail
-    // but the library might still be usable if the user builds it manually
+    failOrWarn('Installation failed — could not install complete prebuilt binaries.', error);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
-// Run the installation
-install();
+install().catch((error) => {
+  failOrWarn('Installation failed unexpectedly.', error);
+});

--- a/packages/sherpa-onnx.rn/jest.setup.js
+++ b/packages/sherpa-onnx.rn/jest.setup.js
@@ -1,0 +1,8 @@
+global.window = global.window || { _sherpaOnnxCombinedLoaded: false };
+global.navigator = global.navigator || {
+  userAgent: 'Mozilla/5.0 Chrome Test',
+  platform: 'test',
+  vendor: 'Google',
+  hardwareConcurrency: 4,
+};
+global.performance = global.performance || {};

--- a/packages/sherpa-onnx.rn/package.json
+++ b/packages/sherpa-onnx.rn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siteed/sherpa-onnx.rn",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.4",
   "sherpaOnnxVersion": "1.13.0",
   "description": "React Native wrapper for sherpa-onnx TTS and STT capabilities",
   "source": "./src/index.tsx",
@@ -36,6 +36,8 @@
     "app.plugin.js",
     "react-native.config.js",
     "install.js",
+    "scripts/validate-prebuilt-release.js",
+    "scripts/sherpa-prebuilt-contract.js",
     "setup.sh",
     "build-sherpa-ios.sh",
     "build-sherpa-android.sh",
@@ -70,7 +72,9 @@
     "codegen": "yarn dlx @react-native-community/cli codegen",
     "regenerate-codegen": "yarn react-native codegen && mkdir -p ios/generated/SherpaOnnxSpec && cp -R build/generated/ios/SherpaOnnxSpec/* ios/generated/SherpaOnnxSpec/",
     "test:android": "cd ../../apps/sherpa-voice/android && ./gradlew :siteed_sherpa-onnx.rn:connectedAndroidTest",
-    "test:ios:info": "./ios-testing-info.sh"
+    "test:ios:info": "./ios-testing-info.sh",
+    "release:preflight": "node ./scripts/validate-prebuilt-release.js",
+    "prepublishOnly": "yarn release:preflight && yarn typecheck && yarn test && npm pack --json --dry-run"
   },
   "keywords": [
     "react-native",
@@ -106,9 +110,11 @@
   "devDependencies": {
     "@babel/core": "^7.26.10",
     "@babel/preset-env": "^7.26.9",
+    "@babel/preset-typescript": "^7.27.0",
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.5.0",
     "@react-native-community/cli": "^18.0.0",
+    "@react-native/babel-preset": "0.83.6",
     "@react-native/eslint-config": "^0.73.1",
     "@siteed/publisher": "^0.6.0",
     "@types/adm-zip": "^0",
@@ -143,6 +149,9 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
+    ],
+    "setupFiles": [
+      "<rootDir>/jest.setup.js"
     ]
   },
   "commitlint": {

--- a/packages/sherpa-onnx.rn/scripts/sherpa-prebuilt-contract.js
+++ b/packages/sherpa-onnx.rn/scripts/sherpa-prebuilt-contract.js
@@ -1,0 +1,125 @@
+const path = require('path');
+const fs = require('fs');
+
+const REPO_URL = 'https://github.com/deeeed/audiolab';
+
+const IOS_LIBRARIES = [
+  'libkissfft-float.a',
+  'libkaldi-native-fbank-core.a',
+  'libkaldi-decoder-core.a',
+  'libsherpa-onnx-fst.a',
+  'libsherpa-onnx-fstfar.a',
+  'libsherpa-onnx-kaldifst-core.a',
+  'libsherpa-onnx-core.a',
+  'libsherpa-onnx-c-api.a',
+  'libpiper_phonemize.a',
+  'libespeak-ng.a',
+  'libssentencepiece_core.a',
+  'libucd.a',
+  'libonnxruntime.a',
+];
+
+const IOS_PLATFORMS = ['device', 'simulator'];
+const ANDROID_ABIS = ['arm64-v8a', 'armeabi-v7a', 'x86_64'];
+const ANDROID_LIBRARIES = ['libsherpa-onnx-jni.so', 'libonnxruntime.so'];
+const REQUIRED_HEADERS = [
+  'prebuilt/include/module.modulemap',
+  'prebuilt/include/sherpa-onnx/c-api/c-api.h',
+  'prebuilt/include/onnxruntime/onnxruntime_c_api.h',
+];
+
+function releaseAssetUrl(version) {
+  return `${REPO_URL}/releases/download/sherpa-onnx-prebuilt-v${version}/sherpa-onnx-binaries-${version}.zip`;
+}
+
+function getRequiredFiles({ includeIosCurrent = false } = {}) {
+  const files = [...REQUIRED_HEADERS];
+
+  for (const platform of IOS_PLATFORMS) {
+    for (const library of IOS_LIBRARIES) {
+      files.push(path.posix.join('prebuilt/ios', platform, library));
+    }
+  }
+
+  if (includeIosCurrent) {
+    for (const library of IOS_LIBRARIES) {
+      files.push(path.posix.join('prebuilt/ios/current', library));
+    }
+  }
+
+  for (const abi of ANDROID_ABIS) {
+    for (const library of ANDROID_LIBRARIES) {
+      files.push(path.posix.join('prebuilt/android', abi, library));
+    }
+  }
+
+  return files;
+}
+
+function validatePrebuiltTree(rootDir, options = {}) {
+  const missing = getRequiredFiles(options).filter(
+    (relativePath) => !fs.existsSync(path.join(rootDir, relativePath))
+  );
+
+  return {
+    ok: missing.length === 0,
+    missing,
+  };
+}
+
+function formatValidationReport(result, { rootDir, assetUrl } = {}) {
+  const lines = [];
+  lines.push('Sherpa ONNX prebuilt validation failed.');
+  if (assetUrl) lines.push(`Expected release asset: ${assetUrl}`);
+  if (rootDir) lines.push(`Validated root: ${rootDir}`);
+  if (result.missing.length > 0) {
+    lines.push('Missing required files:');
+    for (const file of result.missing) {
+      lines.push(`  - ${file}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function validateOrThrow(rootDir, options = {}) {
+  const result = validatePrebuiltTree(rootDir, options);
+  if (!result.ok) {
+    throw new Error(formatValidationReport(result, options));
+  }
+  return result;
+}
+
+function createCurrentIosSymlinks(rootDir) {
+  const currentDir = path.join(rootDir, 'prebuilt', 'ios', 'current');
+  fs.mkdirSync(currentDir, { recursive: true });
+
+  for (const library of IOS_LIBRARIES) {
+    const source = path.join(rootDir, 'prebuilt', 'ios', 'device', library);
+    if (!fs.existsSync(source)) {
+      throw new Error(`Cannot link missing iOS device library: prebuilt/ios/device/${library}`);
+    }
+
+    const target = path.join(currentDir, library);
+    try {
+      fs.unlinkSync(target);
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    fs.symlinkSync(path.join('..', 'device', library), target);
+  }
+}
+
+module.exports = {
+  ANDROID_ABIS,
+  ANDROID_LIBRARIES,
+  IOS_LIBRARIES,
+  IOS_PLATFORMS,
+  REQUIRED_HEADERS,
+  REPO_URL,
+  createCurrentIosSymlinks,
+  formatValidationReport,
+  getRequiredFiles,
+  releaseAssetUrl,
+  validateOrThrow,
+  validatePrebuiltTree,
+};

--- a/packages/sherpa-onnx.rn/scripts/validate-prebuilt-release.js
+++ b/packages/sherpa-onnx.rn/scripts/validate-prebuilt-release.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const fetch = require('node-fetch');
+const AdmZip = require('adm-zip');
+const {
+  createCurrentIosSymlinks,
+  releaseAssetUrl,
+  validateOrThrow,
+} = require('./sherpa-prebuilt-contract');
+
+const packageRoot = path.resolve(__dirname, '..');
+const packageJson = require(path.join(packageRoot, 'package.json'));
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  const options = {
+    version: packageJson.sherpaOnnxVersion,
+    keepTemp: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--version') {
+      options.version = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--url') {
+      options.url = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--keep-temp') {
+      options.keepTemp = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function assertAssetExists(url) {
+  const response = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+  if (!response.ok) {
+    throw new Error(`Release asset HEAD check failed: HTTP ${response.status} ${response.statusText}\n${url}`);
+  }
+  console.log(`Release asset exists: HTTP ${response.status}`);
+}
+
+async function download(url, destination) {
+  console.log(`Downloading release asset: ${url}`);
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok) {
+    throw new Error(`Release asset download failed: HTTP ${response.status} ${response.statusText}\n${url}`);
+  }
+
+  await new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(destination);
+    response.body.pipe(file);
+    response.body.on('error', reject);
+    file.on('finish', resolve);
+    file.on('error', reject);
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const url = options.url || releaseAssetUrl(options.version);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherpa-prebuilt-preflight-'));
+  const archivePath = path.join(tempDir, `sherpa-onnx-binaries-${options.version}.zip`);
+
+  console.log('Sherpa ONNX prebuilt release preflight');
+  console.log(`Package version: ${packageJson.version}`);
+  console.log(`sherpaOnnxVersion: ${options.version}`);
+  console.log(`Expected asset URL: ${url}`);
+  console.log(`Temp dir: ${tempDir}`);
+
+  try {
+    await assertAssetExists(url);
+    await download(url, archivePath);
+
+    console.log('Extracting release asset...');
+    const zip = new AdmZip(archivePath);
+    zip.extractAllTo(tempDir, true);
+
+    validateOrThrow(tempDir, { rootDir: tempDir, assetUrl: url });
+    console.log('Archive contains required iOS device/simulator libraries, Android shared libraries, and headers.');
+
+    createCurrentIosSymlinks(tempDir);
+    validateOrThrow(tempDir, { includeIosCurrent: true, rootDir: tempDir, assetUrl: url });
+    console.log('Podspec prepare_command simulation succeeded: prebuilt/ios/current links all required device libraries.');
+    console.log('Preflight passed.');
+  } finally {
+    if (options.keepTemp) {
+      console.log(`Keeping temp dir: ${tempDir}`);
+    } else {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/packages/sherpa-onnx.rn/sherpa-onnx-rn.podspec
+++ b/packages/sherpa-onnx.rn/sherpa-onnx-rn.podspec
@@ -79,36 +79,50 @@ Pod::Spec.new do |s|
 
   # Set up initial symlinks to device libraries - this runs during pod installation
   s.prepare_command = <<-CMD
+    set -e
+    echo "Validating Sherpa ONNX iOS prebuilts"
+
+    for header in prebuilt/include/module.modulemap prebuilt/include/sherpa-onnx/c-api/c-api.h prebuilt/include/onnxruntime/onnxruntime_c_api.h; do
+      if [ ! -f "$header" ]; then
+        echo "ERROR: Required Sherpa ONNX header/modulemap missing: $header" >&2
+        echo "Expected package postinstall to download: https://github.com/deeeed/audiolab/releases/download/sherpa-onnx-prebuilt-v#{package["sherpaOnnxVersion"]}/sherpa-onnx-binaries-#{package["sherpaOnnxVersion"]}.zip" >&2
+        exit 1
+      fi
+    done
+
     echo "Creating prebuilt/ios/current directory"
     mkdir -p prebuilt/ios/current
-    
+
     # Only setup the symlinks if they don't exist
     if [ ! -f prebuilt/ios/current/libonnxruntime.a ]; then
       echo "Setting up initial symlinks to device libraries"
-      
-      # First check if device libs exist
+
       if [ -d prebuilt/ios/device ]; then
+        missing_libraries=0
         for lib in #{sherpa_libraries.join(" ")}; do
           if [ -f "prebuilt/ios/device/$lib" ]; then
             echo "Linking $lib from device folder"
             ln -sf "../device/$lib" "prebuilt/ios/current/$lib"
           else
-            echo "Warning: Device library $lib not found"
+            echo "ERROR: Device library $lib not found at prebuilt/ios/device/$lib" >&2
+            missing_libraries=1
           fi
         done
+        if [ "$missing_libraries" != "0" ]; then
+          echo "ERROR: Sherpa ONNX iOS device prebuilts are incomplete." >&2
+          echo "Expected package postinstall to download: https://github.com/deeeed/audiolab/releases/download/sherpa-onnx-prebuilt-v#{package["sherpaOnnxVersion"]}/sherpa-onnx-binaries-#{package["sherpaOnnxVersion"]}.zip" >&2
+          exit 1
+        fi
       else
-        echo ""
-        echo "ERROR: iOS libraries not found!"
-        echo ""
-        echo "The sherpa-onnx iOS libraries need to be built before using this package."
-        echo ""
-        echo "To fix this error, run the following commands:"
-        echo "  cd $(pwd)"
-        echo "  ./build-sherpa-ios.sh"
-        echo ""
-        echo "This will download and build the required iOS libraries."
-        echo "The build process may take 5-10 minutes."
-        echo ""
+        echo "" >&2
+        echo "ERROR: iOS libraries not found!" >&2
+        echo "" >&2
+        echo "Expected package postinstall to download: https://github.com/deeeed/audiolab/releases/download/sherpa-onnx-prebuilt-v#{package["sherpaOnnxVersion"]}/sherpa-onnx-binaries-#{package["sherpaOnnxVersion"]}.zip" >&2
+        echo "" >&2
+        echo "For local development, build manually:" >&2
+        echo "  cd $(pwd)" >&2
+        echo "  ./build-sherpa-ios.sh" >&2
+        echo "" >&2
         exit 1
       fi
     else
@@ -124,66 +138,47 @@ Pod::Spec.new do |s|
       CURRENT_DIR="${PODS_TARGET_SRCROOT}/prebuilt/ios/current"
       DEVICE_DIR="${PODS_TARGET_SRCROOT}/prebuilt/ios/device"
       SIMULATOR_DIR="${PODS_TARGET_SRCROOT}/prebuilt/ios/simulator"
-      
-      # Make sure the current directory exists
+
+      link_required_libraries() {
+        local source_dir="$1"
+        local relative_prefix="$2"
+        local label="$3"
+        local missing_libraries=0
+
+        if [ ! -d "$source_dir" ]; then
+          echo "" >&2
+          echo "ERROR: iOS $label libraries not found!" >&2
+          echo "Missing directory: $source_dir" >&2
+          echo "Run package postinstall again or build locally with ./build-sherpa-ios.sh" >&2
+          echo "" >&2
+          exit 1
+        fi
+
+        for lib in ' + sherpa_libraries.join(" ") + '; do
+          if [ -f "$source_dir/$lib" ]; then
+            echo "Linking $lib from $label"
+            ln -sf "$relative_prefix/$lib" "$CURRENT_DIR/$lib"
+          else
+            echo "ERROR: $label library $lib not found at $source_dir/$lib" >&2
+            missing_libraries=1
+          fi
+        done
+
+        if [ "$missing_libraries" != "0" ]; then
+          echo "ERROR: Sherpa ONNX iOS $label prebuilts are incomplete." >&2
+          exit 1
+        fi
+      }
+
       mkdir -p "$CURRENT_DIR"
-      
-      # Remove existing symlinks
       rm -f "$CURRENT_DIR"/*.a
-      
-      # Check if building for simulator
+
       if [[ "$PLATFORM_NAME" == *simulator* ]]; then
         echo "Building for simulator, linking simulator libraries"
-        if [ -d "$SIMULATOR_DIR" ]; then
-          for lib in ' + sherpa_libraries.join(" ") + '; do
-            if [ -f "$SIMULATOR_DIR/$lib" ]; then
-              echo "Linking $lib from simulator"
-              ln -sf "../simulator/$lib" "$CURRENT_DIR/$lib"
-            else
-              echo "Warning: Simulator library $lib not found"
-            fi
-          done
-        else
-          echo ""
-          echo "ERROR: iOS Simulator libraries not found!"
-          echo ""
-          echo "Building for iOS Simulator but libraries are missing at:"
-          echo "  $SIMULATOR_DIR"
-          echo ""
-          echo "To fix this error:"
-          echo "  1. cd ${PODS_TARGET_SRCROOT}"
-          echo "  2. ./build-sherpa-ios.sh"
-          echo ""
-          echo "This will build both device and simulator libraries."
-          echo ""
-          exit 1
-        fi
+        link_required_libraries "$SIMULATOR_DIR" "../simulator" "Simulator"
       else
         echo "Building for device, linking device libraries"
-        if [ -d "$DEVICE_DIR" ]; then
-          for lib in ' + sherpa_libraries.join(" ") + '; do
-            if [ -f "$DEVICE_DIR/$lib" ]; then
-              echo "Linking $lib from device"
-              ln -sf "../device/$lib" "$CURRENT_DIR/$lib"
-            else
-              echo "Warning: Device library $lib not found"
-            fi
-          done
-        else
-          echo ""
-          echo "ERROR: iOS Device libraries not found!"
-          echo ""
-          echo "Building for iOS Device but libraries are missing at:"
-          echo "  $DEVICE_DIR"
-          echo ""
-          echo "To fix this error:"
-          echo "  1. cd ${PODS_TARGET_SRCROOT}"
-          echo "  2. ./build-sherpa-ios.sh"
-          echo ""
-          echo "This will build both device and simulator libraries."
-          echo ""
-          exit 1
-        fi
+        link_required_libraries "$DEVICE_DIR" "../device" "Device"
       fi
     ',
     :execution_position => :before_compile,

--- a/packages/sherpa-onnx.rn/src/__tests__/sherpaPrebuiltContract.test.js
+++ b/packages/sherpa-onnx.rn/src/__tests__/sherpaPrebuiltContract.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  ANDROID_ABIS,
+  ANDROID_LIBRARIES,
+  IOS_LIBRARIES,
+  IOS_PLATFORMS,
+  createCurrentIosSymlinks,
+  releaseAssetUrl,
+  validatePrebuiltTree,
+} = require('../../scripts/sherpa-prebuilt-contract');
+
+function writeFile(rootDir, relativePath) {
+  const absolutePath = path.join(rootDir, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, 'test');
+}
+
+function createCompletePrebuiltTree(rootDir) {
+  writeFile(rootDir, 'prebuilt/include/module.modulemap');
+  writeFile(rootDir, 'prebuilt/include/sherpa-onnx/c-api/c-api.h');
+  writeFile(rootDir, 'prebuilt/include/onnxruntime/onnxruntime_c_api.h');
+
+  for (const platform of IOS_PLATFORMS) {
+    for (const library of IOS_LIBRARIES) {
+      writeFile(rootDir, path.join('prebuilt/ios', platform, library));
+    }
+  }
+
+  for (const abi of ANDROID_ABIS) {
+    for (const library of ANDROID_LIBRARIES) {
+      writeFile(rootDir, path.join('prebuilt/android', abi, library));
+    }
+  }
+}
+
+describe('sherpa prebuilt contract', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sherpa-contract-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('builds the expected release asset URL', () => {
+    expect(releaseAssetUrl('1.13.0')).toBe(
+      'https://github.com/deeeed/audiolab/releases/download/sherpa-onnx-prebuilt-v1.13.0/sherpa-onnx-binaries-1.13.0.zip'
+    );
+  });
+
+  it('reports missing native prebuilts', () => {
+    const result = validatePrebuiltTree(tempDir);
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toContain('prebuilt/ios/device/libsherpa-onnx-core.a');
+    expect(result.missing).toContain('prebuilt/ios/simulator/libsherpa-onnx-core.a');
+    expect(result.missing).toContain('prebuilt/android/arm64-v8a/libsherpa-onnx-jni.so');
+    expect(result.missing).toContain('prebuilt/include/module.modulemap');
+  });
+
+  it('validates a complete prebuilt tree and creates podspec current symlinks', () => {
+    createCompletePrebuiltTree(tempDir);
+
+    expect(validatePrebuiltTree(tempDir).ok).toBe(true);
+
+    createCurrentIosSymlinks(tempDir);
+
+    const result = validatePrebuiltTree(tempDir, { includeIosCurrent: true });
+    expect(result.ok).toBe(true);
+    expect(
+      fs.readlinkSync(path.join(tempDir, 'prebuilt/ios/current/libonnxruntime.a'))
+    ).toBe('../device/libonnxruntime.a');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,7 +1850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.27.1":
+"@babel/plugin-transform-typescript@npm:^7.27.1, @babel/plugin-transform-typescript@npm:^7.28.5":
   version: 7.28.6
   resolution: "@babel/plugin-transform-typescript@npm:7.28.6"
   dependencies:
@@ -2072,6 +2072,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/3b7b44bff0ed5dec49cb056e9a3a3dbf55e51dc5f85baa98336785b2d99670a12b7f9741b8c74ae061f2942d13a9dc7ac4ae0bcaecaff04f9db934c6ab6d9f30
+  languageName: node
+  linkType: hard
+
+"@babel/preset-typescript@npm:^7.27.0":
+  version: 7.28.5
+  resolution: "@babel/preset-typescript@npm:7.28.5"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-validator-option": "npm:^7.27.1"
+    "@babel/plugin-syntax-jsx": "npm:^7.27.1"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.27.1"
+    "@babel/plugin-transform-typescript": "npm:^7.28.5"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/72c03e01c34906041b1813542761a283c52da1751e7ddf63191bc5fb2a0354eca30a00537c5a92951688bec3975bdc0e50ef4516b5e94cfd6d4cf947f2125bdc
   languageName: node
   linkType: hard
 
@@ -8810,10 +8825,12 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.26.10"
     "@babel/preset-env": "npm:^7.26.9"
+    "@babel/preset-typescript": "npm:^7.27.0"
     "@commitlint/config-conventional": "npm:^17.0.2"
     "@evilmartians/lefthook": "npm:^1.5.0"
     "@expo/config-plugins": "npm:~54.0.0"
     "@react-native-community/cli": "npm:^18.0.0"
+    "@react-native/babel-preset": "npm:0.83.6"
     "@react-native/eslint-config": "npm:^0.73.1"
     "@siteed/publisher": "npm:^0.6.0"
     "@types/adm-zip": "npm:^0"
@@ -36232,11 +36249,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^4.6.4 || ^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.4.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.2#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 
@@ -36262,11 +36279,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A~5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/98470634034ec37fd9ea61cc82dcf9a27950d0117a4646146b767d085a2ec14b137aae9642a83d1c62732d7fdcdac19bb6288b0bb468a72f7a06ae4e1d2c72c9
+  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- harden `@siteed/sherpa-onnx.rn` postinstall so CI/EAS fails fast when the matching native prebuilt asset is missing or incomplete
- add a Sherpa release preflight that checks the GitHub release asset, extracts it, validates iOS device/simulator static libs, Android shared libs, headers/modulemap, and simulates the podspec prepare symlinks
- add Moonshine native release validation to prevent the same class of missing native artifact issue
- keep the already-published `@siteed/sherpa-onnx.rn@1.2.0-beta.3` available for EchoBridge validation, while source now prepares the next beta (`1.2.0-beta.4`) with review hardening

## Root cause

EchoBridge iOS EAS production builds failed during `pod install` because `@siteed/sherpa-onnx.rn@1.1.3-beta.1` pointed at a missing prebuilt asset for `sherpaOnnxVersion=1.12.34`. The install script continued after the failed download, so the failure surfaced later from CocoaPods as missing iOS libraries.

## Review follow-up addressed

- made Moonshine `npm pack --json` parsing resilient to whitespace/leading tool output
- changed CI/EAS detection to treat set-and-enabled `CI`/`EAS_BUILD*` values as release context
- restored the React Native Jest preset and added `@react-native/babel-preset` so RN test transforms/mocks remain active
- moved Sherpa install downloads to a per-run temp directory to avoid fixed-path collisions
- added explicit `--version`/`--url` argument validation for Sherpa preflight
- added an explicit `moonshineVersion` guard in Moonshine native validation
- documented the `SKIP_SHERPA_DOWNLOAD` behavior change in the changelog
- added unit coverage for the pure Sherpa prebuilt contract helper

## Validation

- `git diff --check`
- `node -c packages/sherpa-onnx.rn/install.js`
- `node -c packages/sherpa-onnx.rn/scripts/sherpa-prebuilt-contract.js`
- `node -c packages/sherpa-onnx.rn/scripts/validate-prebuilt-release.js`
- `node --check packages/moonshine.rn/scripts/validate-native-release.mjs`
- `cd packages/sherpa-onnx.rn && yarn release:preflight`
- `cd packages/sherpa-onnx.rn && yarn typecheck && yarn test --runInBand`
- `cd packages/moonshine.rn && yarn release:beta:preflight`
- `cd packages/sherpa-onnx.rn && npm pack --json --dry-run`
- `npm view @siteed/sherpa-onnx.rn@1.2.0-beta.3 version dist-tags --json`

## Notes

`@siteed/sherpa-onnx.rn@1.2.0-beta.3` has already been published under the `beta` dist-tag for EchoBridge validation. This PR now includes additional review hardening and bumps source to `1.2.0-beta.4`; publish that beta after review/merge if you want EchoBridge to validate the review-hardening delta too.
