### PR TITLE
fix(moonshine-rn): align long stream audio retention

### DIFF
--- a/packages/audio-studio/docs/UPSTREAM_ASR_PATCHING.md
+++ b/packages/audio-studio/docs/UPSTREAM_ASR_PATCHING.md
@@ -1,0 +1,122 @@
+# Upstream ASR patching workflow
+
+This repo carries React Native integration fixes for long compressed-audio
+transcription. Keep upstream clones beside `audiolab` so fixes can be developed
+against the latest upstream branches before they are vendored or patched here.
+
+## Local upstream checkouts
+
+Expected local layout:
+
+```text
+/Volumes/c910ssd/dev/audiolab       # React Native integration + validation app
+/Volumes/c910ssd/dev/moonshine      # upstream moonshine checkout
+/Volumes/c910ssd/dev/sherpa-onnx    # upstream sherpa-onnx checkout/fork
+```
+
+Recommended remotes:
+
+```bash
+# Moonshine
+cd /Volumes/c910ssd/dev/moonshine
+git remote -v
+# origin   <your fork, if available>
+# upstream https://github.com/moonshine-ai/moonshine.git
+
+git fetch --all --prune --tags
+git checkout -B rn-long-streaming-memory-fix upstream/main
+
+# Sherpa ONNX
+cd /Volumes/c910ssd/dev/sherpa-onnx
+git remote -v
+# origin   <your fork>
+# upstream https://github.com/k2-fsa/sherpa-onnx.git
+
+git fetch --all --prune --tags
+git checkout -B rn-long-audio-asr-validation upstream/master
+```
+
+Use `GIT_LFS_SKIP_SMUDGE=1` when cloning if model artifacts or test binaries are
+not needed for the patch. Fetch LFS objects only for the specific upstream test
+that requires them.
+
+## Moonshine PR scope
+
+The current React Native validation found a long-streaming memory issue in
+Moonshine's VAD path. The fix keeps completed VAD audio only when
+`return_audio_data=true`; React Native defaults that option off unless
+`includeAudioData` is explicitly requested. The audiolab vendored patch is:
+
+```text
+packages/moonshine.rn/patches/LongStreamingMemory.patch
+```
+
+The latest-upstream PR patch prepared from the current upstream `main` branch is:
+
+```text
+.agent/upstream-pr/moonshine-main-long-streaming-memory.patch
+.agent/upstream-pr/moonshine-main-pr-draft.md
+```
+
+Opened upstream draft PR:
+
+```text
+https://github.com/moonshine-ai/moonshine/pull/175
+```
+
+Before opening the PR, verify it against the upstream checkout:
+
+```bash
+cd /Volumes/c910ssd/dev/moonshine
+git fetch upstream main
+git checkout -B rn-long-streaming-memory-fix upstream/main
+git apply --check /Volumes/c910ssd/dev/audiolab/.agent/upstream-pr/moonshine-main-long-streaming-memory.patch
+git apply /Volumes/c910ssd/dev/audiolab/.agent/upstream-pr/moonshine-main-long-streaming-memory.patch
+```
+
+The PR explanation should link back to the React Native validation evidence in
+`audiolab`, especially the Android and iOS 100-minute Opus runs, to show the
+change is driven by a reproducible integration and not an untested drive-by
+patch.
+
+## Sherpa ONNX PR scope
+
+Sherpa is used as the configurable benchmark path for higher-quality ASR models
+such as Qwen3. Current audiolab validation intentionally keeps the model config
+externalized:
+
+```text
+packages/audio-studio/scripts/qwen3-asr-playground-config.json
+packages/audio-studio/scripts/validate-stream-long.mjs
+```
+
+The likely upstream Sherpa/RN improvements to prepare as separate PRs are:
+
+1. Add a typed-array/JSI-friendly RN `acceptWaveform` path so long streaming
+   benchmarks do not require converting every Float32 chunk to a JS `number[]`.
+2. Document or expose memory-safe segmented offline recognition patterns for
+   very long files, including explicit release/reinitialize behavior between
+   segments for large models.
+3. Keep model selection configurable; do not hardcode Zipformer when the
+   validation target is a stronger model such as Qwen3.
+
+Prepare Sherpa patches from `/Volumes/c910ssd/dev/sherpa-onnx` on a branch based
+on `upstream/master`, then mirror the validation command and evidence path in the
+PR body.
+
+## Validation evidence to attach
+
+Long-audio evidence is stored under:
+
+```text
+/Volumes/c910ssd/dev/audiolab/.agent/validation-logs/
+```
+
+Minimum evidence before filing upstream PRs:
+
+- Android full Moonshine 100-minute Opus success log: `.agent/validation-logs/validate-stream-long-android-moonshine-full-vadfix-20260514T062106Z.jsonl`.
+- iOS full Moonshine 100-minute Opus success log: `.agent/validation-logs/validate-stream-long-ios-moonshine-full-vadfix-20260514T085020Z.jsonl`.
+- `git diff --check` and relevant workspace typechecks.
+- Patch application check against the latest upstream branch.
+- If touching Sherpa, Qwen3 segmented benchmark logs with the exact config file
+  used.

--- a/packages/moonshine.rn/CHANGELOG.md
+++ b/packages/moonshine.rn/CHANGELOG.md
@@ -7,12 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.3] - 2026-05-08
+### Breaking / Migration
+
+- Native per-line audio retention now follows the public `includeAudioData`
+  option. If you depended on implicit upstream per-line PCM data, pass
+  `includeAudioData: true`; otherwise long streams default to text/progress
+  retention only.
+
 ### Changed
+
+- Accept `Float32Array` as a Moonshine PCM input type at the JS API boundary. Legacy React Native native-module calls still materialize arrays internally, so long-stream callers should keep chunks bounded until a JSI/ArrayBuffer path is available.
+- Align native `return_audio_data` retention with the public `includeAudioData`
+  option on Android and iOS. RN now defaults native per-line PCM retention off,
+  preventing long streaming sessions from keeping every VAD segment's samples
+  when callers only need transcript text/progress.
+- Avoid copying historical VAD segment PCM on every streaming update and release
+  completed VAD segment samples after transcription when `return_audio_data=false`,
+  so very long Moonshine streams retain only active-segment audio plus text
+  transcript state unless callers explicitly request per-line audio.
+
+## [0.3.3] - 2026-05-08
+
+### Changed
+
 - Promote the lightweight public install flow from beta to stable. Public npm installs stay thin while iOS resolves the xcframework from a checksum-pinned GitHub release asset and Android resolves native binaries through Maven by default.
 
 ## [0.3.3-beta.7] - 2026-05-08
+
 ### Added
+
 - Add CocoaPods-driven iOS artifact preparation for public installs without shipping the xcframework in npm.
 - Add Android Maven fallback for public installs while preserving source-AAR/custom-AAR overrides for development.
 - Add release validators for the packed npm tarball contract, iOS release asset integrity, and optional Android AAR symbol inspection.
@@ -20,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add consumer README guidance for cross-platform setup, customization hooks, and web ORT/model asset configuration.
 
 ### Changed
+
 - Keep the public npm tarball lightweight by excluding heavyweight iOS xcframework and Android AAR binaries.
 - Cache downloaded iOS artifacts outside `node_modules` using version/checksum keys, with URL-hash fallback for unpinned artifacts.
 - Verify pinned iOS artifact checksums both during consumer install and during the publish gate.
@@ -28,19 +52,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `sha256sum` as a fallback when `shasum` is unavailable.
 
 ## [0.3.2] - 2026-05-06
+
 ### Added
+
 - Native release validation via `yarn validate:native-release`, covering the packed npm tarball, required iOS xcframework device/simulator slices, Android Maven fallback expectations, headers, and package-size reporting.
 - `yarn release:beta:preflight` now runs typecheck, tests, and native release validation so incomplete native artifacts are caught before publishing.
 
 ### Changed
+
 - Updated the beta release plan to require native preflight validation and to document packed-size evidence for future releases.
 
 ## [0.3.1] - 2026-05-06
+
 ### Changed
+
 - Published the stable `0.3.1` package and documented `AUDIOLAB_NPM_TOKEN`-based npm publishing credentials for the monorepo release flow.
 
 ## [0.3.0] - 2026-04-09
+
 ### Added
+
 - Moonshine RN package with iOS, Android, and web transcription support, source-built native tooling, offline progress events, and word timestamp parity fixes.
 - Beta release plan and external consumer validation checklist.
 

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
@@ -720,6 +720,12 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
 
   private fun buildTranscriberOptions(config: ReadableMap): Array<TranscriberOption> {
     val options = mutableListOf<TranscriberOption>()
+    val includeAudioData = readIncludeAudioData(config)
+    // `includeAudioData` is the public RN switch for returning per-line PCM.
+    // The upstream native core defaults `return_audio_data` to true, which makes
+    // long streaming transcripts retain each VAD segment's FloatArray even when
+    // RN suppresses `line.audioData` in emitted maps. Keep the native retention
+    // policy aligned with the JS contract and default it off for long sessions.
     if (config.hasKey("options") && !config.isNull("options")) {
       val nativeOptions = config.getMap("options")
       nativeOptions?.let {
@@ -850,6 +856,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
         }
       }
     }
+    options.add(TranscriberOption("return_audio_data", includeAudioData.toString()))
     return options.toTypedArray()
   }
 
@@ -885,11 +892,6 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
         defaultTranscriberId?.let { releaseTranscriberInternal(it) }
       }
 
-      val includeAudioData =
-        config.hasKey("includeAudioData") &&
-        !config.isNull("includeAudioData") &&
-        config.getBoolean("includeAudioData")
-
       val transcriberOptions = buildTranscriberOptions(config)
       val modelArch = resolveModelArch(config)
       val handle = loader(transcriberOptions, modelArch)
@@ -902,7 +904,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
       val state = TranscriberState(
         handle = handle,
         defaultStreamHandle = loadedDefaultStreamHandle,
-        includeAudioDataInLines = includeAudioData
+        includeAudioDataInLines = readIncludeAudioData(config)
       )
       registerStreamState(state, loadedDefaultStreamHandle)
       transcriberStates[transcriberId] = state
@@ -916,6 +918,12 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
     } catch (error: Throwable) {
       promise.resolve(errorResult(error.message ?: "Moonshine load failed"))
     }
+  }
+
+  private fun readIncludeAudioData(config: ReadableMap): Boolean {
+    return config.hasKey("includeAudioData") &&
+      !config.isNull("includeAudioData") &&
+      config.getBoolean("includeAudioData")
   }
 
   private fun emitEvent(

--- a/packages/moonshine.rn/apply-upstream-patches.sh
+++ b/packages/moonshine.rn/apply-upstream-patches.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UPSTREAM_DIR="$SCRIPT_DIR/third_party/moonshine"
 PATCHES=(
   "patches/OrtAndroidOverrides.patch"
+  "patches/LongStreamingMemory.patch"
 )
 
 if [ ! -d "$UPSTREAM_DIR/.git" ]; then
@@ -23,9 +24,13 @@ for relative_patch_path in "${PATCHES[@]}"; do
     exit 1
   fi
 
-  if git apply --check "$patch_path" >/dev/null 2>&1; then
+  if git apply --3way --check "$patch_path" >/dev/null 2>&1; then
     echo "Applying upstream patch: $relative_patch_path"
-    git apply "$patch_path"
+    git apply --3way "$patch_path"
+    if find . -name '*.rej' -print -quit | grep -q .; then
+      echo "Error: patch left reject files after 3-way apply: $relative_patch_path" >&2
+      exit 1
+    fi
     continue
   fi
 

--- a/packages/moonshine.rn/build-moonshine-android.sh
+++ b/packages/moonshine.rn/build-moonshine-android.sh
@@ -71,11 +71,11 @@ decouple_bundled_ort_in_aar() {
   fi
 
   local stage="$(mktemp -d)"
-  trap "rm -rf \"$stage\"" RETURN
 
   unzip -q "$aar_path" -d "$stage"
   local jni_dir="$stage/jni"
   if [ ! -d "$jni_dir" ]; then
+    rm -rf "$stage"
     return
   fi
 
@@ -90,11 +90,13 @@ decouple_bundled_ort_in_aar() {
   done
 
   if [ "$touched" = "0" ]; then
+    rm -rf "$stage"
     return
   fi
 
   rm -f "$aar_path"
   ( cd "$stage" && zip -qr "$aar_path" . )
+  rm -rf "$stage"
 }
 
 extract_ort_symbol_version() {
@@ -256,6 +258,7 @@ fi
 if unzip -p "$OUTPUT_AAR" jni/arm64-v8a/libonnxruntime.so > "$TMP_DIR/libonnxruntime.so" 2>/dev/null; then
   MOONSHINE_PACKAGED_ORT_VERSION="$(extract_ort_symbol_version "$TMP_DIR/libonnxruntime.so")"
 fi
+AAR_SHA256="$(shasum -a 256 "$OUTPUT_AAR" | awk '{print $1}')"
 
 cat > "$METADATA_PATH" <<EOF
 {
@@ -265,7 +268,8 @@ cat > "$METADATA_PATH" <<EOF
   "onnxRuntimeLibPathOverride": "$(sanitize_metadata_path "$ORT_LIB_PATH")",
   "onnxRuntimeIncludeDirOverride": "$(sanitize_metadata_path "$ORT_INCLUDE_DIR")",
   "arm64ImportedOrtSymbolVersion": "${MOONSHINE_IMPORTED_ORT_VERSION}",
-  "arm64PackagedOrtSymbolVersion": "${MOONSHINE_PACKAGED_ORT_VERSION}"
+  "arm64PackagedOrtSymbolVersion": "${MOONSHINE_PACKAGED_ORT_VERSION}",
+  "aarSha256": "${AAR_SHA256}"
 }
 EOF
 

--- a/packages/moonshine.rn/ios/Moonshine.mm
+++ b/packages/moonshine.rn/ios/Moonshine.mm
@@ -1274,6 +1274,12 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
     });
   };
 
+  BOOL includeAudioData = BoolFromValue(config[@"includeAudioData"]);
+  // `includeAudioData` is the public RN switch for returning per-line PCM.
+  // The upstream native core defaults `return_audio_data` to true, which makes
+  // long streaming transcripts retain each VAD segment's samples even when RN
+  // suppresses `line.audioData` in emitted dictionaries. Keep native retention
+  // aligned with the JS contract and default it off for long sessions.
   NSDictionary *nativeOptions = [config[@"options"] isKindOfClass:NSDictionary.class] ? config[@"options"] : nil;
   if (nativeOptions != nil) {
     if (nativeOptions[@"identifySpeakers"] != nil && nativeOptions[@"identifySpeakers"] != (id)kCFNull) {
@@ -1338,6 +1344,7 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
     addOption(name, valueString ?: @"");
   }
 
+  addOption(@"return_audio_data", includeAudioData ? @"true" : @"false");
   return buffer;
 }
 

--- a/packages/moonshine.rn/patches/LongStreamingMemory.patch
+++ b/packages/moonshine.rn/patches/LongStreamingMemory.patch
@@ -1,0 +1,71 @@
+diff --git a/core/transcriber.cpp b/core/transcriber.cpp
+index 77c2733..e572335 100644
+--- a/core/transcriber.cpp
++++ b/core/transcriber.cpp
+@@ -426,10 +426,27 @@ void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
+     std::lock_guard<std::mutex> lock(stream->vad_mutex);
+     stream->vad->process_audio(audio_data, (int32_t)audio_length,
+                                INTERNAL_SAMPLE_RATE);
+-    segments = *(stream->vad->get_segments());
++    const std::vector<VoiceActivitySegment> *vad_segments =
++        stream->vad->get_segments();
++    segments.reserve(vad_segments->size());
++    for (const VoiceActivitySegment &segment : *vad_segments) {
++      VoiceActivitySegment segment_copy;
++      segment_copy.start_time = segment.start_time;
++      segment_copy.end_time = segment.end_time;
++      segment_copy.is_complete = segment.is_complete;
++      segment_copy.just_updated = segment.just_updated;
++      if (segment.just_updated) {
++        segment_copy.audio_data = segment.audio_data;
++      }
++      segments.push_back(std::move(segment_copy));
++    }
+   }
+   stream->clear_new_audio_buffer();
+   this->update_transcript_from_segments(segments, stream, out_transcript);
++  if (!this->options.return_audio_data) {
++    std::lock_guard<std::mutex> lock(stream->vad_mutex);
++    stream->vad->clear_completed_segment_audio_data();
++  }
+ }
+
+ std::string Transcriber::transcript_to_string(
+diff --git a/core/voice-activity-detector.cpp b/core/voice-activity-detector.cpp
+index f49fbcc..58fa083 100644
+--- a/core/voice-activity-detector.cpp
++++ b/core/voice-activity-detector.cpp
+@@ -96,6 +96,14 @@ void VoiceActivityDetector::process_audio(const float *audio_data,
+   processing_remainder_audio_buffer = processing_buffer;
+ }
+
++void VoiceActivityDetector::clear_completed_segment_audio_data() {
++  for (VoiceActivitySegment &segment : segments) {
++    if (segment.is_complete && !segment.audio_data.empty()) {
++      std::vector<float>().swap(segment.audio_data);
++    }
++  }
++}
++
+ void VoiceActivityDetector::process_audio_chunk(const float *audio_data,
+                                                 size_t audio_data_size) {
+   assert(audio_data_size == (size_t)(hop_size));
+diff --git a/core/voice-activity-detector.h b/core/voice-activity-detector.h
+index 3279bc8..bfee186 100644
+--- a/core/voice-activity-detector.h
++++ b/core/voice-activity-detector.h
+@@ -56,6 +56,7 @@ class VoiceActivityDetector {
+   const std::vector<VoiceActivitySegment> *get_segments() const {
+     return &segments;
+   }
++  void clear_completed_segment_audio_data();
+   std::string to_string() const;
+
+  private:
+@@ -66,4 +67,4 @@ class VoiceActivityDetector {
+   void process_audio_chunk(const float *audio_data, size_t audio_data_size);
+ };
+
+-#endif
+\ No newline at end of file
++#endif

--- a/packages/moonshine.rn/patches/README
+++ b/packages/moonshine.rn/patches/README
@@ -1,35 +1,41 @@
-Moonshine Patch Inventory for v0.0.51
-====================================
+# Moonshine Patch Inventory for v0.0.59
 
 These patches track our modifications to upstream `moonshine-ai/moonshine`
 sources so the Android source build is reproducible from a clean checkout.
 
-Pinned version: `v0.0.51`
+Pinned version: `v0.0.59`
 
+## Files patched
 
-Files patched
--------------
-OrtAndroidOverrides.patch
-  - patches upstream Android and CMake build files so the vendored source build
-    can honor:
-      `SITEED_MOONSHINE_ANDROID_ABIS`
-      `SITEED_MOONSHINE_ORT_LIB_PATH`
-      `SITEED_MOONSHINE_ORT_INCLUDE_DIR`
-  - adds a public `close()` method to upstream `Transcriber` so wrappers do not
-    need to reflectively call `finalize()`
-  - applied automatically by `./setup.sh` and `./build-moonshine-android.sh`
+### OrtAndroidOverrides.patch
 
+- patches upstream Android and CMake build files so the vendored source build
+  can honor:
+  `SITEED_MOONSHINE_ANDROID_ABIS`
+  `SITEED_MOONSHINE_ORT_LIB_PATH`
+  `SITEED_MOONSHINE_ORT_INCLUDE_DIR`
+- adds a public `close()` method to upstream `Transcriber` so wrappers do not
+  need to reflectively call `finalize()`
+- applied automatically by `./setup.sh` and `./build-moonshine-android.sh`
 
-How to apply on version upgrade
--------------------------------
+### LongStreamingMemory.patch
+
+- avoids copying historical VAD segment PCM on every streaming transcription
+  update and clears completed VAD segment samples after transcription when
+  `return_audio_data=false`, so long Moonshine streams keep bounded native
+  audio retention while callers that explicitly request audio data retain the
+  upstream debugging/analysis behavior.
+
+## How to apply on version upgrade
+
 When `setup.sh` is updated to a new upstream version:
 
 1. Refresh or re-pin `third_party/moonshine`.
-2. Rebase `OrtAndroidOverrides.patch` against the new upstream checkout.
+2. Rebase each patch in this inventory against the new upstream checkout.
 3. Re-run `bash packages/moonshine.rn/build-moonshine-android.sh`.
 4. Revalidate the resulting AAR and ORT compatibility.
 
 Note:
-- `OrtAndroidOverrides.patch` is applied from inside
-  `third_party/moonshine` via `git apply`, so its paths are relative to the
-  upstream checkout root.
+
+- All patch files are applied from inside `third_party/moonshine` via
+  `git apply`, so their paths are relative to the upstream checkout root.

--- a/packages/moonshine.rn/prebuilt/android/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/android/build-metadata.json
@@ -5,5 +5,6 @@
   "onnxRuntimeLibPathOverride": "",
   "onnxRuntimeIncludeDirOverride": "",
   "arm64ImportedOrtSymbolVersion": "stripped",
-  "arm64PackagedOrtSymbolVersion": "1.23.0"
+  "arm64PackagedOrtSymbolVersion": "1.23.0",
+  "aarSha256": "c68e66ec2cb69dd8967c7c05a3452f59579254930d234ab609bbff52b2b88711"
 }

--- a/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
+++ b/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:650ccab79bf5ad0b3a4009b16162bfba5d381254572fff2b001f329dc3e77d38
-size 29275684
+oid sha256:c68e66ec2cb69dd8967c7c05a3452f59579254930d234ab609bbff52b2b88711
+size 29276023

--- a/packages/moonshine.rn/scripts/validate-native-release.mjs
+++ b/packages/moonshine.rn/scripts/validate-native-release.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
@@ -64,6 +65,10 @@ function readelfCandidates() {
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8')
 )
+
+function sha256File(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
 
 if (!packageJson.moonshineVersion) {
   throw new Error('package.json must define moonshineVersion for native release validation')
@@ -269,6 +274,18 @@ console.log('Repo-local generated prebuilt/ios/current/ artifacts are intentiona
 
 const localAarPath = path.join(PACKAGE_ROOT, ANDROID_AAR)
 if (fs.existsSync(localAarPath)) {
+  const metadataPath = path.join(PACKAGE_ROOT, 'prebuilt/android/build-metadata.json')
+  const androidMetadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
+  if (!/^[a-f0-9]{64}$/i.test(androidMetadata.aarSha256 || '')) {
+    throw new Error('Android build metadata must include aarSha256 for repo-local AAR reproducibility')
+  }
+  const actualAarSha256 = sha256File(localAarPath)
+  if (androidMetadata.aarSha256 !== actualAarSha256) {
+    throw new Error(
+      `Android AAR sha256 mismatch. metadata=${androidMetadata.aarSha256} actual=${actualAarSha256}`
+    )
+  }
+
   const androidAbiReports = inspectAndroidAar(localAarPath)
   const bundledOnnxAbis = androidAbiReports
     .filter((report) => report.bundlesOnnxRuntime)
@@ -277,6 +294,7 @@ if (fs.existsSync(localAarPath)) {
     .filter((report) => !report.bundlesOnnxRuntime)
     .map((report) => report.abi)
 
+  console.log(`Repo-local Android AAR sha256 verified: ${actualAarSha256}`)
   console.log(
     `Repo-local Android AAR ABIs inspected: ${androidAbiReports
       .map((report) => report.abi)

--- a/packages/moonshine.rn/src/services/MoonshineService.ts
+++ b/packages/moonshine.rn/src/services/MoonshineService.ts
@@ -22,12 +22,18 @@ import type {
   MoonshineProcessUtteranceResult,
   MoonshineTranscriptEvent,
   MoonshineTranscriptionResult,
+  MoonshineTranscriptionInput,
   MoonshineTranscribeParams,
 } from '../types/interfaces';
 import { OfflineProgressTracker } from './offlineProgressTracker';
 import { runWithAbortSignal } from './transcriptionCancellation';
 
 type MoonshineListener = (event: MoonshineTranscriptEvent) => void;
+
+function toBridgeSamples(samples: MoonshineTranscriptionInput): number[] {
+  return Array.isArray(samples) ? samples : Array.from(samples);
+}
+
 export class MoonshineTranscriber {
   public constructor(
     private readonly service: MoonshineService,
@@ -35,7 +41,7 @@ export class MoonshineTranscriber {
   ) {}
 
   public addAudio(
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.service.addAudioForTranscriber(
@@ -47,7 +53,7 @@ export class MoonshineTranscriber {
 
   public addAudioToStream(
     streamId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.service.addAudioToStreamForTranscriber(
@@ -161,7 +167,7 @@ export class MoonshineService {
   private readonly offlineProgressTracker = new OfflineProgressTracker();
 
   public addAudio(
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.ensureDefaultTranscriber().addAudio(samples, sampleRate);
@@ -169,19 +175,19 @@ export class MoonshineService {
 
   public addAudioForTranscriber(
     transcriberId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return requireNativeMoonshineModule().addAudioForTranscriber(
       transcriberId,
       sampleRate,
-      samples
+      toBridgeSamples(samples)
     );
   }
 
   public addAudioToStream(
     streamId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.ensureDefaultTranscriber().addAudioToStream(
@@ -194,14 +200,14 @@ export class MoonshineService {
   public addAudioToStreamForTranscriber(
     transcriberId: string,
     streamId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return requireNativeMoonshineModule().addAudioToStreamForTranscriber(
       transcriberId,
       streamId,
       sampleRate,
-      samples
+      toBridgeSamples(samples)
     );
   }
 
@@ -546,13 +552,13 @@ export class MoonshineService {
   private transcribePcmForTranscriber(
     transcriberId: string,
     sampleRate: number,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     options?: MoonshinePcmTranscribeOptions
   ): Promise<MoonshineTranscriptionResult> {
     return requireNativeMoonshineModule().transcribeFromSamplesForTranscriber(
       transcriberId,
       sampleRate,
-      samples,
+      toBridgeSamples(samples),
       options
     );
   }

--- a/packages/moonshine.rn/src/types/interfaces.ts
+++ b/packages/moonshine.rn/src/types/interfaces.ts
@@ -163,9 +163,9 @@ export interface MoonshineOfflineProgressOptions {
 }
 
 export interface MoonshinePcmTranscribeOptions {
-  // PCM is currently transported as number[] over the React Native bridge.
-  // Keep chunks reasonably small (roughly 100-250ms) until a JSI/ArrayBuffer
-  // path exists.
+  // PCM can be provided as number[] or Float32Array. Native legacy bridges may
+  // still materialize arrays internally, so keep chunks reasonably small
+  // (roughly 100-250ms) until a JSI/ArrayBuffer path exists.
   chunkDurationMs?: number;
   progress?: false | MoonshineOfflineProgressOptions;
 }


### PR DESCRIPTION
## Summary

Second PR in the long-audio stack, on top of the core `streamAudioData` PR.

- Aligns Moonshine RN native `return_audio_data` with public `includeAudioData` so long streams do not retain completed VAD segment PCM unless requested.
- Accepts `Float32Array` at the JS Moonshine PCM input boundary while preserving bridge compatibility.
- Adds the upstream Moonshine patch file and patching docs for the same long-stream memory fix.
- Rebuilds/verifies the Android source AAR and records the sha256 in metadata.

Related upstream PR: https://github.com/moonshine-ai/moonshine/pull/175

## Stack

1. #386 — core audio-studio progressive decode API.
2. This PR — Moonshine RN long-stream retention and upstream patching.
3. #388 — long-audio validation playground, agentic recipe, and benchmark harness.

## Validation

- [x] `yarn workspace @siteed/moonshine.rn typecheck`
- [x] `yarn workspace @siteed/moonshine.rn validate:native-release`
- [x] upstream patch applies cleanly with `git apply --3way --check`
