### PR TITLE
feat: land long audio moonshine validation followups

### DIFF
--- a/apps/playground/.env.sample
+++ b/apps/playground/.env.sample
@@ -1,3 +1,7 @@
 # External browser CDP URL — connect to an already-running Chrome/Chromium
 # Launch Chrome with: google-chrome --remote-debugging-port=9222
 # CDP_URL=http://localhost:9222
+# Optional: local iOS physical-device signing. Keep real values in ignored
+# .env.development.local / .env.production.local, not in git.
+# APPLE_TEAM_ID=XXXXXXXXXX
+# IOS_DEVELOPMENT_TEAM=XXXXXXXXXX

--- a/apps/playground/scripts/agentic/teams/playground/evals.json
+++ b/apps/playground/scripts/agentic/teams/playground/evals.json
@@ -24,6 +24,16 @@
     "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
     "async": false
   },
+  "long-audio-validation-state": {
+    "description": "Current state of the long audio validation page",
+    "expression": "JSON.stringify(globalThis.__AGENTIC__?.getPageState?.() || null)",
+    "async": false
+  },
+  "long-audio-validation-progress": {
+    "description": "Current long audio validation progress from the app-side bridge",
+    "expression": "JSON.stringify(globalThis.__AGENTIC__?.getLongAudioValidationProgress?.() || null)",
+    "async": false
+  },
   "audio-player-state": {
     "description": "AudioPlayer screen probe state (mounted flag plus ExtractionState fields).",
     "expression": "JSON.stringify(globalThis.__AGENTIC__?.audioPlayer?.getState() || null)",

--- a/apps/playground/scripts/agentic/teams/playground/flows/long-audio-validation-screen-ready.json
+++ b/apps/playground/scripts/agentic/teams/playground/flows/long-audio-validation-screen-ready.json
@@ -1,0 +1,67 @@
+{
+  "title": "Playground long audio validation screen ready",
+  "validate": {
+    "workflow": {
+      "entry": "nav-long-audio-validation",
+      "pre_conditions": [
+        "playground.agentic_ready"
+      ],
+      "nodes": {
+        "nav-long-audio-validation": {
+          "action": "navigate",
+          "target": "/long-audio-validation",
+          "next": "wait-route"
+        },
+        "wait-route": {
+          "action": "wait_for",
+          "route": "/long-audio-validation",
+          "next": "wait-fixture-input"
+        },
+        "wait-fixture-input": {
+          "action": "wait_for",
+          "test_id": "long-audio-fixture-uri",
+          "next": "wait-segment-duration-input"
+        },
+        "wait-segment-duration-input": {
+          "action": "wait_for",
+          "test_id": "long-audio-sherpa-segment-duration-ms",
+          "next": "wait-range-end-input"
+        },
+        "wait-range-end-input": {
+          "action": "wait_for",
+          "test_id": "long-audio-range-end-ms",
+          "next": "wait-decode-button"
+        },
+        "wait-decode-button": {
+          "action": "wait_for",
+          "test_id": "long-audio-start-decode",
+          "next": "wait-full-decode-button"
+        },
+        "wait-full-decode-button": {
+          "action": "wait_for",
+          "test_id": "long-audio-start-full-decode",
+          "next": "wait-moonshine-button"
+        },
+        "wait-moonshine-button": {
+          "action": "wait_for",
+          "test_id": "long-audio-start-moonshine",
+          "next": "wait-sherpa-button"
+        },
+        "wait-sherpa-button": {
+          "action": "wait_for",
+          "test_id": "long-audio-start-sherpa-online",
+          "next": "wait-sherpa-segments-button"
+        },
+        "wait-sherpa-segments-button": {
+          "action": "wait_for",
+          "test_id": "long-audio-start-sherpa-segments",
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/apps/playground/scripts/agentic/teams/playground/recipes/long-audio-validation.json
+++ b/apps/playground/scripts/agentic/teams/playground/recipes/long-audio-validation.json
@@ -1,0 +1,161 @@
+{
+  "title": "Playground long audio validation UI smoke",
+  "description": "Opens the long-audio validation page, verifies the long fixture controls including Sherpa/Qwen3 segments, starts the staged 100-minute fixture in decode-only mode long enough to prove chunk/progress updates, cancels, then starts decode + Moonshine long enough to prove combined decode/transcription progress is visible. For full unattended runs, use `yarn workspace @siteed/audio-studio validate:stream-long --moonshine` or `--sherpa-offline-segments --sherpa-config <qwen3.json>` after staging/building the app.",
+  "validate": {
+    "workflow": {
+      "entry": "screen-ready",
+      "nodes": {
+        "screen-ready": {
+          "action": "call",
+          "ref": "long-audio-validation-screen-ready",
+          "next": "assert-screen-state"
+        },
+        "assert-screen-state": {
+          "action": "eval_ref",
+          "ref": "long-audio-validation-state",
+          "assert": {
+            "all": [
+              {
+                "operator": "eq",
+                "field": "route",
+                "value": "/long-audio-validation"
+              },
+              {
+                "operator": "contains",
+                "field": "fileUri",
+                "value": "perps_controller_refactor_100m.opus"
+              }
+            ]
+          },
+          "next": "press-decode"
+        },
+        "press-decode": {
+          "action": "press",
+          "test_id": "long-audio-start-decode",
+          "next": "wait-decode-progress"
+        },
+        "wait-decode-progress": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getLongAudioValidationProgress?.() || null)",
+          "assert": {
+            "all": [
+              {
+                "operator": "eq",
+                "field": "mode",
+                "value": "decode-only"
+              },
+              {
+                "operator": "gte",
+                "field": "chunkCount",
+                "value": 40
+              },
+              {
+                "operator": "gt",
+                "field": "processedAudioMs",
+                "value": 9000
+              }
+            ]
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "lastError"
+          },
+          "timeout_ms": 120000,
+          "poll_ms": 2000,
+          "next": "cancel-decode"
+        },
+        "cancel-decode": {
+          "action": "press",
+          "test_id": "long-audio-cancel",
+          "next": "wait-decode-cancelled"
+        },
+        "wait-decode-cancelled": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getLongAudioValidationProgress?.() || null)",
+          "assert": {
+            "operator": "eq",
+            "field": "status",
+            "value": "cancelled"
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "lastError"
+          },
+          "timeout_ms": 60000,
+          "poll_ms": 1000,
+          "next": "press-moonshine"
+        },
+        "press-moonshine": {
+          "action": "press",
+          "test_id": "long-audio-start-moonshine",
+          "next": "wait-moonshine-progress"
+        },
+        "wait-moonshine-progress": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getLongAudioValidationProgress?.() || null)",
+          "assert": {
+            "all": [
+              {
+                "operator": "eq",
+                "field": "mode",
+                "value": "moonshine"
+              },
+              {
+                "operator": "gte",
+                "field": "chunkCount",
+                "value": 40
+              },
+              {
+                "operator": "gt",
+                "field": "processedAudioMs",
+                "value": 9000
+              }
+            ]
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "lastError"
+          },
+          "timeout_ms": 600000,
+          "poll_ms": 5000,
+          "next": "cancel-moonshine"
+        },
+        "cancel-moonshine": {
+          "action": "press",
+          "test_id": "long-audio-cancel",
+          "next": "wait-moonshine-cancelled"
+        },
+        "wait-moonshine-cancelled": {
+          "action": "wait_for",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getLongAudioValidationProgress?.() || null)",
+          "assert": {
+            "operator": "eq",
+            "field": "status",
+            "value": "cancelled"
+          },
+          "fail_when": {
+            "operator": "not_null",
+            "field": "lastError"
+          },
+          "timeout_ms": 120000,
+          "poll_ms": 1000,
+          "next": "log-watch"
+        },
+        "log-watch": {
+          "action": "log_watch",
+          "watch_for": [
+            "[LongAudioValidation]",
+            "AudioStreamDecoder"
+          ],
+          "timeout_ms": 60000,
+          "poll_ms": 1000,
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/apps/playground/src/agentic-bridge.ts
+++ b/apps/playground/src/agentic-bridge.ts
@@ -28,9 +28,17 @@ import {
     extractAudioAnalysis,
     extractMelSpectrogram,
     trimAudio,
+    streamAudioData,
+    getAudioDecodeCapabilities,
     AudioDeviceManager,
 } from '@siteed/audio-studio'
-import { OnnxInference, typedArrayToBase64, base64ToTypedArray } from '@siteed/sherpa-onnx.rn'
+import {
+    ASR as SherpaASR,
+    OnnxInference,
+    typedArrayToBase64,
+    base64ToTypedArray,
+    type AsrModelConfig,
+} from '@siteed/sherpa-onnx.rn'
 import type { OnnxTensorData } from '@siteed/sherpa-onnx.rn'
 import {
     getBenchmarkModelOrThrow,
@@ -46,6 +54,7 @@ import {
 import Moonshine, {
     type MoonshineTranscriber,
     type MoonshineTranscriptEvent,
+    type MoonshineTranscriptionInput,
 } from '@siteed/moonshine.rn'
 import { readMonoPcm16Wav } from './utils/wav'
 import { createAudioStudioAgenticContracts } from './agentic/audioStudioContracts'
@@ -153,6 +162,638 @@ function stripFunctions(obj: Record<string, unknown>): Record<string, unknown> {
 
 // --- Async result store for fire-and-store pattern (CDP awaitPromise:false) ---
 let _lastAsyncResult: AgenticAsyncResult | null = null
+
+export type LongAudioValidationMode =
+    | 'decode-only'
+    | 'moonshine'
+    | 'full-decode'
+    | 'sherpa-online'
+    | 'sherpa-offline-segments'
+export type LongAudioMoonshineFeedMode = 'typed-array' | 'array-copy'
+
+export interface LongAudioValidationOptions {
+    fileUri: string
+    mode?: LongAudioValidationMode
+    modelId?: string
+    startTimeMs?: number
+    endTimeMs?: number
+    chunkDurationMs?: number
+    maxBufferedChunks?: number
+    progressEveryChunks?: number
+    cancelAfterChunks?: number
+    moonshineFeedMode?: LongAudioMoonshineFeedMode
+    sherpaAsrConfig?: AsrModelConfig
+    sherpaSegmentDurationMs?: number
+    sherpaReleaseBetweenSegments?: boolean
+}
+
+export interface LongAudioValidationProgress {
+    op: 'validateLongAudioStream'
+    status: 'idle' | 'pending' | 'success' | 'cancelled' | 'error'
+    mode: LongAudioValidationMode
+    fileUri: string
+    modelId?: string
+    moonshineFeedMode?: LongAudioMoonshineFeedMode
+    sherpaModelType?: string
+    sherpaSegmentCount?: number
+    sherpaReleaseBetweenSegments?: boolean
+    startedAtMs: number
+    updatedAtMs: number
+    elapsedWallMs: number
+    processedAudioMs: number
+    durationMs: number
+    progress: number
+    chunkCount: number
+    sampleCount: number
+    sampleRate: number
+    channels: number
+    transcriptLineCount: number
+    transcriptCharCount: number
+    transcriptEventCount: number
+    lastError?: string
+    cancelReason?: string
+}
+
+let _longAudioValidationProgress: LongAudioValidationProgress | null = null
+let _longAudioValidationAbortController: AbortController | null = null
+
+function getTranscriptCharCount(lengthByLineId: Map<string, number>): number {
+    let total = 0
+    for (const length of lengthByLineId.values()) {
+        total += length
+    }
+    return total
+}
+
+function updateLongAudioValidationProgress(
+    patch: Partial<LongAudioValidationProgress>,
+) {
+    if (!_longAudioValidationProgress) return
+    const now = Date.now()
+    _longAudioValidationProgress = {
+        ..._longAudioValidationProgress,
+        ...patch,
+        updatedAtMs: now,
+        elapsedWallMs: now - _longAudioValidationProgress.startedAtMs,
+    }
+}
+
+export async function validateLongAudioStream(
+    options: LongAudioValidationOptions,
+): Promise<void> {
+    const op = 'validateLongAudioStream'
+    const mode = options.mode ?? 'decode-only'
+    const moonshineFeedMode = options.moonshineFeedMode ?? 'typed-array'
+    const progressEveryChunks = options.progressEveryChunks ?? 40
+    const sherpaSegmentDurationMs = options.sherpaSegmentDurationMs ?? 30_000
+    const sherpaReleaseBetweenSegments =
+        options.sherpaReleaseBetweenSegments ??
+        (mode === 'sherpa-offline-segments' &&
+            options.sherpaAsrConfig?.modelType === 'qwen3')
+    const startedAtMs = Date.now()
+    const transcriptLengthByLineId = new Map<string, number>()
+    let transcriber: MoonshineTranscriber | null = null
+    let streamId: string | null = null
+    let removeListener: (() => void) | null = null
+    let sherpaAsrInitialized = false
+    let sherpaOfflineConfig: AsrModelConfig | null = null
+    let sherpaSegmentChunks: Float32Array[] = []
+    let sherpaSegmentSampleCount = 0
+    let sherpaSegmentCount = 0
+    let sherpaTranscriptText = ''
+    const controller = new AbortController()
+
+    if (!options.fileUri) {
+        throw new Error('validateLongAudioStream requires fileUri')
+    }
+    if (
+        mode !== 'decode-only' &&
+        mode !== 'moonshine' &&
+        mode !== 'full-decode' &&
+        mode !== 'sherpa-online' &&
+        mode !== 'sherpa-offline-segments'
+    ) {
+        throw new Error(`Unsupported long-audio validation mode: ${mode}`)
+    }
+    if (_longAudioValidationProgress?.status === 'pending') {
+        throw new Error('validateLongAudioStream is already running')
+    }
+
+    _lastAsyncResult = { op, status: 'pending' }
+    _longAudioValidationAbortController = controller
+    _longAudioValidationProgress = {
+        op,
+        status: 'pending',
+        mode,
+        fileUri: options.fileUri,
+        modelId: options.modelId,
+        moonshineFeedMode: mode === 'moonshine' ? moonshineFeedMode : undefined,
+        sherpaModelType:
+            mode === 'sherpa-online' || mode === 'sherpa-offline-segments'
+                ? options.sherpaAsrConfig?.modelType
+                : undefined,
+        sherpaReleaseBetweenSegments:
+            mode === 'sherpa-offline-segments'
+                ? sherpaReleaseBetweenSegments
+                : undefined,
+        startedAtMs,
+        updatedAtMs: startedAtMs,
+        elapsedWallMs: 0,
+        processedAudioMs: 0,
+        durationMs: 0,
+        progress: 0,
+        chunkCount: 0,
+        sampleCount: 0,
+        sampleRate: 0,
+        channels: 0,
+        transcriptLineCount: 0,
+        transcriptCharCount: 0,
+        transcriptEventCount: 0,
+    }
+
+    try {
+        if (mode === 'full-decode') {
+            let probedDurationMs = 0
+            const probeController = new AbortController()
+            await streamAudioData(
+                {
+                    fileUri: options.fileUri,
+                    startTimeMs: options.startTimeMs,
+                    endTimeMs: options.endTimeMs,
+                    targetSampleRate: 16000,
+                    channels: 1,
+                    normalizeAudio: true,
+                    streamFormat: 'float32',
+                    chunkDurationMs: options.chunkDurationMs ?? 250,
+                    maxBufferedChunks: 1,
+                    signal: probeController.signal,
+                },
+                {
+                    onChunk: async () => {
+                        probeController.abort()
+                    },
+                    onProgress: (progress) => {
+                        probedDurationMs = progress.durationMs
+                        updateLongAudioValidationProgress({
+                            durationMs: progress.durationMs,
+                            progress: 0,
+                        })
+                    },
+                },
+            ).catch((e) => {
+                const error = String(e)
+                if (!error.includes('ERR_AUDIO_STREAM_CANCELLED')) {
+                    throw e
+                }
+            })
+            if (probedDurationMs <= 0) {
+                throw new Error('Unable to determine fixture duration for full decode')
+            }
+            const fullDecodeStartTimeMs = options.startTimeMs ?? 0
+            const fullDecodeEndTimeMs =
+                options.endTimeMs ?? fullDecodeStartTimeMs + probedDurationMs
+            const startedDecodeAtMs = Date.now()
+            const fullDecode = await extractAudioData({
+                fileUri: options.fileUri,
+                startTimeMs: fullDecodeStartTimeMs,
+                endTimeMs: fullDecodeEndTimeMs,
+                includeNormalizedData: false,
+                includeBase64Data: false,
+                includeWavHeader: false,
+                decodingOptions: {
+                    targetSampleRate: 16000,
+                    targetChannels: 1,
+                    targetBitDepth: 16,
+                    normalizeAudio: true,
+                },
+            })
+            const decodeWallMs = Date.now() - startedDecodeAtMs
+            const sampleCount = fullDecode.samples * fullDecode.channels
+            updateLongAudioValidationProgress({
+                status: 'success',
+                processedAudioMs: fullDecode.durationMs,
+                durationMs: fullDecode.durationMs,
+                progress: fullDecode.durationMs > 0 ? 1 : 0,
+                chunkCount: 0,
+                sampleCount,
+                sampleRate: fullDecode.sampleRate,
+                channels: fullDecode.channels,
+            })
+            _lastAsyncResult = {
+                op,
+                status: 'success',
+                result: {
+                    ..._longAudioValidationProgress,
+                    fullDecode: {
+                        bitDepth: fullDecode.bitDepth,
+                        channels: fullDecode.channels,
+                        decodeWallMs,
+                        durationMs: fullDecode.durationMs,
+                        format: fullDecode.format,
+                        pcmBytes: fullDecode.pcmData.byteLength,
+                        sampleRate: fullDecode.sampleRate,
+                        samples: fullDecode.samples,
+                    },
+                },
+            }
+            return
+        }
+
+        if (mode === 'moonshine') {
+            const modelId = options.modelId ?? 'moonshine-small-streaming-en'
+            const model = getBenchmarkModelOrThrow(modelId)
+            if (model.engine !== 'moonshine') {
+                throw new Error(
+                    `validateLongAudioStream moonshine mode requires a Moonshine model; got ${modelId}`,
+                )
+            }
+            const config = await getMoonshineRuntimeConfig(modelId)
+            transcriber = await Moonshine.createTranscriberFromFiles(config)
+            streamId = await transcriber.createStream()
+            removeListener = transcriber.addListener((event: MoonshineTranscriptEvent) => {
+                if (streamId && event.streamId !== streamId) return
+                const lineId = event.line?.lineId
+                if (lineId) {
+                    transcriptLengthByLineId.set(lineId, event.line?.text?.length ?? 0)
+                }
+                updateLongAudioValidationProgress({
+                    transcriptEventCount:
+                        (_longAudioValidationProgress?.transcriptEventCount ?? 0) + 1,
+                    transcriptLineCount: transcriptLengthByLineId.size,
+                    transcriptCharCount: getTranscriptCharCount(transcriptLengthByLineId),
+                })
+            })
+            await transcriber.startStream(streamId)
+            updateLongAudioValidationProgress({ modelId })
+        }
+
+        if (mode === 'sherpa-online') {
+            const config = options.sherpaAsrConfig
+            if (!config?.modelDir || !config.modelType) {
+                throw new Error(
+                    'sherpa-online mode requires sherpaAsrConfig with modelDir and modelType',
+                )
+            }
+            if (config.modelType === 'qwen3') {
+                throw new Error(
+                    'Qwen3-ASR is offline-only in the current Sherpa ONNX RN API; use sherpa-offline-segments instead.',
+                )
+            }
+            if (config.streaming === false) {
+                throw new Error(
+                    'sherpa-online mode requires a streaming-capable Sherpa model/config. Use sherpa-offline-segments for offline configs.',
+                )
+            }
+            const streamingConfig: AsrModelConfig = {
+                ...config,
+                streaming: true,
+            }
+            const initResult = await SherpaASR.initialize(streamingConfig)
+            if (!initResult.success) {
+                throw new Error(
+                    initResult.error ??
+                        `Sherpa ASR init failed for ${streamingConfig.modelType}`,
+                )
+            }
+            const streamResult = await SherpaASR.createOnlineStream()
+            if (!streamResult.success) {
+                throw new Error('Sherpa ASR createOnlineStream failed')
+            }
+            sherpaAsrInitialized = true
+            updateLongAudioValidationProgress({
+                modelId: options.modelId ?? `sherpa:${streamingConfig.modelType}`,
+                sherpaModelType: streamingConfig.modelType,
+            })
+        }
+
+        if (mode === 'sherpa-offline-segments') {
+            const config = options.sherpaAsrConfig
+            if (!config?.modelDir || !config.modelType) {
+                throw new Error(
+                    'sherpa-offline-segments mode requires sherpaAsrConfig with modelDir and modelType',
+                )
+            }
+            const offlineConfig: AsrModelConfig = {
+                ...config,
+                streaming: false,
+            }
+            sherpaOfflineConfig = offlineConfig
+            const initResult = await SherpaASR.initialize(offlineConfig)
+            if (!initResult.success) {
+                throw new Error(
+                    initResult.error ??
+                        `Sherpa ASR init failed for ${offlineConfig.modelType}`,
+                )
+            }
+            sherpaAsrInitialized = true
+            updateLongAudioValidationProgress({
+                modelId: options.modelId ?? `sherpa:${offlineConfig.modelType}`,
+                sherpaModelType: offlineConfig.modelType,
+                sherpaSegmentCount: 0,
+            })
+        }
+
+        const reinitializeSherpaOfflineAsr = async () => {
+            if (!sherpaOfflineConfig) {
+                throw new Error('Sherpa offline config unavailable for reinitialize')
+            }
+            try {
+                await SherpaASR.release()
+            } catch (error) {
+                console.warn(
+                    '[LongAudioValidation] Sherpa release between segments failed',
+                    error,
+                )
+            }
+            sherpaAsrInitialized = false
+            const initResult = await SherpaASR.initialize(sherpaOfflineConfig)
+            if (!initResult.success) {
+                throw new Error(
+                    initResult.error ??
+                        `Sherpa ASR re-init failed for ${sherpaOfflineConfig.modelType}`,
+                )
+            }
+            sherpaAsrInitialized = true
+        }
+
+        const flushSherpaOfflineSegment = async (
+            sampleRate: number,
+            force = false,
+        ) => {
+            if (mode !== 'sherpa-offline-segments') return
+            const minSamples = Math.max(
+                1,
+                Math.floor((sherpaSegmentDurationMs / 1000) * sampleRate),
+            )
+            if (!force && sherpaSegmentSampleCount < minSamples) return
+            if (sherpaSegmentSampleCount === 0) return
+            // Keep long segment accumulation in Float32Array chunks to avoid
+            // retaining millions of boxed JS numbers while decode is still
+            // running. The current Sherpa RN bridge still requires number[]
+            // at the recognition boundary, so materialize it only for the
+            // bounded segment being submitted.
+            const segmentSamples = new Array<number>(sherpaSegmentSampleCount)
+            let offset = 0
+            for (const samples of sherpaSegmentChunks) {
+                for (let i = 0; i < samples.length; i += 1) {
+                    segmentSamples[offset + i] = samples[i]
+                }
+                offset += samples.length
+            }
+            sherpaSegmentChunks = []
+            sherpaSegmentSampleCount = 0
+            const recognized = await SherpaASR.recognizeFromSamples(
+                sampleRate,
+                segmentSamples,
+            )
+            if (!recognized.success) {
+                throw new Error(
+                    recognized.error ??
+                        `Sherpa offline segment ${sherpaSegmentCount + 1} failed`,
+                )
+            }
+            sherpaSegmentCount += 1
+            const text = (recognized.text ?? '').trim()
+            if (text) {
+                sherpaTranscriptText = sherpaTranscriptText
+                    ? `${sherpaTranscriptText}\n${text}`
+                    : text
+            }
+            updateLongAudioValidationProgress({
+                transcriptLineCount: sherpaTranscriptText
+                    ? sherpaTranscriptText.split('\n').length
+                    : 0,
+                transcriptCharCount: sherpaTranscriptText.length,
+                transcriptEventCount:
+                    (_longAudioValidationProgress?.transcriptEventCount ?? 0) + 1,
+                sherpaSegmentCount,
+            })
+            if (
+                sherpaReleaseBetweenSegments &&
+                !force &&
+                !controller.signal.aborted
+            ) {
+                await reinitializeSherpaOfflineAsr()
+            }
+        }
+
+        const result = await streamAudioData(
+            {
+                fileUri: options.fileUri,
+                startTimeMs: options.startTimeMs,
+                endTimeMs: options.endTimeMs,
+                targetSampleRate: 16000,
+                channels: 1,
+                normalizeAudio: true,
+                streamFormat: 'float32',
+                chunkDurationMs: options.chunkDurationMs ?? 250,
+                maxBufferedChunks: options.maxBufferedChunks ?? 4,
+                signal: controller.signal,
+            },
+            {
+                onChunk: async (chunk) => {
+                    try {
+                        if (mode === 'moonshine') {
+                            if (!transcriber || !streamId) {
+                                throw new Error('Moonshine stream was not initialized')
+                            }
+                            const samples: MoonshineTranscriptionInput =
+                                moonshineFeedMode === 'array-copy'
+                                    ? Array.from(chunk.samples)
+                                    : chunk.samples
+                            await transcriber.addAudioToStream(
+                                streamId,
+                                samples,
+                                chunk.sampleRate,
+                            )
+                        }
+                        if (mode === 'sherpa-online') {
+                            // Sherpa's current React Native ASR service accepts
+                            // number[] at the JS boundary. This path still
+                            // benchmarks long-audio decode + online ASR progress,
+                            // but it is not zero-copy like a future typed-array/JSI
+                            // bridge could be.
+                            await SherpaASR.acceptWaveform(
+                                chunk.sampleRate,
+                                Array.from(chunk.samples),
+                            )
+                            if (
+                                chunk.chunkIndex % progressEveryChunks === 0 ||
+                                chunk.isFinal
+                            ) {
+                                const partial = await SherpaASR.getResult().catch(
+                                    () => null,
+                                )
+                                const text = partial?.text ?? ''
+                                updateLongAudioValidationProgress({
+                                    transcriptLineCount: text ? 1 : 0,
+                                    transcriptCharCount: text.length,
+                                    transcriptEventCount:
+                                        (_longAudioValidationProgress
+                                            ?.transcriptEventCount ?? 0) + 1,
+                                })
+                            }
+                        }
+                        if (mode === 'sherpa-offline-segments') {
+                            sherpaSegmentChunks.push(chunk.samples)
+                            sherpaSegmentSampleCount += chunk.samples.length
+                            await flushSherpaOfflineSegment(chunk.sampleRate, chunk.isFinal)
+                        }
+
+                        const chunkCount = chunk.chunkIndex + 1
+                        const sampleCount =
+                            (_longAudioValidationProgress?.sampleCount ?? 0) +
+                            chunk.sampleCount
+                        if (
+                            chunkCount % progressEveryChunks === 0 ||
+                            chunk.isFinal ||
+                            options.cancelAfterChunks === chunkCount
+                        ) {
+                            updateLongAudioValidationProgress({
+                                chunkCount,
+                                processedAudioMs: chunk.endTimeMs,
+                                sampleCount,
+                                sampleRate: chunk.sampleRate,
+                                channels: chunk.channels,
+                            })
+                        } else if (_longAudioValidationProgress) {
+                            _longAudioValidationProgress.sampleCount = sampleCount
+                        }
+                        if (
+                            options.cancelAfterChunks !== undefined &&
+                            chunkCount >= options.cancelAfterChunks
+                        ) {
+                            updateLongAudioValidationProgress({
+                                cancelReason: `cancelAfterChunks:${options.cancelAfterChunks}`,
+                            })
+                            controller.abort()
+                        }
+                    } catch (error) {
+                        controller.abort()
+                        throw error
+                    }
+                },
+                onProgress: (progress) => {
+                    updateLongAudioValidationProgress({
+                        processedAudioMs: progress.processedMs,
+                        durationMs: progress.durationMs,
+                        progress: progress.progress,
+                        chunkCount: progress.emittedChunks,
+                    })
+                },
+            },
+        )
+
+        let moonshineResult: { text?: string; lines?: unknown[] } | null = null
+        if (mode === 'moonshine' && transcriber && streamId) {
+            moonshineResult = (await transcriber.stopStream(streamId)) as unknown as {
+                text?: string
+                lines?: unknown[]
+            }
+        }
+        let sherpaResult: { text?: string; tokens?: unknown[]; timestamps?: unknown[] } | null =
+            null
+        if (mode === 'sherpa-online' && sherpaAsrInitialized) {
+            sherpaResult = await SherpaASR.getResult().catch(() => null)
+        }
+        if (mode === 'sherpa-offline-segments' && sherpaAsrInitialized) {
+            await flushSherpaOfflineSegment(result.sampleRate, true)
+            sherpaResult = { text: sherpaTranscriptText }
+        }
+
+        const cancelled = result.cancelled
+        const completionStatus = cancelled ? 'cancelled' : 'success'
+        updateLongAudioValidationProgress({
+            status: completionStatus,
+            processedAudioMs: cancelled
+                ? (_longAudioValidationProgress?.processedAudioMs ?? 0)
+                : result.durationMs,
+            durationMs: result.durationMs,
+            progress: cancelled
+                ? (_longAudioValidationProgress?.progress ?? 0)
+                : result.durationMs > 0
+                  ? 1
+                  : (_longAudioValidationProgress?.progress ?? 1),
+            chunkCount: result.chunks,
+            sampleCount: result.samples,
+            sampleRate: result.sampleRate,
+            channels: result.channels,
+            transcriptLineCount:
+                sherpaResult?.text != null
+                    ? sherpaResult.text
+                        ? sherpaResult.text.split('\n').length
+                        : 0
+                    : Math.max(
+                          moonshineResult?.lines?.length ?? 0,
+                          transcriptLengthByLineId.size
+                      ),
+            transcriptCharCount:
+                sherpaResult?.text?.length ??
+                moonshineResult?.text?.length ??
+                getTranscriptCharCount(transcriptLengthByLineId),
+        })
+
+        _lastAsyncResult = {
+            op,
+            status: completionStatus,
+            result: {
+                ..._longAudioValidationProgress,
+                audio: result,
+                moonshine: moonshineResult
+                    ? {
+                          lineCount: Math.max(
+                              moonshineResult.lines?.length ?? 0,
+                              transcriptLengthByLineId.size
+                          ),
+                          transcriptCharCount: moonshineResult.text?.length ?? 0,
+                      }
+                    : null,
+                sherpa: sherpaResult
+                    ? {
+                          transcriptCharCount: sherpaResult.text?.length ?? 0,
+                          tokenCount: sherpaResult.tokens?.length ?? 0,
+                          timestampCount: sherpaResult.timestamps?.length ?? 0,
+                      }
+                    : null,
+            },
+        }
+    } catch (e) {
+        const error = String(e)
+        updateLongAudioValidationProgress({ status: 'error', lastError: error })
+        _lastAsyncResult = {
+            op,
+            status: 'error',
+            error,
+            result: _longAudioValidationProgress,
+        }
+    } finally {
+        removeListener?.()
+        if (transcriber && streamId) {
+            await transcriber.removeStream(streamId).catch(() => undefined)
+        }
+        await safeReleaseMoonshineTranscriber(transcriber)
+        await safeReleaseMoonshine()
+        if (sherpaAsrInitialized) {
+            await SherpaASR.release().catch(() => undefined)
+        }
+        if (_longAudioValidationAbortController === controller) {
+            _longAudioValidationAbortController = null
+        }
+    }
+}
+
+export function getLongAudioValidationProgress(): LongAudioValidationProgress | null {
+    return _longAudioValidationProgress
+}
+
+export function cancelLongAudioValidation(reason = 'cancelled-by-agent') {
+    if (!_longAudioValidationAbortController) {
+        return { cancelled: false, reason: 'not-running' }
+    }
+    updateLongAudioValidationProgress({ cancelReason: reason })
+    _longAudioValidationAbortController.abort()
+    return { cancelled: true, reason }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const JFK_MP3_ASSET = require('@assets/jfk.mp3')
@@ -344,6 +985,15 @@ if (__DEV__) {
             }
         },
 
+        resolveDocumentFileUri: (relativePath: string) => {
+            const normalizedPath = String(relativePath || '').replace(/^\/+/, '')
+            return {
+                uri: `${FileSystem.documentDirectory}${normalizedPath}`,
+                documentDirectory: FileSystem.documentDirectory,
+                relativePath: normalizedPath,
+            }
+        },
+
         getStepHud: () => {
             return stepHudStore.getStep()
         },
@@ -435,6 +1085,29 @@ if (__DEV__) {
 
         getLastResult: () => {
             return _lastAsyncResult
+        },
+
+        getLongAudioValidationProgress: () => {
+            return getLongAudioValidationProgress()
+        },
+
+        cancelLongAudioValidation: (reason?: string) => {
+            return cancelLongAudioValidation(reason)
+        },
+
+        validateLongAudioStream: (options: LongAudioValidationOptions) => {
+            const op = 'validateLongAudioStream'
+            void validateLongAudioStream(options).catch((e) => {
+                const error = String(e)
+                updateLongAudioValidationProgress({ status: 'error', lastError: error })
+                _lastAsyncResult = {
+                    op,
+                    status: 'error',
+                    error,
+                    result: _longAudioValidationProgress,
+                }
+            })
+            return { op, status: 'pending' }
         },
 
         ...createAudioStudioAgenticContracts({
@@ -1286,6 +1959,108 @@ if (__DEV__) {
                             channels: result.channels,
                             durationMs: result.durationMs,
                             samples: result.samples,
+                        },
+                    }
+                } catch (e) {
+                    _lastAsyncResult = { op, status: 'error', error: String(e) }
+                }
+            })()
+            return { op, status: 'pending' }
+        },
+
+        testStreamAudioData: (opts?: {
+            chunkDurationMs?: number
+            targetSampleRate?: number
+            channels?: number
+            cancelAfterChunks?: number
+        }) => {
+            const op = 'streamAudioData'
+            _lastAsyncResult = { op, status: 'pending' }
+            void (async () => {
+                try {
+                    const caps = await getAudioDecodeCapabilities()
+                    const fileUri = await loadSampleFileUri()
+                    const controller = new AbortController()
+                    const chunkSummaries: {
+                        chunkIndex: number
+                        startTimeMs: number
+                        endTimeMs: number
+                        sampleCount: number
+                        firstSample: number
+                        lastSample: number
+                        isFinal: boolean
+                    }[] = []
+                    let monotonic = true
+                    let lastEnd = -1
+                    let prevIndex = -1
+                    let progressEvents = 0
+
+                    const result = await streamAudioData(
+                        {
+                            fileUri,
+                            chunkDurationMs: opts?.chunkDurationMs ?? 250,
+                            targetSampleRate: opts?.targetSampleRate ?? 16000,
+                            channels: opts?.channels ?? 1,
+                            streamFormat: 'float32',
+                            normalizeAudio: true,
+                            maxBufferedChunks: 2,
+                            signal: controller.signal,
+                        },
+                        {
+                            onChunk: ({
+                                chunkIndex,
+                                startTimeMs,
+                                endTimeMs,
+                                sampleCount,
+                                samples,
+                                isFinal,
+                            }) => {
+                                if (chunkIndex !== prevIndex + 1) {
+                                    monotonic = false
+                                }
+                                prevIndex = chunkIndex
+                                if (startTimeMs < lastEnd) {
+                                    monotonic = false
+                                }
+                                lastEnd = endTimeMs
+                                if (chunkSummaries.length < 8) {
+                                    chunkSummaries.push({
+                                        chunkIndex,
+                                        startTimeMs,
+                                        endTimeMs,
+                                        sampleCount,
+                                        firstSample: samples[0] ?? 0,
+                                        lastSample: samples[samples.length - 1] ?? 0,
+                                        isFinal,
+                                    })
+                                }
+                                if (
+                                    opts?.cancelAfterChunks !== undefined &&
+                                    chunkIndex + 1 >= opts.cancelAfterChunks
+                                ) {
+                                    controller.abort()
+                                }
+                            },
+                            onProgress: () => {
+                                progressEvents += 1
+                            },
+                        }
+                    )
+                    _lastAsyncResult = {
+                        op,
+                        status: 'success',
+                        result: {
+                            platform: caps.platform,
+                            requestId: result.requestId,
+                            durationMs: result.durationMs,
+                            sampleRate: result.sampleRate,
+                            channels: result.channels,
+                            chunks: result.chunks,
+                            samples: result.samples,
+                            cancelled: result.cancelled,
+                            monotonic,
+                            progressEvents,
+                            firstChunks: chunkSummaries,
                         },
                     }
                 } catch (e) {

--- a/apps/playground/src/agentic/types.ts
+++ b/apps/playground/src/agentic/types.ts
@@ -1,6 +1,6 @@
 export type AgenticAsyncResult = {
     op: string
-    status: 'pending' | 'success' | 'error'
+    status: 'pending' | 'success' | 'cancelled' | 'error'
     result?: unknown
     error?: string
 }

--- a/apps/playground/src/app/(tabs)/more.tsx
+++ b/apps/playground/src/app/(tabs)/more.tsx
@@ -360,6 +360,17 @@ export const MoreScreen = () => {
                                     ...styles.listItemContainer,
                                     backgroundColor: theme.colors.errorContainer,
                                 }}
+                                label="Long Audio Validation"
+                                subLabel="Decode and transcribe staged long fixtures with live progress"
+                                onPress={() => {
+                                    router.navigate('/long-audio-validation')
+                                }}
+                            />
+                            <ListItem
+                                contentContainerStyle={{
+                                    ...styles.listItemContainer,
+                                    backgroundColor: theme.colors.errorContainer,
+                                }}
                                 label="Moonshine Live Demo"
                                 subLabel="Small live streaming with medium finalize-on-stop"
                                 onPress={() => {

--- a/apps/playground/src/app/long-audio-validation.tsx
+++ b/apps/playground/src/app/long-audio-validation.tsx
@@ -1,0 +1,441 @@
+import Constants from 'expo-constants'
+import { Redirect } from 'expo-router'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Platform, StyleSheet, TextInput, View } from 'react-native'
+import { Button, ProgressBar } from 'react-native-paper'
+
+import type { AppTheme } from '@siteed/design-system'
+import { Notice, ScreenWrapper, Text, useTheme } from '@siteed/design-system'
+import type { AsrModelConfig } from '@siteed/sherpa-onnx.rn'
+
+import {
+    cancelLongAudioValidation,
+    getLongAudioValidationProgress,
+    setAgenticPageState,
+    validateLongAudioStream,
+    type LongAudioValidationMode,
+    type LongAudioValidationProgress,
+} from '../agentic-bridge'
+
+const APP_VARIANT =
+    typeof Constants.expoConfig?.extra?.APP_VARIANT === 'string'
+        ? Constants.expoConfig.extra.APP_VARIANT
+        : 'development'
+const ANDROID_PACKAGE_NAME =
+    APP_VARIANT === 'production'
+        ? 'net.siteed.audioplayground'
+        : `net.siteed.audioplayground.${APP_VARIANT}`
+const ANDROID_STAGED_FIXTURE = `/data/user/0/${ANDROID_PACKAGE_NAME}/files/agent-fixtures/perps_controller_refactor_100m.opus`
+const WEB_SAFE_RANGE_LIMIT_MS = 5 * 60 * 1000
+
+const DEFAULT_FIXTURE_URI = Platform.select({
+    android: ANDROID_STAGED_FIXTURE,
+    default: '',
+})
+
+const DEFAULT_SHERPA_CONFIG = JSON.stringify(
+    {
+        modelDir: `/data/user/0/${ANDROID_PACKAGE_NAME}/files/sherpa-onnx/asr/qwen3-asr-0.6B-int8-2026-03-25`,
+        modelType: 'qwen3',
+        streaming: false,
+        numThreads: 4,
+        decodingMethod: 'greedy_search',
+        maxActivePaths: 4,
+        provider: 'cpu',
+        modelFiles: {
+            encoder: 'encoder.int8.onnx',
+            decoder: 'decoder.int8.onnx',
+            convFrontend: 'conv_frontend.onnx',
+            tokenizer: 'tokenizer',
+        },
+        qwen3: {
+            maxTotalLen: 512,
+            maxNewTokens: 128,
+            temperature: 0.000001,
+            topP: 0.8,
+            seed: 42,
+        },
+    },
+    null,
+    2,
+)
+
+const getStyles = (theme: AppTheme) =>
+    StyleSheet.create({
+        container: {
+            gap: theme.spacing.gap,
+            paddingHorizontal: theme.padding.s,
+            paddingBottom: theme.padding.l,
+            paddingTop: theme.padding.s,
+        },
+        section: {
+            gap: theme.spacing.gap,
+            padding: theme.padding.s,
+            borderRadius: theme.roundness,
+            backgroundColor: theme.colors.surface,
+        },
+        sectionTitle: {
+            fontSize: 18,
+            fontWeight: '700',
+            color: theme.colors.onSurface,
+        },
+        body: {
+            color: theme.colors.onSurfaceVariant,
+        },
+        input: {
+            minHeight: 48,
+            paddingHorizontal: theme.padding.s,
+            paddingVertical: theme.padding.s,
+            borderRadius: theme.roundness,
+            borderWidth: 1,
+            borderColor: theme.colors.outline,
+            color: theme.colors.onSurface,
+            backgroundColor: theme.colors.surfaceVariant,
+        },
+        row: {
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            gap: theme.spacing.gap,
+        },
+        metricCard: {
+            flexGrow: 1,
+            minWidth: 140,
+            gap: 4,
+            padding: theme.padding.s,
+            borderRadius: theme.roundness,
+            backgroundColor: theme.colors.surfaceVariant,
+        },
+        metricLabel: {
+            fontSize: 12,
+            color: theme.colors.onSurfaceVariant,
+        },
+        metricValue: {
+            fontSize: 18,
+            fontWeight: '700',
+            color: theme.colors.onSurface,
+        },
+        error: {
+            color: theme.colors.error,
+        },
+        monospace: {
+            fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
+            fontSize: 12,
+            color: theme.colors.onSurfaceVariant,
+        },
+    })
+
+function formatDuration(ms: number): string {
+    if (!Number.isFinite(ms) || ms <= 0) return 'n/a'
+    const totalSeconds = Math.round(ms / 1000)
+    const hours = Math.floor(totalSeconds / 3600)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+    const seconds = totalSeconds % 60
+    return hours > 0 ? `${hours}h ${minutes}m ${seconds}s` : `${minutes}m ${seconds}s`
+}
+
+function formatPercent(value: number): string {
+    if (!Number.isFinite(value)) return 'n/a'
+    return `${Math.max(0, Math.min(100, value * 100)).toFixed(2)}%`
+}
+
+interface ParsedRangeEnd {
+    readonly error?: string
+    readonly value?: number
+}
+
+function parseRangeEndMs(input: string): ParsedRangeEnd {
+    const trimmed = input.trim()
+    if (!trimmed) return {}
+    const value = Number.parseInt(trimmed, 10)
+    if (!Number.isFinite(value) || value <= 0) {
+        return { error: 'Range end must be a positive millisecond value' }
+    }
+    return { value }
+}
+
+interface MetricProps {
+    readonly label: string
+    readonly value: string | number
+}
+
+function Metric({ label, value }: MetricProps) {
+    const theme = useTheme()
+    const styles = useMemo(() => getStyles(theme), [theme])
+    return (
+        <View style={styles.metricCard}>
+            <Text style={styles.metricLabel}>{label}</Text>
+            <Text style={styles.metricValue}>{value}</Text>
+        </View>
+    )
+}
+
+export default function LongAudioValidationScreen() {
+    const theme = useTheme()
+    const styles = useMemo(() => getStyles(theme), [theme])
+    const [fileUri, setFileUri] = useState(DEFAULT_FIXTURE_URI ?? '')
+    const [modelId, setModelId] = useState('moonshine-small-streaming-en')
+    const [sherpaConfigJson, setSherpaConfigJson] = useState(DEFAULT_SHERPA_CONFIG)
+    const [sherpaSegmentDurationMs, setSherpaSegmentDurationMs] = useState('30000')
+    const [rangeEndMs, setRangeEndMs] = useState('')
+    const [uiError, setUiError] = useState<string | null>(null)
+    const [progress, setProgress] = useState<LongAudioValidationProgress | null>(() =>
+        getLongAudioValidationProgress(),
+    )
+    const [lastStartMode, setLastStartMode] = useState<LongAudioValidationMode>('decode-only')
+    const running = progress?.status === 'pending'
+    const error = progress?.lastError
+    const parsedRangeEnd = useMemo(() => parseRangeEndMs(rangeEndMs), [rangeEndMs])
+    const webLongRangeBlocked =
+        Platform.OS === 'web' &&
+        (!parsedRangeEnd.value || parsedRangeEnd.value > WEB_SAFE_RANGE_LIMIT_MS)
+    const startDisabled = running || !fileUri.trim() || webLongRangeBlocked
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            const next = getLongAudioValidationProgress()
+            setProgress(next)
+        }, 1000)
+        return () => clearInterval(interval)
+    }, [])
+
+    useEffect(() => {
+        setAgenticPageState({
+            route: '/long-audio-validation',
+            fileUri,
+            modelId,
+            sherpaSegmentDurationMs,
+            rangeEndMs,
+            sherpaConfigJson,
+            lastStartMode,
+            status: progress?.status ?? 'idle',
+            progress,
+            running,
+            error: error ?? uiError,
+        })
+    }, [
+        error,
+        fileUri,
+        lastStartMode,
+        modelId,
+        progress,
+        rangeEndMs,
+        running,
+        sherpaConfigJson,
+        sherpaSegmentDurationMs,
+        uiError,
+    ])
+
+    const start = useCallback(
+        (mode: LongAudioValidationMode) => {
+            if (!fileUri.trim()) return
+            let sherpaAsrConfig: AsrModelConfig | undefined
+            if (mode === 'sherpa-online' || mode === 'sherpa-offline-segments') {
+                try {
+                    sherpaAsrConfig = JSON.parse(sherpaConfigJson) as AsrModelConfig
+                    setUiError(null)
+                } catch (e) {
+                    setUiError(`Invalid Sherpa config JSON: ${String(e)}`)
+                    return
+                }
+            }
+            const parsedSherpaSegmentDurationMs =
+                Number.parseInt(sherpaSegmentDurationMs, 10) || 30_000
+            if (parsedRangeEnd.error) {
+                setUiError(parsedRangeEnd.error)
+                return
+            }
+            setLastStartMode(mode)
+            validateLongAudioStream({
+                fileUri: fileUri.trim(),
+                mode,
+                modelId: mode === 'moonshine' ? modelId.trim() : undefined,
+                moonshineFeedMode: mode === 'moonshine' ? 'typed-array' : undefined,
+                sherpaAsrConfig,
+                sherpaSegmentDurationMs: parsedSherpaSegmentDurationMs,
+                endTimeMs: parsedRangeEnd.value,
+                chunkDurationMs: 250,
+                maxBufferedChunks: 4,
+                progressEveryChunks: 40,
+            }).catch((e) => {
+                console.error('[LongAudioValidation] start failed', e)
+            })
+        },
+        [fileUri, modelId, parsedRangeEnd, sherpaConfigJson, sherpaSegmentDurationMs],
+    )
+
+    const cancel = useCallback(() => {
+        cancelLongAudioValidation('cancelled-from-long-audio-validation-ui')
+    }, [])
+
+    if (!__DEV__) {
+        return <Redirect href="/(tabs)/more" />
+    }
+
+    const progressValue =
+        progress?.progress && Number.isFinite(progress.progress)
+            ? Math.max(0, Math.min(1, progress.progress))
+            : 0
+
+    return (
+        <ScreenWrapper withScrollView useInsets={false} contentContainerStyle={styles.container}>
+            <Notice
+                type="info"
+                message="Stage the 100-minute Opus fixture first, then use this page to watch decode-only or decode + Moonshine progress from inside the app."
+            />
+            {webLongRangeBlocked ? (
+                <Notice
+                    type="warning"
+                    message="Web decoding uses AudioContext.decodeAudioData and loads the whole range into memory. Set range end to 300000 ms or less for web smoke tests; use iOS/Android for full long-audio validation."
+                />
+            ) : null}
+
+            <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Long audio validation</Text>
+                <Text style={styles.body}>
+                    The default Android fixture path follows the current Expo app variant (
+                    {APP_VARIANT}) and matches the agentic harness staging location. For iOS, paste
+                    the file:// URI staged by the validation harness, or edit this for another path.
+                </Text>
+                <TextInput
+                    testID="long-audio-fixture-uri"
+                    style={styles.input}
+                    value={fileUri}
+                    onChangeText={setFileUri}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder="file URI or absolute path"
+                    placeholderTextColor={theme.colors.onSurfaceVariant}
+                />
+                <Text style={styles.body}>
+                    Moonshine model ID (for the decode + transcription run)
+                </Text>
+                <TextInput
+                    testID="long-audio-model-id"
+                    style={styles.input}
+                    value={modelId}
+                    onChangeText={setModelId}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder="moonshine-small-streaming-en"
+                    placeholderTextColor={theme.colors.onSurfaceVariant}
+                />
+                <Text style={styles.body}>
+                    Sherpa ASR JSON config. Default follows the sherpa-voice Qwen3-ASR 0.6B int8
+                    config and runs as bounded offline segments over the streaming decoder. The safe
+                    default segment is 30 seconds; set 300000 ms to explicitly test a 5-minute
+                    segment against the full long fixture. Qwen3 releases and reinitializes Sherpa
+                    between segments by default to reduce retained native heap. Use Sherpa online
+                    only for truly streaming-capable models.
+                </Text>
+                <TextInput
+                    testID="long-audio-sherpa-config-json"
+                    style={[styles.input, { minHeight: 160, textAlignVertical: 'top' }]}
+                    value={sherpaConfigJson}
+                    onChangeText={setSherpaConfigJson}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    multiline
+                    placeholder="{ ... AsrModelConfig ... }"
+                    placeholderTextColor={theme.colors.onSurfaceVariant}
+                />
+                <Text style={styles.body}>Sherpa segment duration ms</Text>
+                <TextInput
+                    testID="long-audio-sherpa-segment-duration-ms"
+                    style={styles.input}
+                    value={sherpaSegmentDurationMs}
+                    onChangeText={setSherpaSegmentDurationMs}
+                    keyboardType="numeric"
+                    placeholder="30000"
+                    placeholderTextColor={theme.colors.onSurfaceVariant}
+                />
+                <Text style={styles.body}>
+                    Optional range end ms. Set to 300000 to benchmark just the first 5 minutes, or
+                    leave empty for the full long fixture.
+                </Text>
+                <TextInput
+                    testID="long-audio-range-end-ms"
+                    style={styles.input}
+                    value={rangeEndMs}
+                    onChangeText={setRangeEndMs}
+                    keyboardType="numeric"
+                    placeholder="empty = full fixture"
+                    placeholderTextColor={theme.colors.onSurfaceVariant}
+                />
+                <View style={styles.row}>
+                    <Button
+                        testID="long-audio-start-decode"
+                        mode="contained"
+                        disabled={startDisabled}
+                        onPress={() => start('decode-only')}
+                    >
+                        Decode only
+                    </Button>
+                    <Button
+                        testID="long-audio-start-full-decode"
+                        mode="outlined"
+                        disabled={startDisabled}
+                        onPress={() => start('full-decode')}
+                    >
+                        Full decode
+                    </Button>
+                    <Button
+                        testID="long-audio-start-moonshine"
+                        mode="contained-tonal"
+                        disabled={startDisabled}
+                        onPress={() => start('moonshine')}
+                    >
+                        Decode + Moonshine
+                    </Button>
+                    <Button
+                        testID="long-audio-start-sherpa-online"
+                        mode="contained-tonal"
+                        disabled={startDisabled || !sherpaConfigJson.trim()}
+                        onPress={() => start('sherpa-online')}
+                    >
+                        Decode + Sherpa online
+                    </Button>
+                    <Button
+                        testID="long-audio-start-sherpa-segments"
+                        mode="contained-tonal"
+                        disabled={startDisabled || !sherpaConfigJson.trim()}
+                        onPress={() => start('sherpa-offline-segments')}
+                    >
+                        Decode + Sherpa Qwen3 segments
+                    </Button>
+                    <Button
+                        testID="long-audio-cancel"
+                        mode="outlined"
+                        disabled={!running}
+                        onPress={cancel}
+                    >
+                        Cancel
+                    </Button>
+                </View>
+            </View>
+
+            <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Progress</Text>
+                <ProgressBar progress={progressValue} />
+                <View style={styles.row}>
+                    <Metric label="Status" value={progress?.status ?? 'idle'} />
+                    <Metric label="Mode" value={progress?.mode ?? lastStartMode} />
+                    <Metric label="Progress" value={formatPercent(progressValue)} />
+                    <Metric
+                        label="Processed"
+                        value={formatDuration(progress?.processedAudioMs ?? 0)}
+                    />
+                    <Metric label="Duration" value={formatDuration(progress?.durationMs ?? 0)} />
+                    <Metric label="Chunks" value={progress?.chunkCount ?? 0} />
+                    <Metric label="Samples" value={progress?.sampleCount ?? 0} />
+                    <Metric label="Sample rate" value={progress?.sampleRate ?? 0} />
+                    <Metric label="Transcript lines" value={progress?.transcriptLineCount ?? 0} />
+                    <Metric label="Transcript chars" value={progress?.transcriptCharCount ?? 0} />
+                </View>
+                {error || uiError ? <Text style={styles.error}>{error ?? uiError}</Text> : null}
+                <Text style={styles.monospace}>
+                    {JSON.stringify(progress ?? { status: 'idle' }, null, 2)}
+                </Text>
+            </View>
+        </ScreenWrapper>
+    )
+}

--- a/packages/audio-studio/CHANGELOG.md
+++ b/packages/audio-studio/CHANGELOG.md
@@ -19,6 +19,32 @@ Beta release for client validation of the progressive decode API.
   rate, channel downmix, and stable error codes via the new
   `AudioStreamError` class.
 - `getAudioDecodeCapabilities()` for platform feature discovery.
+- `validate:stream-long` physical-device harness for CDP/ADB JSONL validation
+  of long compressed files, including decode-only, full-buffer control,
+  Moonshine-feed, configurable Sherpa ONNX online-ASR, and bounded offline
+  Sherpa/Qwen3 segment modes, range-limited short-run comparisons, Android
+  memory snapshots, cancellation, stall detection, and pass/fail memory budgets.
+- `validate:stream-long` can copy a previously downloaded Sherpa model from
+  another debug app sandbox (for example `apps/sherpa-voice`) into the
+  playground sandbox via `--stage-sherpa-model-from package:path`, or stage a
+  host model directory with `--stage-sherpa-model-host-dir`, making Qwen3
+  benchmarking reproducible without re-downloading the ~GB extracted model.
+- Sherpa offline segment validation can release/reinitialize ASR between
+  segments (`--sherpa-release-between-segments`, defaulted on for Qwen3) to
+  reduce retained native heap during long segmented Qwen3 runs.
+- `summarize:stream-long` converts `validate:stream-long` JSONL logs into
+  Markdown/CSV/JSON benchmark tables for comparing decode-only, Moonshine,
+  Sherpa online, and Sherpa/Qwen3 segmented runs.
+- Long-fixture Android evidence now includes a full 100-minute Qwen3 offline
+  segment run with 30-second segments and ASR release/reinit between segments,
+  plus a Moonshine memory-budget failure path that cancels before OOM.
+- The long-fixture validation matrix now covers Opus, MP3, and AAC/M4A Android
+  decode, with MP3/AAC short Qwen3 decode/transcribe smokes against the same
+  100-minute source recording.
+- Playground `/long-audio-validation` page and agentic recipe for interactive
+  long compressed-audio validation with live progress, cancellation, Moonshine
+  model id selection, pasted Sherpa `AsrModelConfig` JSON, and a Qwen3-oriented
+  offline segment button.
 - iOS: `AVAssetReader`-based decoder with per-`requestId` cancellation.
 - Android: `MediaExtractor` + `MediaCodec` decoder with linear resampling that
   preserves continuity across codec buffer boundaries. Codec output-format
@@ -58,19 +84,22 @@ Beta release for client validation of the progressive decode API.
 - iOS `streamAudioData` no longer pays `O(n)` `Array.removeFirst` cost per
   emitted chunk; the pending buffer uses a head-index cursor with periodic
   compaction.
-- `streamAudioData` chunk timestamps are absolute (range start + offset)
+- `streamAudioData` chunk timestamps are now absolute (range start + offset)
   on Web to match iOS/Android, and `onProgress.processedMs` is elapsed time
   within the requested range on every platform so the
   `processedMs / durationMs` fraction stays in `[0, 1]` regardless of
   `startTimeMs`.
 - iOS/Android `streamAudioData` event delivery is now gated on the decoder
   still being tracked by the module. Terminal events emitted by a worker
-  thread after `OnDestroy` are dropped instead of forwarded through a
-  destroyed React context.
-- Android `streamAudioData` trims encoder pre-roll: when `SEEK_TO_CLOSEST_SYNC`
-  lands before the requested `startTimeMs`, source-rate frames whose
-  presentation time is before `startTimeMs` are dropped before resampling so
-  the first emitted sample lines up with the requested start.
+  thread after `OnDestroy` (which clears the map before cancelling) are
+  dropped instead of forwarded through a destroyed React context. This also
+  survives Expo's `definition()` re-runs because there is no one-way
+  shutdown flag.
+- Android `streamAudioData` trims encoder pre-roll: when
+  `SEEK_TO_CLOSEST_SYNC` lands before the requested `startTimeMs` (common
+  for AAC/MP3 sync-frame containers), source-rate frames whose presentation
+  time is before `startTimeMs` are dropped before resampling so the first
+  emitted sample lines up with the requested start.
 - Web `streamAudioData` clamps the `onProgress` fraction to `[0, 1]` so
   resample rounding on the tail chunk never reports `> 1`. iOS and Android
   also emit a final `onProgress` after the tail chunk for parity with the

--- a/packages/audio-studio/docs/LONG_AUDIO_BENCHMARK.md
+++ b/packages/audio-studio/docs/LONG_AUDIO_BENCHMARK.md
@@ -1,0 +1,175 @@
+# Long audio ASR benchmark
+
+Snapshot date: 2026-05-14. Default fixture:
+`.agent/fixtures/perps_controller_refactor_100m.opus`.
+
+This benchmark proves that very long compressed-audio decode + transcription can
+reach `progress=1` without crashing. It is a runtime/memory benchmark, not a
+formal WER/transcription-quality benchmark.
+
+## Comparable Android long-run results
+
+These are the only apples-to-apples performance rows today: same physical
+Android device, same Opus fixture, same harness, Android memory sampling.
+
+| Platform | Engine/model | Mode | Audio processed | Wall time | Chunks | ASR segments | Transcript chars | Peak PSS | Peak native heap | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Android physical device | Decode only | streaming decode | 1h 40m 24s | 9m 40s | 24,098 | n/a | 0 | 689.7 MB | 128.2 MB | PASS |
+| Android physical device | Moonshine `moonshine-small-streaming-en` | streaming ASR | 1h 40m 24s | 1h 57m 22s | 24,098 | n/a | 50,176 | 1,216.6 MB | 674.7 MB | PASS |
+| Android physical device | Sherpa ONNX Qwen3 | offline 30s segments, release between segments | 1h 40m 24s | 1h 44m 51s | 24,098 | 201 | 50,793 | 2,714.9 MB | 2,390.3 MB | PASS |
+
+## iOS physical-device validation rows
+
+These rows are from a physical iPhone 12. They are real device evidence
+for the iOS path, but they are not hardware-comparable with the Android rows.
+iOS memory sampling is not implemented in this harness yet.
+
+| Platform | Engine/model | Mode | Audio processed | Wall time | Chunks | Transcript chars | Peak PSS | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| iOS physical iPhone 12 | Decode only | streaming decode | 1h 42m 57s | 1m 03s | 24,098 | 0 | n/a | PASS |
+| iOS physical iPhone 12 | Moonshine `moonshine-small-streaming-en` | streaming ASR | 1h 42m 57s | 1h 31m 26s | 24,098 | 50,975 | n/a | PASS |
+
+## iOS physical Sherpa/Qwen3 checks
+
+The Qwen3 model was copied from the Android app sandbox to host
+`.agent/sherpa-models/qwen3-asr-0.6B-int8-2026-03-25`, then staged into the
+iOS app data container with `xcrun devicectl device copy to`. The harness now
+also supports host-side model staging via `--stage-sherpa-model-host-dir`.
+
+| Platform | Engine/model | Config | Audio processed | Wall time | Chunks | Segments | Transcript chars | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| iOS physical iPhone 12 | Sherpa ONNX Qwen3 | low-memory: `numThreads=1`, `maxTotalLen=256`, `maxNewTokens=64` | 5s | 4.8s | 20 | 1 | 9 | PASS |
+| iOS physical iPhone 12 | Sherpa ONNX Qwen3 | low-memory: `numThreads=1`, `maxTotalLen=256`, `maxNewTokens=64` | 30s | 7.9s | 120 | 1 | 8 | PASS |
+| iOS physical iPhone 12 | Sherpa ONNX Qwen3 | Android-like: `numThreads=4`, `maxTotalLen=512`, `maxNewTokens=128` | 30s | n/a | n/a | n/a | n/a | FAIL: app left CDP/process |
+| iOS physical iPhone 12 | Sherpa ONNX Qwen3 | low-memory: `numThreads=1`, `maxTotalLen=256`, `maxNewTokens=64` | 5m | n/a | n/a | n/a | n/a | FAIL: app left CDP/process |
+
+## iOS simulator validation rows, not comparable performance
+
+These rows prove the iOS runtime path completes and produces transcripts, but
+they should **not** be compared directly to Android timings. They run in an iOS
+simulator on the host Mac using AVFoundation and host CPU, while Android rows run
+on a physical phone through Android `MediaCodec`. iOS memory sampling is also not
+implemented in the harness.
+
+| Platform | Engine/model | Mode | Audio processed | Wall time | Chunks | Transcript chars | Peak PSS | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| iOS simulator `playground-1` | Decode only | streaming decode | 1h 42m 57s | 24.5s | 24,098 | 0 | n/a | PASS / simulator-only timing |
+| iOS simulator `playground-1` | Moonshine `moonshine-small-streaming-en` | streaming ASR | 1h 42m 57s | 28m 30s | 24,098 | 50,975 | n/a | PASS / simulator-only timing |
+
+## Android decode-only controls by format
+
+| Fixture | Audio processed | Wall time | Chunks | Peak PSS | Peak native heap | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Opus | 1h 40m 24s | 9m 40s | 24,098 | 689.7 MB | 128.2 MB | PASS |
+| MP3 | 1h 40m 24s | 3m 43s | 24,098 | 493.7 MB | 119.9 MB | PASS |
+| M4A/AAC | 1h 40m 24s | 1m 11s | 24,098 | 467.7 MB | 119.9 MB | PASS |
+
+## Short format ASR smokes
+
+These prove Opus/MP3/M4A all reach the same post-decode ASR path. Full 100m ASR
+was run on Opus; MP3/M4A are covered by full-length decode plus short ASR smoke
+because the ASR receives normalized 16 kHz mono PCM after platform decode.
+
+| Platform | Engine/model | Fixture | Audio processed | Wall time | Chunks | Segments | Transcript chars | Peak PSS | Peak native heap | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Android | Moonshine small streaming | MP3 | 30s | 8.4s | 120 | n/a | 127 | 679.0 MB | 151.8 MB | PASS |
+| Android | Moonshine small streaming | M4A/AAC | 30s | 8.0s | 121 | n/a | 136 | 668.9 MB | 153.6 MB | PASS |
+| iOS simulator | Moonshine small streaming | MP3 | 30s | 3.0s | 121 | n/a | 118 | n/a | n/a | PASS |
+| iOS simulator | Moonshine small streaming | M4A/AAC | 30s | 2.9s | 121 | n/a | 134 | n/a | n/a | PASS |
+| Android | Sherpa ONNX Qwen3 | Opus | 30s | 17s | 121 | 2 | 140 | 2,655.5 MB | 2,406.0 MB | PASS |
+| Android | Sherpa ONNX Qwen3 | MP3 | 30s | 15.5s | 120 | 1 | 144 | 487.6 MB | 146.4 MB | PASS |
+| Android | Sherpa ONNX Qwen3 | M4A/AAC | 30s | 21.5s | 121 | 2 | 145 | 475.6 MB | 144.7 MB | PASS |
+
+## Sherpa/Qwen3 scale checks on Android
+
+| Segmenting | Audio processed | Wall time | Segments | Transcript chars | Peak PSS | Peak native heap | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 30s segments, release between segments | 30s | 17s | 2 | 140 | 2,655.5 MB | 2,406.0 MB | PASS |
+| 30s segments, release between segments | 2m | 1m 38s | 5 | 921 | 1,503.2 MB | 1,245.5 MB | PASS |
+| 30s segments, release between segments | 5m | 4m 40s | 11 | 1,882 | 2,716.8 MB | 2,318.1 MB | PASS |
+| 30s segments, release between segments | 10m | 8m 30s | 21 | 2,114 | 2,652.4 MB | 2,291.6 MB | PASS |
+| 30s segments, release between segments | full 100m | 1h 44m 51s | 201 | 50,793 | 2,714.9 MB | 2,390.3 MB | PASS |
+| larger/single segment stress | 5m | n/a | n/a | n/a | n/a | n/a | FAIL: app process exited |
+
+## Interpretation
+
+- The root Moonshine VAD-retention fix is validated by full 100m Moonshine runs
+  on Android physical device, iOS physical iPhone 12, and iOS simulator.
+- Only rows within the same device class are comparable for performance today.
+  The iOS physical rows are valid real-device completion evidence, but should
+  not be read as an Android-vs-iOS hardware comparison. The iOS simulator decode
+  time remains simulator-only completion evidence.
+- Sherpa ONNX Qwen3 completes the full 100m run on Android only when using
+  bounded 30-second offline segments with release/reinitialize between segments.
+- Android Sherpa/Qwen3 was faster than Android Moonshine in the full run
+  (`1h44m51s` vs `1h57m22s`), but it used a much larger peak memory envelope
+  (`2.7 GB` PSS / `2.39 GB` native vs Moonshine `1.2 GB` PSS / `675 MB` native).
+- Android decode-only controls show that decode itself is not the long-run memory
+  problem; ASR/model lifecycle dominates memory.
+- A larger/single-segment Sherpa stress run crashed the app, so long Sherpa files
+  should use bounded segmentation today.
+- iOS Sherpa/Qwen3 is not benchmarked yet. The current Qwen3 config is Android
+  sandbox-path based, and iOS model staging for Sherpa is not wired into the
+  validation harness.
+- iOS memory sampling is not implemented in the current harness, so iOS rows only
+  prove runtime completion and wall time.
+- iOS physical fixture staging is now wired through `xcrun devicectl device copy
+  to` into the app data container, so future physical-device validation does not
+  require manual file import.
+- iOS physical Sherpa/Qwen3 is only a short-smoke PASS on the iPhone 12 today.
+  The 30s Android-like config and the 5m low-memory config both made the app
+  leave CDP and terminate. Treat Qwen3 on this 4 GB-class iPhone as not
+  long-audio-ready until we add iOS memory sampling and/or a smaller Qwen3
+  variant/quantization.
+- Transcript character counts are only sanity signals that text was produced;
+  they are not quality/WER metrics.
+
+## Evidence files
+
+Focused summary:
+
+- `.agent/validation-logs/focused-benchmark-summary-20260514T095650Z.log`
+
+Long-run evidence:
+
+- Android decode-only Opus full:
+  `.agent/validation-logs/validate-stream-long-android-decode-full-opus-focused-20260514T094620Z.jsonl`
+- iOS decode-only Opus full:
+  `.agent/validation-logs/validate-stream-long-ios-decode-full-opus-focused-20260514T094139Z.jsonl`
+- iOS physical decode-only Opus full:
+  `.agent/validation-logs/validate-stream-long-ios-physical-decode-full-20260514T110327Z.jsonl`
+- Android Moonshine Opus full:
+  `.agent/validation-logs/validate-stream-long-android-moonshine-full-vadfix-20260514T062106Z.jsonl`
+- iOS Moonshine Opus full:
+  `.agent/validation-logs/validate-stream-long-ios-moonshine-full-vadfix-20260514T085020Z.jsonl`
+- iOS physical Moonshine Opus full:
+  `.agent/validation-logs/validate-stream-long-ios-physical-moonshine-full-20260514T110606Z.jsonl`
+- Android Sherpa/Qwen3 Opus full:
+  `.agent/validation-logs/validate-stream-long-android-qwen3-full-30s-release-between-20260514T032814Z.jsonl`
+- iOS physical Sherpa/Qwen3 5s low-memory smoke:
+  `.agent/validation-logs/validate-stream-long-ios-physical-qwen3-5s-lowmem-20260514T130650Z.jsonl`
+- iOS physical Sherpa/Qwen3 30s low-memory smoke:
+  `.agent/validation-logs/validate-stream-long-ios-physical-qwen3-30s-lowmem-20260514T130822Z.jsonl`
+- iOS physical Sherpa/Qwen3 30s Android-like config failure:
+  `.agent/validation-logs/validate-stream-long-ios-physical-qwen3-30s-20260514T130309Z.jsonl`
+- iOS physical Sherpa/Qwen3 5m low-memory failure:
+  `.agent/validation-logs/validate-stream-long-ios-physical-qwen3-5m-lowmem-20260514T130953Z.jsonl`
+
+Format evidence:
+
+- Android decode-only MP3 full:
+  `.agent/validation-logs/validate-stream-long-android-decode-full-mp3-20260514T051957Z.jsonl`
+- Android decode-only M4A full:
+  `.agent/validation-logs/validate-stream-long-android-decode-full-m4a-20260514T052510Z.jsonl`
+- Android Moonshine MP3 30s:
+  `.agent/validation-logs/validate-stream-long-android-moonshine-mp3-30s-focused-20260514T094252Z.jsonl`
+- Android Moonshine M4A 30s:
+  `.agent/validation-logs/validate-stream-long-android-moonshine-m4a-30s-focused-20260514T094336Z.jsonl`
+- iOS Moonshine MP3 30s:
+  `.agent/validation-logs/validate-stream-long-ios-moonshine-mp3-30s-focused-20260514T094426Z.jsonl`
+- iOS Moonshine M4A 30s:
+  `.agent/validation-logs/validate-stream-long-ios-moonshine-m4a-30s-focused-20260514T094515Z.jsonl`
+- Android Sherpa/Qwen3 MP3 30s:
+  `.agent/validation-logs/validate-stream-long-android-qwen3-mp3-30s-20260514T052717Z.jsonl`
+- Android Sherpa/Qwen3 M4A 30s:
+  `.agent/validation-logs/validate-stream-long-android-qwen3-m4a-30s-20260514T052815Z.jsonl`

--- a/packages/audio-studio/docs/UPSTREAM_ASR_PATCHING.md
+++ b/packages/audio-studio/docs/UPSTREAM_ASR_PATCHING.md
@@ -1,0 +1,122 @@
+# Upstream ASR patching workflow
+
+This repo carries React Native integration fixes for long compressed-audio
+transcription. Keep upstream clones beside `audiolab` so fixes can be developed
+against the latest upstream branches before they are vendored or patched here.
+
+## Local upstream checkouts
+
+Expected local layout:
+
+```text
+/Volumes/c910ssd/dev/audiolab       # React Native integration + validation app
+/Volumes/c910ssd/dev/moonshine      # upstream moonshine checkout
+/Volumes/c910ssd/dev/sherpa-onnx    # upstream sherpa-onnx checkout/fork
+```
+
+Recommended remotes:
+
+```bash
+# Moonshine
+cd /Volumes/c910ssd/dev/moonshine
+git remote -v
+# origin   <your fork, if available>
+# upstream https://github.com/moonshine-ai/moonshine.git
+
+git fetch --all --prune --tags
+git checkout -B rn-long-streaming-memory-fix upstream/main
+
+# Sherpa ONNX
+cd /Volumes/c910ssd/dev/sherpa-onnx
+git remote -v
+# origin   <your fork>
+# upstream https://github.com/k2-fsa/sherpa-onnx.git
+
+git fetch --all --prune --tags
+git checkout -B rn-long-audio-asr-validation upstream/master
+```
+
+Use `GIT_LFS_SKIP_SMUDGE=1` when cloning if model artifacts or test binaries are
+not needed for the patch. Fetch LFS objects only for the specific upstream test
+that requires them.
+
+## Moonshine PR scope
+
+The current React Native validation found a long-streaming memory issue in
+Moonshine's VAD path. The fix keeps completed VAD audio only when
+`return_audio_data=true`; React Native defaults that option off unless
+`includeAudioData` is explicitly requested. The audiolab vendored patch is:
+
+```text
+packages/moonshine.rn/patches/LongStreamingMemory.patch
+```
+
+The latest-upstream PR patch prepared from the current upstream `main` branch is:
+
+```text
+.agent/upstream-pr/moonshine-main-long-streaming-memory.patch
+.agent/upstream-pr/moonshine-main-pr-draft.md
+```
+
+Opened upstream draft PR:
+
+```text
+https://github.com/moonshine-ai/moonshine/pull/175
+```
+
+Before opening the PR, verify it against the upstream checkout:
+
+```bash
+cd /Volumes/c910ssd/dev/moonshine
+git fetch upstream main
+git checkout -B rn-long-streaming-memory-fix upstream/main
+git apply --check /Volumes/c910ssd/dev/audiolab/.agent/upstream-pr/moonshine-main-long-streaming-memory.patch
+git apply /Volumes/c910ssd/dev/audiolab/.agent/upstream-pr/moonshine-main-long-streaming-memory.patch
+```
+
+The PR explanation should link back to the React Native validation evidence in
+`audiolab`, especially the Android and iOS 100-minute Opus runs, to show the
+change is driven by a reproducible integration and not an untested drive-by
+patch.
+
+## Sherpa ONNX PR scope
+
+Sherpa is used as the configurable benchmark path for higher-quality ASR models
+such as Qwen3. Current audiolab validation intentionally keeps the model config
+externalized:
+
+```text
+packages/audio-studio/scripts/qwen3-asr-playground-config.json
+packages/audio-studio/scripts/validate-stream-long.mjs
+```
+
+The likely upstream Sherpa/RN improvements to prepare as separate PRs are:
+
+1. Add a typed-array/JSI-friendly RN `acceptWaveform` path so long streaming
+   benchmarks do not require converting every Float32 chunk to a JS `number[]`.
+2. Document or expose memory-safe segmented offline recognition patterns for
+   very long files, including explicit release/reinitialize behavior between
+   segments for large models.
+3. Keep model selection configurable; do not hardcode Zipformer when the
+   validation target is a stronger model such as Qwen3.
+
+Prepare Sherpa patches from `/Volumes/c910ssd/dev/sherpa-onnx` on a branch based
+on `upstream/master`, then mirror the validation command and evidence path in the
+PR body.
+
+## Validation evidence to attach
+
+Long-audio evidence is stored under:
+
+```text
+/Volumes/c910ssd/dev/audiolab/.agent/validation-logs/
+```
+
+Minimum evidence before filing upstream PRs:
+
+- Android full Moonshine 100-minute Opus success log: `.agent/validation-logs/validate-stream-long-android-moonshine-full-vadfix-20260514T062106Z.jsonl`.
+- iOS full Moonshine 100-minute Opus success log: `.agent/validation-logs/validate-stream-long-ios-moonshine-full-vadfix-20260514T085020Z.jsonl`.
+- `git diff --check` and relevant workspace typechecks.
+- Patch application check against the latest upstream branch.
+- If touching Sherpa, Qwen3 segmented benchmark logs with the exact config file
+  used.

--- a/packages/audio-studio/package.json
+++ b/packages/audio-studio/package.json
@@ -100,7 +100,13 @@
         "release": "./publish.sh",
         "agent:test:unit": "yarn test:android:unit",
         "agent:test:integration": "yarn test:android:instrumented",
-        "agent:compilation:check": "yarn typecheck && yarn build"
+        "agent:compilation:check": "yarn typecheck && yarn build",
+        "android": "cd ../../apps/playground && yarn android",
+        "android:launch": "cd ../../apps/playground && yarn android:launch",
+        "validate:stream-long": "node scripts/validate-stream-long.mjs",
+        "android:device": "cd ../../apps/playground && yarn android:device",
+        "android:device:launch": "cd ../../apps/playground && yarn android:device:launch",
+        "summarize:stream-long": "node scripts/summarize-stream-long.mjs"
     },
     "devDependencies": {
         "@expo/config-plugins": "~54.0.0",

--- a/packages/audio-studio/scripts/qwen3-asr-playground-config.json
+++ b/packages/audio-studio/scripts/qwen3-asr-playground-config.json
@@ -1,0 +1,22 @@
+{
+  "modelDir": "/data/user/0/${ANDROID_PACKAGE_NAME}/files/sherpa-onnx/asr/qwen3-asr-0.6B-int8-2026-03-25",
+  "modelType": "qwen3",
+  "streaming": false,
+  "numThreads": 4,
+  "decodingMethod": "greedy_search",
+  "maxActivePaths": 4,
+  "provider": "cpu",
+  "modelFiles": {
+    "encoder": "encoder.int8.onnx",
+    "decoder": "decoder.int8.onnx",
+    "convFrontend": "conv_frontend.onnx",
+    "tokenizer": "tokenizer"
+  },
+  "qwen3": {
+    "maxTotalLen": 512,
+    "maxNewTokens": 128,
+    "temperature": 1e-06,
+    "topP": 0.8,
+    "seed": 42
+  }
+}

--- a/packages/audio-studio/scripts/summarize-stream-long.mjs
+++ b/packages/audio-studio/scripts/summarize-stream-long.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+function parseArgs(argv) {
+    const out = { format: 'markdown', files: [] }
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i]
+        if (arg === '--json') out.format = 'json'
+        else if (arg === '--csv') out.format = 'csv'
+        else if (arg === '--markdown' || arg === '--md') out.format = 'markdown'
+        else if (arg === '--help' || arg === '-h') {
+            printHelp()
+            process.exit(0)
+        } else {
+            out.files.push(arg)
+        }
+    }
+    if (out.files.length === 0) {
+        throw new Error('Provide one or more validate:stream-long JSONL log files')
+    }
+    return out
+}
+
+function printHelp() {
+    console.log(`Usage: yarn summarize:stream-long [--markdown|--csv|--json] <log.jsonl> [...logs]
+
+Summarizes validate:stream-long JSONL logs for backend benchmarking.
+Reports final status, processed audio, wall time, chunks, transcript size,
+Sherpa segment count, peak memory, final memory, and error/stall reason.`)
+}
+
+function readJsonl(file) {
+    return fs
+        .readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line, index) => {
+            try {
+                return JSON.parse(line)
+            } catch (error) {
+                throw new Error(`${file}:${index + 1}: ${String(error)}`)
+            }
+        })
+}
+
+function maxNumber(values) {
+    const finite = values.filter((value) => Number.isFinite(value))
+    return finite.length ? Math.max(...finite) : undefined
+}
+
+function getMemoryEvents(events) {
+    return events
+        .map((event) => event.memory)
+        .filter((memory) => memory && typeof memory === 'object')
+}
+
+function summarize(file) {
+    const events = readJsonl(file)
+    const start = events.find((event) => event.event === 'start')
+    const final = [...events].reverse().find((event) => event.event === 'final')
+    const error = [...events].reverse().find((event) => event.event === 'error')
+    const budgetExceeded = [...events]
+        .reverse()
+        .find((event) => event.event === 'budget-exceeded')
+    const stalled = [...events]
+        .reverse()
+        .find((event) => event.event === 'progress-stalled')
+    const terminal = final?.result?.result ?? final?.result ?? null
+    const progressEvents = events.filter((event) => event.progress)
+    const lastProgress = [...progressEvents].reverse()[0]?.progress
+    const progress = terminal ?? lastProgress ?? {}
+    const memoryEvents = getMemoryEvents(events)
+    const finalMemory = final?.memory ?? [...memoryEvents].reverse()[0] ?? {}
+    const peakTotalPssKb = maxNumber(memoryEvents.map((m) => m.totalPssKb))
+    const peakNativeHeapKb = maxNumber(memoryEvents.map((m) => m.nativeHeapKb))
+    const startedAt = start?.at ? Date.parse(start.at) : undefined
+    const endedAt = (final ?? error ?? stalled ?? budgetExceeded)?.at
+        ? Date.parse((final ?? error ?? stalled ?? budgetExceeded).at)
+        : undefined
+    const wallMsFromLog =
+        Number.isFinite(startedAt) && Number.isFinite(endedAt)
+            ? endedAt - startedAt
+            : undefined
+
+    return {
+        file,
+        name: path.basename(file),
+        status: final?.result?.status ?? error?.event ?? stalled?.event ?? budgetExceeded?.event ?? progress.status ?? 'unknown',
+        mode: start?.mode ?? progress.mode,
+        modelId: progress.modelId,
+        fixture: start?.fixture,
+        startTimeMs: start?.startTimeMs,
+        endTimeMs: start?.endTimeMs,
+        durationMs: progress.durationMs ?? progress.audio?.durationMs,
+        processedAudioMs: progress.processedAudioMs,
+        progress: progress.progress,
+        chunks: progress.chunkCount ?? progress.audio?.chunks,
+        samples: progress.sampleCount ?? progress.audio?.samples,
+        sampleRate: progress.sampleRate ?? progress.audio?.sampleRate,
+        transcriptChars:
+            progress.transcriptCharCount ?? progress.sherpa?.transcriptCharCount,
+        transcriptLines: progress.transcriptLineCount,
+        transcriptEvents: progress.transcriptEventCount,
+        sherpaSegmentCount: progress.sherpaSegmentCount,
+        sherpaReleaseBetweenSegments: progress.sherpaReleaseBetweenSegments,
+        elapsedWallMs: progress.elapsedWallMs ?? wallMsFromLog,
+        logWallMs: wallMsFromLog,
+        peakTotalPssKb,
+        peakNativeHeapKb,
+        finalTotalPssKb: finalMemory.totalPssKb,
+        finalNativeHeapKb: finalMemory.nativeHeapKb,
+        error: error?.error ?? stalled?.reason ?? budgetExceeded?.reason,
+    }
+}
+
+function formatMs(ms) {
+    if (!Number.isFinite(ms)) return ''
+    if (ms < 1000) return `${ms}ms`
+    const seconds = ms / 1000
+    if (seconds < 60) return `${seconds.toFixed(1)}s`
+    const minutes = Math.floor(seconds / 60)
+    const rest = Math.round(seconds % 60)
+    return `${minutes}m${String(rest).padStart(2, '0')}s`
+}
+
+function formatKb(kb) {
+    if (!Number.isFinite(kb)) return ''
+    return `${(kb / 1024).toFixed(1)}MB`
+}
+
+function formatPercent(value) {
+    if (!Number.isFinite(value)) return ''
+    return `${(value * 100).toFixed(1)}%`
+}
+
+function markdown(rows) {
+    const headers = [
+        'log',
+        'status',
+        'mode',
+        'model',
+        'audio',
+        'wall',
+        'chunks',
+        'segments',
+        'chars',
+        'peak PSS',
+        'peak native',
+        'final PSS',
+        'error',
+    ]
+    const lines = [
+        `| ${headers.join(' | ')} |`,
+        `| ${headers.map(() => '---').join(' | ')} |`,
+    ]
+    for (const row of rows) {
+        lines.push(
+            `| ${[
+                row.name,
+                row.status,
+                row.mode ?? '',
+                row.modelId ?? '',
+                formatMs(row.durationMs ?? row.processedAudioMs),
+                formatMs(row.elapsedWallMs ?? row.logWallMs),
+                row.chunks ?? '',
+                row.sherpaSegmentCount ?? '',
+                row.transcriptChars ?? '',
+                formatKb(row.peakTotalPssKb),
+                formatKb(row.peakNativeHeapKb),
+                formatKb(row.finalTotalPssKb),
+                row.error ?? '',
+            ]
+                .map((cell) => String(cell).replace(/\|/g, '\\|'))
+                .join(' | ')} |`,
+        )
+    }
+    return lines.join('\n')
+}
+
+function csv(rows) {
+    const headers = Object.keys(rows[0] ?? {})
+    const escape = (value) => {
+        const string = value == null ? '' : String(value)
+        return /[",\n]/.test(string) ? `"${string.replace(/"/g, '""')}"` : string
+    }
+    return [headers.join(','), ...rows.map((row) => headers.map((key) => escape(row[key])).join(','))].join('\n')
+}
+
+try {
+    const options = parseArgs(process.argv.slice(2))
+    const rows = options.files.map(summarize)
+    if (options.format === 'json') console.log(JSON.stringify(rows, null, 2))
+    else if (options.format === 'csv') console.log(csv(rows))
+    else console.log(markdown(rows))
+} catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+}

--- a/packages/audio-studio/scripts/validate-stream-long.mjs
+++ b/packages/audio-studio/scripts/validate-stream-long.mjs
@@ -1,0 +1,990 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const PACKAGE_ROOT = path.resolve(SCRIPT_DIR, '..')
+const REPO_ROOT = path.resolve(PACKAGE_ROOT, '..', '..')
+const APP_ROOT = path.join(REPO_ROOT, 'apps', 'playground')
+const BRIDGE = path.join(APP_ROOT, 'scripts', 'agentic', 'cdp-bridge.mjs')
+const DEFAULT_FIXTURE = path.join(
+    REPO_ROOT,
+    '.agent',
+    'fixtures',
+    'perps_controller_refactor_100m.opus'
+)
+const APP_VARIANT = process.env.APP_VARIANT || 'development'
+const PACKAGE_NAME =
+    APP_VARIANT === 'production'
+        ? 'net.siteed.audioplayground'
+        : `net.siteed.audioplayground.${APP_VARIANT}`
+const SERIAL = process.env.ANDROID_SERIAL || process.env.ADB_SERIAL || ''
+let TARGET_DEVICE =
+    process.env.AGENTIC_DEVICE || process.env.BENCHMARK_DEVICE || ''
+let TARGET_PLATFORM = process.env.LONG_AUDIO_PLATFORM || 'android'
+const POLL_INTERVAL_MS = Number.parseInt(
+    process.env.POLL_INTERVAL_MS || '5000',
+    10
+)
+const TIMEOUT_MS = Number.parseInt(
+    process.env.LONG_AUDIO_TIMEOUT_MS || String(45 * 60 * 1000),
+    10
+)
+const DEFAULT_STALL_TIMEOUT_MS = Number.parseInt(
+    process.env.LONG_AUDIO_STALL_TIMEOUT_MS || String(5 * 60 * 1000),
+    10
+)
+const HEARTBEAT_INTERVAL_MS = Number.parseInt(
+    process.env.LONG_AUDIO_HEARTBEAT_MS || String(30 * 1000),
+    10
+)
+const BRIDGE_GRACE_MS = Number.parseInt(
+    process.env.LONG_AUDIO_BRIDGE_GRACE_MS || String(30 * 1000),
+    10
+)
+
+function parseArgs(argv) {
+    const out = {
+        mode: 'decode-only',
+        fixture: process.env.AUDIO_FIXTURE || DEFAULT_FIXTURE,
+        modelId:
+            process.env.MOONSHINE_MODEL_ID || 'moonshine-small-streaming-en',
+        sherpaConfig: process.env.SHERPA_ASR_CONFIG_JSON
+            ? parseSherpaConfig(process.env.SHERPA_ASR_CONFIG_JSON)
+            : undefined,
+        sherpaModelSource: process.env.SHERPA_MODEL_SOURCE,
+        sherpaModelHostDir: process.env.SHERPA_MODEL_HOST_DIR,
+        sherpaModelTargetDir: process.env.SHERPA_MODEL_TARGET_DIR,
+        sherpaReleaseBetweenSegments:
+            process.env.SHERPA_RELEASE_BETWEEN_SEGMENTS !== undefined
+                ? process.env.SHERPA_RELEASE_BETWEEN_SEGMENTS !== '0' &&
+                  process.env.SHERPA_RELEASE_BETWEEN_SEGMENTS !== 'false'
+                : undefined,
+        moonshineFeedMode: process.env.MOONSHINE_FEED_MODE || 'typed-array',
+        startTimeMs: process.env.START_TIME_MS
+            ? Number.parseInt(process.env.START_TIME_MS, 10)
+            : undefined,
+        endTimeMs: process.env.END_TIME_MS
+            ? Number.parseInt(process.env.END_TIME_MS, 10)
+            : undefined,
+        chunkDurationMs: Number.parseInt(
+            process.env.CHUNK_DURATION_MS || '250',
+            10
+        ),
+        maxBufferedChunks: Number.parseInt(
+            process.env.MAX_BUFFERED_CHUNKS || '4',
+            10
+        ),
+        progressEveryChunks: Number.parseInt(
+            process.env.PROGRESS_EVERY_CHUNKS || '40',
+            10
+        ),
+        sherpaSegmentDurationMs: Number.parseInt(
+            process.env.SHERPA_SEGMENT_DURATION_MS || '30000',
+            10
+        ),
+        cancelAfterChunks: process.env.CANCEL_AFTER_CHUNKS
+            ? Number.parseInt(process.env.CANCEL_AFTER_CHUNKS, 10)
+            : undefined,
+        maxPssKb: process.env.MAX_PSS_KB
+            ? Number.parseInt(process.env.MAX_PSS_KB, 10)
+            : undefined,
+        maxNativeHeapKb: process.env.MAX_NATIVE_HEAP_KB
+            ? Number.parseInt(process.env.MAX_NATIVE_HEAP_KB, 10)
+            : undefined,
+        stallTimeoutMs: DEFAULT_STALL_TIMEOUT_MS,
+        device: TARGET_DEVICE,
+        platform: TARGET_PLATFORM,
+    }
+
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i]
+        if (arg === '--decode-only') out.mode = 'decode-only'
+        else if (arg === '--full-decode') out.mode = 'full-decode'
+        else if (arg === '--moonshine') out.mode = 'moonshine'
+        else if (arg === '--sherpa-online') out.mode = 'sherpa-online'
+        else if (arg === '--sherpa-offline-segments')
+            out.mode = 'sherpa-offline-segments'
+        else if (arg === '--fixture') out.fixture = argv[++i]
+        else if (arg === '--model-id') out.modelId = argv[++i]
+        else if (arg === '--sherpa-config') {
+            const value = argv[++i]
+            out.sherpaConfig = parseSherpaConfig(value)
+        } else if (arg === '--stage-sherpa-model-from')
+            out.sherpaModelSource = argv[++i]
+        else if (arg === '--stage-sherpa-model-host-dir')
+            out.sherpaModelHostDir = argv[++i]
+        else if (arg === '--stage-sherpa-model-to')
+            out.sherpaModelTargetDir = argv[++i]
+        else if (arg === '--sherpa-release-between-segments')
+            out.sherpaReleaseBetweenSegments = true
+        else if (arg === '--no-sherpa-release-between-segments')
+            out.sherpaReleaseBetweenSegments = false
+        else if (arg === '--feed') out.moonshineFeedMode = argv[++i]
+        else if (arg === '--start-ms')
+            out.startTimeMs = Number.parseInt(argv[++i], 10)
+        else if (arg === '--end-ms')
+            out.endTimeMs = Number.parseInt(argv[++i], 10)
+        else if (arg === '--limit-ms') {
+            const limitMs = Number.parseInt(argv[++i], 10)
+            out.endTimeMs = (out.startTimeMs || 0) + limitMs
+        } else if (arg === '--chunk-duration-ms')
+            out.chunkDurationMs = Number.parseInt(argv[++i], 10)
+        else if (arg === '--max-buffered-chunks')
+            out.maxBufferedChunks = Number.parseInt(argv[++i], 10)
+        else if (arg === '--progress-every-chunks')
+            out.progressEveryChunks = Number.parseInt(argv[++i], 10)
+        else if (arg === '--sherpa-segment-duration-ms')
+            out.sherpaSegmentDurationMs = Number.parseInt(argv[++i], 10)
+        else if (arg === '--cancel-after-chunks')
+            out.cancelAfterChunks = Number.parseInt(argv[++i], 10)
+        else if (arg === '--max-pss-kb')
+            out.maxPssKb = Number.parseInt(argv[++i], 10)
+        else if (arg === '--max-native-heap-kb')
+            out.maxNativeHeapKb = Number.parseInt(argv[++i], 10)
+        else if (arg === '--stall-timeout-ms')
+            out.stallTimeoutMs = Number.parseInt(argv[++i], 10)
+        else if (arg === '--device') out.device = argv[++i]
+        else if (arg === '--platform') out.platform = argv[++i]
+        else if (arg === '--help' || arg === '-h') {
+            printHelp()
+            process.exit(0)
+        } else {
+            throw new Error(`Unknown argument: ${arg}`)
+        }
+    }
+    return out
+}
+
+function printHelp() {
+    console.log(
+        `Usage: yarn validate:stream-long [--decode-only|--full-decode|--moonshine|--sherpa-online|--sherpa-offline-segments] [options]\n\nOptions:\n  --fixture <path>               Host audio fixture path (default AUDIO_FIXTURE or repo 100m opus)\n  --model-id <id>                Moonshine model id (default moonshine-small-streaming-en)\n  --sherpa-config <json|path>    Sherpa AsrModelConfig JSON or path\n  --stage-sherpa-model-from <package:path>\n                                Copy a downloaded Sherpa model dir from another debug app sandbox\n  --stage-sherpa-model-host-dir <path>\n                                Copy a Sherpa model dir from host into the target app sandbox\n  --stage-sherpa-model-to <path> Destination modelDir (default: sherpa-config.modelDir)\n  --sherpa-segment-duration-ms <n> Segment length for --sherpa-offline-segments (default 30000)\n  --sherpa-release-between-segments / --no-sherpa-release-between-segments\n                                Release/reinitialize offline ASR after each segment (default: true for Qwen3)\n  --feed <typed-array|array-copy> Moonshine feed mode (default typed-array)\n  --start-ms <n>                 Decode/transcribe range start in ms (default 0)\n  --end-ms <n>                   Decode/transcribe range end in ms (default EOF)\n  --limit-ms <n>                 Range length from --start-ms/0, e.g. 300000 for 5 min\n  --chunk-duration-ms <n>        Decode chunk size in ms (default 250)\n  --max-buffered-chunks <n>      Native backpressure window (default 4)\n  --progress-every-chunks <n>    App-side progress update cadence (default 40)\n  --cancel-after-chunks <n>      Cancel early after n chunks (smoke-tests cancellation)\n  --max-pss-kb <n>               Cancel and fail if TOTAL PSS exceeds this budget\n  --max-native-heap-kb <n>       Cancel and fail if Native Heap exceeds this budget\n  --stall-timeout-ms <n>         Cancel and fail if chunk progress stalls (default 300000)\n  --platform <android|ios|auto>  Target app platform (default LONG_AUDIO_PLATFORM or android)\n  --device <name>                Agentic device name substring (default AGENTIC_DEVICE/BENCHMARK_DEVICE)\n\nEnvironment:\n  AUDIO_FIXTURE, ANDROID_SERIAL/ADB_SERIAL, AGENTIC_DEVICE, BENCHMARK_DEVICE,\n  IOS_DEVICE_UDID, APP_VARIANT,\n  LONG_AUDIO_PLATFORM, LONG_AUDIO_TIMEOUT_MS, LONG_AUDIO_STALL_TIMEOUT_MS,\n  LONG_AUDIO_HEARTBEAT_MS, LONG_AUDIO_BRIDGE_GRACE_MS, POLL_INTERVAL_MS,\n  MOONSHINE_MODEL_ID, MOONSHINE_FEED_MODE, SHERPA_ASR_CONFIG_JSON,\n  SHERPA_SEGMENT_DURATION_MS, SHERPA_MODEL_SOURCE, SHERPA_MODEL_HOST_DIR,\n  SHERPA_MODEL_TARGET_DIR, SHERPA_RELEASE_BETWEEN_SEGMENTS, START_TIME_MS,\n  END_TIME_MS, CHUNK_DURATION_MS, MAX_BUFFERED_CHUNKS,\n  PROGRESS_EVERY_CHUNKS, CANCEL_AFTER_CHUNKS, MAX_PSS_KB, MAX_NATIVE_HEAP_KB\n`
+    )
+}
+
+function run(
+    command,
+    args,
+    { cwd = REPO_ROOT, parseJson = false, maxBuffer = 50 * 1024 * 1024 } = {}
+) {
+    const result = spawnSync(command, args, {
+        cwd,
+        encoding: 'utf8',
+        env: { ...process.env, APP_ROOT },
+        maxBuffer,
+    })
+    if (result.status !== 0) {
+        const output = [result.stdout, result.stderr]
+            .filter(Boolean)
+            .join('\n')
+            .trim()
+        throw new Error(output || `${command} ${args.join(' ')} failed`)
+    }
+    const stdout = (result.stdout || '').trim()
+    return parseJson ? (stdout ? JSON.parse(stdout) : null) : stdout
+}
+
+function adb(args) {
+    return run('adb', SERIAL ? ['-s', SERIAL, ...args] : args)
+}
+
+function shellQuote(value) {
+    return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+function bridge(args, parseJson = true) {
+    return run(
+        'node',
+        [
+            BRIDGE,
+            ...(TARGET_DEVICE ? ['--device', TARGET_DEVICE] : []),
+            ...args,
+        ],
+        {
+            cwd: APP_ROOT,
+            parseJson,
+        }
+    )
+}
+
+function expandConfigPlaceholders(value) {
+    if (typeof value === 'string') {
+        return value
+            .replaceAll('${ANDROID_PACKAGE_NAME}', PACKAGE_NAME)
+            .replaceAll('${APP_VARIANT}', APP_VARIANT)
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => expandConfigPlaceholders(item))
+    }
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, entry]) => [
+                key,
+                expandConfigPlaceholders(entry),
+            ])
+        )
+    }
+    return value
+}
+
+function parseSherpaConfig(value) {
+    const maybePath = path.isAbsolute(value)
+        ? value
+        : path.resolve(process.cwd(), value)
+    const raw = fs.existsSync(maybePath)
+        ? fs.readFileSync(maybePath, 'utf8')
+        : value
+    return expandConfigPlaceholders(JSON.parse(raw))
+}
+
+function normalizeDevices(devicesPayload) {
+    if (Array.isArray(devicesPayload)) return devicesPayload
+    if (Array.isArray(devicesPayload?.devices)) return devicesPayload.devices
+    return []
+}
+
+function selectTargetDevice(devicesPayload, options) {
+    const devices = normalizeDevices(devicesPayload)
+    const requestedPlatform = (options.platform || 'android').toLowerCase()
+    const requestedDevice = options.device?.toLowerCase()
+    let candidates = devices
+
+    if (requestedPlatform !== 'auto') {
+        candidates = candidates.filter(
+            (device) => device.platform === requestedPlatform
+        )
+    }
+    if (requestedDevice) {
+        candidates = candidates.filter((device) =>
+            String(device.name || '')
+                .toLowerCase()
+                .includes(requestedDevice)
+        )
+    }
+
+    if (candidates.length !== 1) {
+        const available = devices
+            .map(
+                (device) =>
+                    `${device.name} (${device.platform}/${device.targetType || 'unknown'})`
+            )
+            .join(', ')
+        throw new Error(
+            `Expected exactly one target device for platform=${requestedPlatform} device=${
+                options.device || '(auto)'
+            }, found ${candidates.length}. Available: ${available || '(none)'}`
+        )
+    }
+
+    const selected = candidates[0]
+    TARGET_DEVICE = options.device || toBridgeDeviceName(selected)
+    TARGET_PLATFORM = selected.platform
+    return selected
+}
+
+function toBridgeDeviceName(device) {
+    const name = String(device.name || '')
+    if (name.startsWith('sim:')) return name.slice('sim:'.length)
+    if (name.startsWith('device:')) {
+        return name.slice('device:'.length).split(/[’']/)[0].trim()
+    }
+    return name
+}
+
+function emit(event, payload = {}) {
+    console.log(
+        JSON.stringify({ event, at: new Date().toISOString(), ...payload })
+    )
+}
+
+function resolveFixture(inputPath) {
+    if (path.isAbsolute(inputPath)) {
+        return inputPath
+    }
+    const cwdPath = path.resolve(process.cwd(), inputPath)
+    if (fs.existsSync(cwdPath)) {
+        return cwdPath
+    }
+    return path.resolve(REPO_ROOT, inputPath)
+}
+
+function stageFixture(hostPath) {
+    if (!fs.existsSync(hostPath)) {
+        throw new Error(`Fixture not found: ${hostPath}`)
+    }
+    const basename = path.basename(hostPath).replace(/[^a-zA-Z0-9._-]/g, '_')
+    const devicePath = `/data/user/0/${PACKAGE_NAME}/files/agent-fixtures/${basename}`
+    adb([
+        'shell',
+        `run-as ${PACKAGE_NAME} sh -c ${shellQuote(`mkdir -p ${path.posix.dirname(devicePath)} && rm -f ${devicePath}`)}`,
+    ])
+    run('bash', [
+        '-lc',
+        `cat ${shellQuote(hostPath)} | ${SERIAL ? `adb -s ${shellQuote(SERIAL)}` : 'adb'} shell ${shellQuote(`run-as ${PACKAGE_NAME} sh -c 'cat > ${devicePath}'`)}`,
+    ])
+    const size = Number(
+        adb([
+            'shell',
+            `run-as ${PACKAGE_NAME} sh -c ${shellQuote(`wc -c < ${devicePath} 2>/dev/null || echo 0`)}`,
+        ]).trim() || '0'
+    )
+    if (size <= 0) {
+        throw new Error(`Failed to stage fixture to ${devicePath}`)
+    }
+    return { devicePath, size }
+}
+
+function getBootedSimulatorUdid(deviceName) {
+    const wanted = String(deviceName || '')
+        .replace(/^sim:/, '')
+        .toLowerCase()
+    const payload = run(
+        'xcrun',
+        ['simctl', 'list', 'devices', 'booted', '-j'],
+        {
+            parseJson: true,
+        }
+    )
+    const booted = Object.values(payload.devices || {})
+        .flat()
+        .filter((device) => device.state === 'Booted')
+    const matches = wanted
+        ? booted.filter(
+              (device) =>
+                  device.udid.toLowerCase() === wanted ||
+                  device.name.toLowerCase() === wanted ||
+                  device.name.toLowerCase().includes(wanted)
+          )
+        : booted
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected one booted simulator for ${deviceName}, found ${matches.length}: ${booted
+                .map((device) => `${device.name}:${device.udid}`)
+                .join(', ')}`
+        )
+    }
+    return matches[0].udid
+}
+
+function stageFixtureIOSSimulator(hostPath, selectedDevice) {
+    if (!fs.existsSync(hostPath)) {
+        throw new Error(`Fixture not found: ${hostPath}`)
+    }
+    if (selectedDevice.targetType !== 'simulator') {
+        throw new Error(
+            'iOS physical fixture staging is not implemented; use an iOS simulator or Android device'
+        )
+    }
+    const udid = getBootedSimulatorUdid(selectedDevice.name)
+    const container = run('xcrun', [
+        'simctl',
+        'get_app_container',
+        udid,
+        PACKAGE_NAME,
+        'data',
+    ]).trim()
+    const basename = path.basename(hostPath).replace(/[^a-zA-Z0-9._-]/g, '_')
+    const targetDir = path.join(container, 'Documents', 'agent-fixtures')
+    const targetPath = path.join(targetDir, basename)
+    fs.mkdirSync(targetDir, { recursive: true })
+    fs.copyFileSync(hostPath, targetPath)
+    const size = fs.statSync(targetPath).size
+    if (size <= 0) {
+        throw new Error(`Failed to stage fixture to ${targetPath}`)
+    }
+    return {
+        devicePath: `file://${targetPath}`,
+        size,
+        simulatorUdid: udid,
+        container,
+    }
+}
+
+function findIOSPhysicalDeviceIdentifier(selectedDevice) {
+    if (process.env.IOS_DEVICE_UDID) return process.env.IOS_DEVICE_UDID
+
+    const wantedName = String(selectedDevice?.name || '')
+        .replace(/^device:/, '')
+        .replace(/^ios:/, '')
+        .trim()
+    const output = run('xcrun', ['devicectl', 'list', 'devices', '-v'])
+    const blocks = output.split(/(?=▿ .+ - [0-9A-F]{8}-)/)
+    const physicalDevices = blocks
+        .filter((block) => block.includes('physical'))
+        .map((block) => ({
+            block,
+            name:
+                block.match(/name: Optional\("([^"]+)"\)/)?.[1] ||
+                block.match(/marketingName: Optional\("([^"]+)"\)/)?.[1] ||
+                '',
+            udid: block.match(/udid: Optional\("([^"]+)"\)/)?.[1] || '',
+            identifier:
+                block.match(/identifier: ([0-9A-F-]+)/)?.[1] ||
+                block.match(/^▿ .+ - ([0-9A-F-]+)/m)?.[1] ||
+                '',
+        }))
+        .filter((device) => device.udid || device.identifier)
+
+    const normalizedWanted = wantedName.toLowerCase()
+    const matches = normalizedWanted
+        ? physicalDevices.filter((device) => {
+              const normalizedName = device.name.toLowerCase()
+              return (
+                  normalizedName === normalizedWanted ||
+                  normalizedName.includes(normalizedWanted) ||
+                  normalizedWanted.includes(normalizedName)
+              )
+          })
+        : physicalDevices
+
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected one iOS physical device for ${wantedName || '(auto)'}, found ${
+                matches.length
+            }. Available: ${physicalDevices
+                .map(
+                    (device) =>
+                        `${device.name || '(unnamed)'}:${device.udid || device.identifier}`
+                )
+                .join(', ')}`
+        )
+    }
+
+    return matches[0].udid || matches[0].identifier
+}
+
+function stageFixtureIOSPhysical(hostPath, selectedDevice) {
+    if (!fs.existsSync(hostPath)) {
+        throw new Error(`Fixture not found: ${hostPath}`)
+    }
+
+    const deviceIdentifier = findIOSPhysicalDeviceIdentifier(selectedDevice)
+    const basename = path.basename(hostPath).replace(/[^a-zA-Z0-9._-]/g, '_')
+    const relativePath = `agent-fixtures/${basename}`
+    const destination = `Documents/${relativePath}`
+    const output = run('xcrun', [
+        'devicectl',
+        'device',
+        'copy',
+        'to',
+        '--device',
+        deviceIdentifier,
+        '--domain-type',
+        'appDataContainer',
+        '--domain-identifier',
+        PACKAGE_NAME,
+        '--source',
+        hostPath,
+        '--destination',
+        destination,
+        '--remove-existing-content',
+        'false',
+    ])
+    const targetPath =
+        output.match(/^Path: (.+)$/m)?.[1]?.trim() ||
+        output.match(/Path:\s+(.+)$/m)?.[1]?.trim()
+    const size = fs.statSync(hostPath).size
+    if (!targetPath || size <= 0) {
+        throw new Error(
+            `Failed to stage iOS physical fixture to ${destination}; devicectl output: ${output}`
+        )
+    }
+
+    return {
+        devicePath: `file://${targetPath}`,
+        size,
+        iosDeviceIdentifier: deviceIdentifier,
+        relativePath,
+    }
+}
+
+function stageFixtureForTarget(hostPath, selectedDevice) {
+    if (selectedDevice.platform === 'android') {
+        return stageFixture(hostPath)
+    }
+    if (selectedDevice.platform === 'ios') {
+        return selectedDevice.targetType === 'physical'
+            ? stageFixtureIOSPhysical(hostPath, selectedDevice)
+            : stageFixtureIOSSimulator(hostPath, selectedDevice)
+    }
+    throw new Error(
+        `Unsupported platform for fixture staging: ${selectedDevice.platform}`
+    )
+}
+
+function parsePackagePath(value) {
+    const separator = value?.indexOf(':') ?? -1
+    if (!value || separator <= 0 || separator === value.length - 1) {
+        throw new Error(
+            `Expected package:path for --stage-sherpa-model-from, got ${value}`
+        )
+    }
+    const packageName = value.slice(0, separator)
+    if (!/^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(packageName)) {
+        throw new Error(
+            `Invalid Android package name for --stage-sherpa-model-from: ${packageName}`
+        )
+    }
+    return {
+        packageName,
+        path: value.slice(separator + 1),
+    }
+}
+
+function toRunAsPath(packageName, inputPath) {
+    const dataPrefix = `/data/user/0/${packageName}/`
+    return inputPath.startsWith(dataPrefix)
+        ? inputPath.slice(dataPrefix.length)
+        : inputPath
+}
+
+function stageSherpaModelFromPackage(options) {
+    if (!options.sherpaModelSource) return null
+    if (TARGET_PLATFORM !== 'android') {
+        throw new Error('--stage-sherpa-model-from is currently Android-only')
+    }
+    const targetDir =
+        options.sherpaModelTargetDir || options.sherpaConfig?.modelDir
+    if (!targetDir) {
+        throw new Error(
+            '--stage-sherpa-model-from requires --stage-sherpa-model-to or sherpa-config.modelDir'
+        )
+    }
+
+    const source = parsePackagePath(options.sherpaModelSource)
+    const sourcePath = toRunAsPath(source.packageName, source.path)
+    const targetPath = toRunAsPath(PACKAGE_NAME, targetDir)
+    const quotedSourcePath = shellQuote(sourcePath)
+    const quotedTargetPath = shellQuote(targetPath)
+    const adbPrefix = SERIAL ? `adb -s ${shellQuote(SERIAL)}` : 'adb'
+    const sourceCommand = `${adbPrefix} exec-out ${shellQuote(
+        `run-as ${source.packageName} sh -c ${shellQuote(`cd ${quotedSourcePath} && tar -cf - .`)}`
+    )}`
+    const targetCommand = `${adbPrefix} shell ${shellQuote(
+        `run-as ${PACKAGE_NAME} sh -c ${shellQuote(
+            `rm -rf ${quotedTargetPath} && mkdir -p ${quotedTargetPath} && cd ${quotedTargetPath} && tar -xf -`
+        )}`
+    )}`
+
+    run('bash', ['-lc', `${sourceCommand} | ${targetCommand}`], {
+        maxBuffer: 10 * 1024 * 1024,
+    })
+
+    const listing = adb([
+        'shell',
+        `run-as ${PACKAGE_NAME} sh -c ${shellQuote(
+            `find ${shellQuote(targetPath)} -maxdepth 2 -type f | sed 's#^${targetPath}/##' | sort | head -50`
+        )}`,
+    ])
+    return {
+        sourcePackage: source.packageName,
+        sourcePath: source.path,
+        targetDir,
+        files: listing.split('\n').filter(Boolean),
+    }
+}
+
+function normalizeIOSDocumentsRelativePath(value, fallback) {
+    const raw = String(value || fallback || '').trim()
+    return raw
+        .replace(/^file:\/\//, '')
+        .replace(
+            /^\/private\/var\/mobile\/Containers\/Data\/Application\/[^/]+\/Documents\//,
+            ''
+        )
+        .replace(
+            /^\/var\/mobile\/Containers\/Data\/Application\/[^/]+\/Documents\//,
+            ''
+        )
+        .replace(/^Documents\//, '')
+        .replace(/^\/+/, '')
+}
+
+function stageSherpaHostModel(options, selectedDevice) {
+    if (!options.sherpaModelHostDir) return null
+
+    const hostDir = path.isAbsolute(options.sherpaModelHostDir)
+        ? options.sherpaModelHostDir
+        : path.resolve(process.cwd(), options.sherpaModelHostDir)
+    if (!fs.existsSync(hostDir) || !fs.statSync(hostDir).isDirectory()) {
+        throw new Error(`Sherpa host model dir not found: ${hostDir}`)
+    }
+
+    const fallbackRelativeTarget = `sherpa-onnx/asr/${path.basename(hostDir)}`
+    const configuredTarget =
+        options.sherpaModelTargetDir || options.sherpaConfig?.modelDir
+
+    if (selectedDevice.platform === 'ios') {
+        if (selectedDevice.targetType !== 'physical') {
+            throw new Error(
+                '--stage-sherpa-model-host-dir for iOS currently requires a physical device'
+            )
+        }
+        const relativeTarget = normalizeIOSDocumentsRelativePath(
+            configuredTarget,
+            fallbackRelativeTarget
+        )
+        const deviceIdentifier = findIOSPhysicalDeviceIdentifier(selectedDevice)
+        const output = run('xcrun', [
+            'devicectl',
+            'device',
+            'copy',
+            'to',
+            '--device',
+            deviceIdentifier,
+            '--domain-type',
+            'appDataContainer',
+            '--domain-identifier',
+            PACKAGE_NAME,
+            '--source',
+            hostDir,
+            '--destination',
+            `Documents/${relativeTarget}`,
+            '--remove-existing-content',
+            'false',
+        ])
+        const targetDir =
+            output.match(/^Path: (.+)$/m)?.[1]?.trim() ||
+            output.match(/Path:\s+(.+)$/m)?.[1]?.trim()
+        if (!targetDir) {
+            throw new Error(
+                `Failed to stage iOS Sherpa model to Documents/${relativeTarget}; devicectl output: ${output}`
+            )
+        }
+        if (options.sherpaConfig) {
+            options.sherpaConfig = {
+                ...options.sherpaConfig,
+                modelDir: targetDir,
+            }
+        }
+        return {
+            sourceHostDir: hostDir,
+            targetDir,
+            iosDeviceIdentifier: deviceIdentifier,
+        }
+    }
+
+    if (selectedDevice.platform === 'android') {
+        const targetDir = configuredTarget
+        if (!targetDir) {
+            throw new Error(
+                '--stage-sherpa-model-host-dir on Android requires --stage-sherpa-model-to or sherpa-config.modelDir'
+            )
+        }
+        const targetPath = toRunAsPath(PACKAGE_NAME, targetDir)
+        const adbPrefix = SERIAL ? `adb -s ${shellQuote(SERIAL)}` : 'adb'
+        run('bash', [
+            '-lc',
+            `tar -C ${shellQuote(hostDir)} -cf - . | ${adbPrefix} shell ${shellQuote(
+                `run-as ${PACKAGE_NAME} sh -c ${shellQuote(
+                    `rm -rf ${shellQuote(targetPath)} && mkdir -p ${shellQuote(
+                        targetPath
+                    )} && cd ${shellQuote(targetPath)} && tar -xf -`
+                )}`
+            )}`,
+        ])
+        return {
+            sourceHostDir: hostDir,
+            targetDir,
+        }
+    }
+
+    throw new Error(
+        `Unsupported platform for host Sherpa model staging: ${selectedDevice.platform}`
+    )
+}
+
+function readMemory() {
+    if (TARGET_PLATFORM !== 'android') {
+        return {
+            platform: TARGET_PLATFORM,
+            unsupported: 'memory sampling is currently Android/ADB-only',
+        }
+    }
+    try {
+        const output = adb(['shell', `dumpsys meminfo ${PACKAGE_NAME}`])
+        const totalPss = output.match(/^\s*TOTAL\s+(\d+)/m)?.[1]
+        const nativeHeap = output.match(/^\s*Native Heap\s+(\d+)/m)?.[1]
+        const javaHeap = output.match(/^\s*Java Heap\s+(\d+)/m)?.[1]
+        const swapPss = output.match(/^\s*TOTAL SWAP PSS\s+(\d+)/m)?.[1]
+        return {
+            totalPssKb: totalPss ? Number(totalPss) : undefined,
+            nativeHeapKb: nativeHeap ? Number(nativeHeap) : undefined,
+            javaHeapKb: javaHeap ? Number(javaHeap) : undefined,
+            swapPssKb: swapPss ? Number(swapPss) : undefined,
+        }
+    } catch (error) {
+        return { error: String(error) }
+    }
+}
+
+function readAppProcess() {
+    if (TARGET_PLATFORM !== 'android') {
+        return {
+            alive: true,
+            platform: TARGET_PLATFORM,
+            unsupported: 'process sampling is currently Android/ADB-only',
+        }
+    }
+    try {
+        const output = adb([
+            'shell',
+            `pidof ${PACKAGE_NAME} 2>/dev/null || true`,
+        ]).trim()
+        return {
+            alive: output.length > 0,
+            pid: output || undefined,
+        }
+    } catch (error) {
+        return { alive: false, error: String(error) }
+    }
+}
+
+function checkMemoryBudget(options, memory) {
+    const exceeded =
+        (options.maxPssKb !== undefined &&
+            memory.totalPssKb !== undefined &&
+            memory.totalPssKb > options.maxPssKb) ||
+        (options.maxNativeHeapKb !== undefined &&
+            memory.nativeHeapKb !== undefined &&
+            memory.nativeHeapKb > options.maxNativeHeapKb)
+    if (!exceeded) return null
+    return `memory-budget-exceeded: totalPssKb=${memory.totalPssKb ?? 'unknown'} maxPssKb=${
+        options.maxPssKb ?? 'unset'
+    } nativeHeapKb=${memory.nativeHeapKb ?? 'unknown'} maxNativeHeapKb=${
+        options.maxNativeHeapKb ?? 'unset'
+    }`
+}
+
+function progressKey(progress) {
+    if (!progress) return ''
+    return [
+        progress.status,
+        progress.chunkCount,
+        progress.processedAudioMs,
+        progress.transcriptEventCount,
+        progress.transcriptCharCount,
+    ].join(':')
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForCompletion(options) {
+    const startedAt = Date.now()
+    let lastProgressKey = ''
+    let lastProgressAt = startedAt
+    let lastHeartbeatAt = 0
+    let firstBridgeErrorAt = 0
+    let lastProgress = null
+    while (Date.now() - startedAt < TIMEOUT_MS) {
+        let progress
+        let result
+        try {
+            progress = bridge([
+                'eval',
+                'globalThis.__AGENTIC__?.getLongAudioValidationProgress?.()',
+            ])
+            result = bridge([
+                'eval',
+                'globalThis.__AGENTIC__?.getLastResult?.()',
+            ])
+            firstBridgeErrorAt = 0
+        } catch (error) {
+            const memory = readMemory()
+            const appProcess = readAppProcess()
+            if (firstBridgeErrorAt === 0) firstBridgeErrorAt = Date.now()
+            emit('bridge-error', {
+                error: error instanceof Error ? error.message : String(error),
+                elapsedWallMs: Date.now() - startedAt,
+                bridgeGraceMs: BRIDGE_GRACE_MS,
+                progress: lastProgress,
+                memory,
+                process: appProcess,
+            })
+            if (!appProcess.alive) {
+                throw new Error(
+                    `app-process-not-running while waiting for ${options.mode}`
+                )
+            }
+            if (Date.now() - firstBridgeErrorAt > BRIDGE_GRACE_MS) {
+                throw new Error(
+                    `cdp-bridge-unavailable for ${Date.now() - firstBridgeErrorAt}ms while app process is alive`
+                )
+            }
+            await sleep(POLL_INTERVAL_MS)
+            continue
+        }
+
+        if (progress) {
+            lastProgress = progress
+        }
+        const currentProgressKey = progressKey(progress)
+        if (progress && currentProgressKey !== lastProgressKey) {
+            lastProgressKey = currentProgressKey
+            lastProgressAt = Date.now()
+            const memory = readMemory()
+            emit('progress', { progress, memory })
+            const reason = checkMemoryBudget(options, memory)
+            if (reason) {
+                bridge([
+                    'eval',
+                    `globalThis.__AGENTIC__?.cancelLongAudioValidation?.(${JSON.stringify(reason)})`,
+                ])
+                emit('budget-exceeded', {
+                    reason,
+                    progress,
+                    memory,
+                    process: readAppProcess(),
+                })
+                throw new Error(reason)
+            }
+        }
+        if (Date.now() - lastHeartbeatAt >= HEARTBEAT_INTERVAL_MS) {
+            lastHeartbeatAt = Date.now()
+            const memory = readMemory()
+            const appProcess = readAppProcess()
+            emit('heartbeat', {
+                elapsedWallMs: Date.now() - startedAt,
+                progress,
+                memory,
+                process: appProcess,
+            })
+            const reason = checkMemoryBudget(options, memory)
+            if (reason) {
+                bridge([
+                    'eval',
+                    `globalThis.__AGENTIC__?.cancelLongAudioValidation?.(${JSON.stringify(reason)})`,
+                ])
+                emit('budget-exceeded', {
+                    reason,
+                    progress,
+                    memory,
+                    process: appProcess,
+                })
+                throw new Error(reason)
+            }
+        }
+        if (
+            result?.op === 'validateLongAudioStream' &&
+            result.status !== 'pending'
+        ) {
+            emit('final', { result, memory: readMemory() })
+            if (result.status === 'cancelled' && options.cancelAfterChunks) {
+                emit('cancelled-ok', { result })
+                return result
+            }
+            if (result.status !== 'success') {
+                throw new Error(result.error || 'long-audio validation failed')
+            }
+            return result
+        }
+        if (Date.now() - lastProgressAt > options.stallTimeoutMs) {
+            const reason = `progress-stalled: no new chunk progress for ${options.stallTimeoutMs}ms`
+            bridge([
+                'eval',
+                `globalThis.__AGENTIC__?.cancelLongAudioValidation?.(${JSON.stringify(reason)})`,
+            ])
+            emit('progress-stalled', {
+                reason,
+                progress,
+                memory: readMemory(),
+                process: readAppProcess(),
+            })
+            throw new Error(reason)
+        }
+        await sleep(POLL_INTERVAL_MS)
+    }
+    throw new Error(`validateLongAudioStream timed out after ${TIMEOUT_MS}ms`)
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2))
+    TARGET_DEVICE = options.device || TARGET_DEVICE
+    TARGET_PLATFORM = options.platform || TARGET_PLATFORM
+    if (options.sherpaModelTargetDir && options.sherpaConfig) {
+        options.sherpaConfig = {
+            ...options.sherpaConfig,
+            modelDir: options.sherpaModelTargetDir,
+        }
+    }
+    const fixture = resolveFixture(options.fixture)
+
+    emit('start', {
+        mode: options.mode,
+        fixture,
+        packageName: PACKAGE_NAME,
+        device: TARGET_DEVICE || '(auto)',
+        platform: TARGET_PLATFORM,
+        serial: SERIAL || '(auto)',
+        startTimeMs: options.startTimeMs,
+        endTimeMs: options.endTimeMs,
+    })
+
+    const previousTargetDevice = TARGET_DEVICE
+    TARGET_DEVICE = ''
+    const devices = bridge(['list-devices'])
+    emit('devices', devices)
+    TARGET_DEVICE = previousTargetDevice
+    const selectedDevice = selectTargetDevice(devices, options)
+    emit('target-device', selectedDevice)
+
+    const staged = stageFixtureForTarget(fixture, selectedDevice)
+    emit('fixture-staged', staged)
+
+    const stagedSherpaHostModel = stageSherpaHostModel(options, selectedDevice)
+    if (stagedSherpaHostModel) {
+        emit('sherpa-host-model-staged', stagedSherpaHostModel)
+    }
+
+    const stagedSherpaModel = stageSherpaModelFromPackage(options)
+    if (stagedSherpaModel) {
+        emit('sherpa-model-staged', stagedSherpaModel)
+    }
+
+    const appOptions = {
+        fileUri: staged.devicePath,
+        mode: options.mode,
+        modelId: options.mode === 'moonshine' ? options.modelId : undefined,
+        startTimeMs: options.startTimeMs,
+        endTimeMs: options.endTimeMs,
+        sherpaAsrConfig:
+            options.mode === 'sherpa-online' ||
+            options.mode === 'sherpa-offline-segments'
+                ? options.sherpaConfig
+                : undefined,
+        sherpaSegmentDurationMs:
+            options.mode === 'sherpa-offline-segments'
+                ? options.sherpaSegmentDurationMs
+                : undefined,
+        sherpaReleaseBetweenSegments:
+            options.mode === 'sherpa-offline-segments'
+                ? options.sherpaReleaseBetweenSegments
+                : undefined,
+        moonshineFeedMode:
+            options.mode === 'moonshine'
+                ? options.moonshineFeedMode
+                : undefined,
+        chunkDurationMs: options.chunkDurationMs,
+        maxBufferedChunks: options.maxBufferedChunks,
+        progressEveryChunks: options.progressEveryChunks,
+        cancelAfterChunks: options.cancelAfterChunks,
+    }
+
+    bridge([
+        'eval',
+        `globalThis.__AGENTIC__?.validateLongAudioStream?.(${JSON.stringify(appOptions)})`,
+    ])
+    await waitForCompletion(options)
+}
+
+main().catch((error) => {
+    emit('error', {
+        error: error instanceof Error ? error.message : String(error),
+    })
+    process.exitCode = 1
+})

--- a/packages/moonshine.rn/CHANGELOG.md
+++ b/packages/moonshine.rn/CHANGELOG.md
@@ -7,12 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.3] - 2026-05-08
+### Breaking / Migration
+
+- Native per-line audio retention now follows the public `includeAudioData`
+  option. If you depended on implicit upstream per-line PCM data, pass
+  `includeAudioData: true`; otherwise long streams default to text/progress
+  retention only.
+
 ### Changed
+
+- Accept `Float32Array` as a Moonshine PCM input type at the JS API boundary. Legacy React Native native-module calls still materialize arrays internally, so long-stream callers should keep chunks bounded until a JSI/ArrayBuffer path is available.
+- Align native `return_audio_data` retention with the public `includeAudioData`
+  option on Android and iOS. RN now defaults native per-line PCM retention off,
+  preventing long streaming sessions from keeping every VAD segment's samples
+  when callers only need transcript text/progress.
+- Avoid copying historical VAD segment PCM on every streaming update and release
+  completed VAD segment samples after transcription when `return_audio_data=false`,
+  so very long Moonshine streams retain only active-segment audio plus text
+  transcript state unless callers explicitly request per-line audio.
+
+## [0.3.3] - 2026-05-08
+
+### Changed
+
 - Promote the lightweight public install flow from beta to stable. Public npm installs stay thin while iOS resolves the xcframework from a checksum-pinned GitHub release asset and Android resolves native binaries through Maven by default.
 
 ## [0.3.3-beta.7] - 2026-05-08
+
 ### Added
+
 - Add CocoaPods-driven iOS artifact preparation for public installs without shipping the xcframework in npm.
 - Add Android Maven fallback for public installs while preserving source-AAR/custom-AAR overrides for development.
 - Add release validators for the packed npm tarball contract, iOS release asset integrity, and optional Android AAR symbol inspection.
@@ -20,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add consumer README guidance for cross-platform setup, customization hooks, and web ORT/model asset configuration.
 
 ### Changed
+
 - Keep the public npm tarball lightweight by excluding heavyweight iOS xcframework and Android AAR binaries.
 - Cache downloaded iOS artifacts outside `node_modules` using version/checksum keys, with URL-hash fallback for unpinned artifacts.
 - Verify pinned iOS artifact checksums both during consumer install and during the publish gate.
@@ -28,19 +52,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `sha256sum` as a fallback when `shasum` is unavailable.
 
 ## [0.3.2] - 2026-05-06
+
 ### Added
+
 - Native release validation via `yarn validate:native-release`, covering the packed npm tarball, required iOS xcframework device/simulator slices, Android Maven fallback expectations, headers, and package-size reporting.
 - `yarn release:beta:preflight` now runs typecheck, tests, and native release validation so incomplete native artifacts are caught before publishing.
 
 ### Changed
+
 - Updated the beta release plan to require native preflight validation and to document packed-size evidence for future releases.
 
 ## [0.3.1] - 2026-05-06
+
 ### Changed
+
 - Published the stable `0.3.1` package and documented `AUDIOLAB_NPM_TOKEN`-based npm publishing credentials for the monorepo release flow.
 
 ## [0.3.0] - 2026-04-09
+
 ### Added
+
 - Moonshine RN package with iOS, Android, and web transcription support, source-built native tooling, offline progress events, and word timestamp parity fixes.
 - Beta release plan and external consumer validation checklist.
 

--- a/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
+++ b/packages/moonshine.rn/android/src/main/java/net/siteed/moonshine/MoonshineModule.kt
@@ -720,6 +720,12 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
 
   private fun buildTranscriberOptions(config: ReadableMap): Array<TranscriberOption> {
     val options = mutableListOf<TranscriberOption>()
+    val includeAudioData = readIncludeAudioData(config)
+    // `includeAudioData` is the public RN switch for returning per-line PCM.
+    // The upstream native core defaults `return_audio_data` to true, which makes
+    // long streaming transcripts retain each VAD segment's FloatArray even when
+    // RN suppresses `line.audioData` in emitted maps. Keep the native retention
+    // policy aligned with the JS contract and default it off for long sessions.
     if (config.hasKey("options") && !config.isNull("options")) {
       val nativeOptions = config.getMap("options")
       nativeOptions?.let {
@@ -850,6 +856,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
         }
       }
     }
+    options.add(TranscriberOption("return_audio_data", includeAudioData.toString()))
     return options.toTypedArray()
   }
 
@@ -885,11 +892,6 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
         defaultTranscriberId?.let { releaseTranscriberInternal(it) }
       }
 
-      val includeAudioData =
-        config.hasKey("includeAudioData") &&
-        !config.isNull("includeAudioData") &&
-        config.getBoolean("includeAudioData")
-
       val transcriberOptions = buildTranscriberOptions(config)
       val modelArch = resolveModelArch(config)
       val handle = loader(transcriberOptions, modelArch)
@@ -902,7 +904,7 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
       val state = TranscriberState(
         handle = handle,
         defaultStreamHandle = loadedDefaultStreamHandle,
-        includeAudioDataInLines = includeAudioData
+        includeAudioDataInLines = readIncludeAudioData(config)
       )
       registerStreamState(state, loadedDefaultStreamHandle)
       transcriberStates[transcriberId] = state
@@ -916,6 +918,12 @@ class MoonshineModule(reactContext: ReactApplicationContext) :
     } catch (error: Throwable) {
       promise.resolve(errorResult(error.message ?: "Moonshine load failed"))
     }
+  }
+
+  private fun readIncludeAudioData(config: ReadableMap): Boolean {
+    return config.hasKey("includeAudioData") &&
+      !config.isNull("includeAudioData") &&
+      config.getBoolean("includeAudioData")
   }
 
   private fun emitEvent(

--- a/packages/moonshine.rn/apply-upstream-patches.sh
+++ b/packages/moonshine.rn/apply-upstream-patches.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UPSTREAM_DIR="$SCRIPT_DIR/third_party/moonshine"
 PATCHES=(
   "patches/OrtAndroidOverrides.patch"
+  "patches/LongStreamingMemory.patch"
 )
 
 if [ ! -d "$UPSTREAM_DIR/.git" ]; then
@@ -23,9 +24,13 @@ for relative_patch_path in "${PATCHES[@]}"; do
     exit 1
   fi
 
-  if git apply --check "$patch_path" >/dev/null 2>&1; then
+  if git apply --3way --check "$patch_path" >/dev/null 2>&1; then
     echo "Applying upstream patch: $relative_patch_path"
-    git apply "$patch_path"
+    git apply --3way "$patch_path"
+    if find . -name '*.rej' -print -quit | grep -q .; then
+      echo "Error: patch left reject files after 3-way apply: $relative_patch_path" >&2
+      exit 1
+    fi
     continue
   fi
 

--- a/packages/moonshine.rn/build-moonshine-android.sh
+++ b/packages/moonshine.rn/build-moonshine-android.sh
@@ -71,11 +71,11 @@ decouple_bundled_ort_in_aar() {
   fi
 
   local stage="$(mktemp -d)"
-  trap "rm -rf \"$stage\"" RETURN
 
   unzip -q "$aar_path" -d "$stage"
   local jni_dir="$stage/jni"
   if [ ! -d "$jni_dir" ]; then
+    rm -rf "$stage"
     return
   fi
 
@@ -90,11 +90,13 @@ decouple_bundled_ort_in_aar() {
   done
 
   if [ "$touched" = "0" ]; then
+    rm -rf "$stage"
     return
   fi
 
   rm -f "$aar_path"
   ( cd "$stage" && zip -qr "$aar_path" . )
+  rm -rf "$stage"
 }
 
 extract_ort_symbol_version() {
@@ -256,6 +258,7 @@ fi
 if unzip -p "$OUTPUT_AAR" jni/arm64-v8a/libonnxruntime.so > "$TMP_DIR/libonnxruntime.so" 2>/dev/null; then
   MOONSHINE_PACKAGED_ORT_VERSION="$(extract_ort_symbol_version "$TMP_DIR/libonnxruntime.so")"
 fi
+AAR_SHA256="$(shasum -a 256 "$OUTPUT_AAR" | awk '{print $1}')"
 
 cat > "$METADATA_PATH" <<EOF
 {
@@ -265,7 +268,8 @@ cat > "$METADATA_PATH" <<EOF
   "onnxRuntimeLibPathOverride": "$(sanitize_metadata_path "$ORT_LIB_PATH")",
   "onnxRuntimeIncludeDirOverride": "$(sanitize_metadata_path "$ORT_INCLUDE_DIR")",
   "arm64ImportedOrtSymbolVersion": "${MOONSHINE_IMPORTED_ORT_VERSION}",
-  "arm64PackagedOrtSymbolVersion": "${MOONSHINE_PACKAGED_ORT_VERSION}"
+  "arm64PackagedOrtSymbolVersion": "${MOONSHINE_PACKAGED_ORT_VERSION}",
+  "aarSha256": "${AAR_SHA256}"
 }
 EOF
 

--- a/packages/moonshine.rn/ios/Moonshine.mm
+++ b/packages/moonshine.rn/ios/Moonshine.mm
@@ -1274,6 +1274,12 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
     });
   };
 
+  BOOL includeAudioData = BoolFromValue(config[@"includeAudioData"]);
+  // `includeAudioData` is the public RN switch for returning per-line PCM.
+  // The upstream native core defaults `return_audio_data` to true, which makes
+  // long streaming transcripts retain each VAD segment's samples even when RN
+  // suppresses `line.audioData` in emitted dictionaries. Keep native retention
+  // aligned with the JS contract and default it off for long sessions.
   NSDictionary *nativeOptions = [config[@"options"] isKindOfClass:NSDictionary.class] ? config[@"options"] : nil;
   if (nativeOptions != nil) {
     if (nativeOptions[@"identifySpeakers"] != nil && nativeOptions[@"identifySpeakers"] != (id)kCFNull) {
@@ -1338,6 +1344,7 @@ RCT_EXPORT_METHOD(unregisterIntent:(NSString *)intentRecognizerId
     addOption(name, valueString ?: @"");
   }
 
+  addOption(@"return_audio_data", includeAudioData ? @"true" : @"false");
   return buffer;
 }
 

--- a/packages/moonshine.rn/patches/LongStreamingMemory.patch
+++ b/packages/moonshine.rn/patches/LongStreamingMemory.patch
@@ -1,0 +1,71 @@
+diff --git a/core/transcriber.cpp b/core/transcriber.cpp
+index 77c2733..e572335 100644
+--- a/core/transcriber.cpp
++++ b/core/transcriber.cpp
+@@ -426,10 +426,27 @@ void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
+     std::lock_guard<std::mutex> lock(stream->vad_mutex);
+     stream->vad->process_audio(audio_data, (int32_t)audio_length,
+                                INTERNAL_SAMPLE_RATE);
+-    segments = *(stream->vad->get_segments());
++    const std::vector<VoiceActivitySegment> *vad_segments =
++        stream->vad->get_segments();
++    segments.reserve(vad_segments->size());
++    for (const VoiceActivitySegment &segment : *vad_segments) {
++      VoiceActivitySegment segment_copy;
++      segment_copy.start_time = segment.start_time;
++      segment_copy.end_time = segment.end_time;
++      segment_copy.is_complete = segment.is_complete;
++      segment_copy.just_updated = segment.just_updated;
++      if (segment.just_updated) {
++        segment_copy.audio_data = segment.audio_data;
++      }
++      segments.push_back(std::move(segment_copy));
++    }
+   }
+   stream->clear_new_audio_buffer();
+   this->update_transcript_from_segments(segments, stream, out_transcript);
++  if (!this->options.return_audio_data) {
++    std::lock_guard<std::mutex> lock(stream->vad_mutex);
++    stream->vad->clear_completed_segment_audio_data();
++  }
+ }
+
+ std::string Transcriber::transcript_to_string(
+diff --git a/core/voice-activity-detector.cpp b/core/voice-activity-detector.cpp
+index f49fbcc..58fa083 100644
+--- a/core/voice-activity-detector.cpp
++++ b/core/voice-activity-detector.cpp
+@@ -96,6 +96,14 @@ void VoiceActivityDetector::process_audio(const float *audio_data,
+   processing_remainder_audio_buffer = processing_buffer;
+ }
+
++void VoiceActivityDetector::clear_completed_segment_audio_data() {
++  for (VoiceActivitySegment &segment : segments) {
++    if (segment.is_complete && !segment.audio_data.empty()) {
++      std::vector<float>().swap(segment.audio_data);
++    }
++  }
++}
++
+ void VoiceActivityDetector::process_audio_chunk(const float *audio_data,
+                                                 size_t audio_data_size) {
+   assert(audio_data_size == (size_t)(hop_size));
+diff --git a/core/voice-activity-detector.h b/core/voice-activity-detector.h
+index 3279bc8..bfee186 100644
+--- a/core/voice-activity-detector.h
++++ b/core/voice-activity-detector.h
+@@ -56,6 +56,7 @@ class VoiceActivityDetector {
+   const std::vector<VoiceActivitySegment> *get_segments() const {
+     return &segments;
+   }
++  void clear_completed_segment_audio_data();
+   std::string to_string() const;
+
+  private:
+@@ -66,4 +67,4 @@ class VoiceActivityDetector {
+   void process_audio_chunk(const float *audio_data, size_t audio_data_size);
+ };
+
+-#endif
+\ No newline at end of file
++#endif

--- a/packages/moonshine.rn/patches/README
+++ b/packages/moonshine.rn/patches/README
@@ -1,35 +1,41 @@
-Moonshine Patch Inventory for v0.0.51
-====================================
+# Moonshine Patch Inventory for v0.0.59
 
 These patches track our modifications to upstream `moonshine-ai/moonshine`
 sources so the Android source build is reproducible from a clean checkout.
 
-Pinned version: `v0.0.51`
+Pinned version: `v0.0.59`
 
+## Files patched
 
-Files patched
--------------
-OrtAndroidOverrides.patch
-  - patches upstream Android and CMake build files so the vendored source build
-    can honor:
-      `SITEED_MOONSHINE_ANDROID_ABIS`
-      `SITEED_MOONSHINE_ORT_LIB_PATH`
-      `SITEED_MOONSHINE_ORT_INCLUDE_DIR`
-  - adds a public `close()` method to upstream `Transcriber` so wrappers do not
-    need to reflectively call `finalize()`
-  - applied automatically by `./setup.sh` and `./build-moonshine-android.sh`
+### OrtAndroidOverrides.patch
 
+- patches upstream Android and CMake build files so the vendored source build
+  can honor:
+  `SITEED_MOONSHINE_ANDROID_ABIS`
+  `SITEED_MOONSHINE_ORT_LIB_PATH`
+  `SITEED_MOONSHINE_ORT_INCLUDE_DIR`
+- adds a public `close()` method to upstream `Transcriber` so wrappers do not
+  need to reflectively call `finalize()`
+- applied automatically by `./setup.sh` and `./build-moonshine-android.sh`
 
-How to apply on version upgrade
--------------------------------
+### LongStreamingMemory.patch
+
+- avoids copying historical VAD segment PCM on every streaming transcription
+  update and clears completed VAD segment samples after transcription when
+  `return_audio_data=false`, so long Moonshine streams keep bounded native
+  audio retention while callers that explicitly request audio data retain the
+  upstream debugging/analysis behavior.
+
+## How to apply on version upgrade
+
 When `setup.sh` is updated to a new upstream version:
 
 1. Refresh or re-pin `third_party/moonshine`.
-2. Rebase `OrtAndroidOverrides.patch` against the new upstream checkout.
+2. Rebase each patch in this inventory against the new upstream checkout.
 3. Re-run `bash packages/moonshine.rn/build-moonshine-android.sh`.
 4. Revalidate the resulting AAR and ORT compatibility.
 
 Note:
-- `OrtAndroidOverrides.patch` is applied from inside
-  `third_party/moonshine` via `git apply`, so its paths are relative to the
-  upstream checkout root.
+
+- All patch files are applied from inside `third_party/moonshine` via
+  `git apply`, so their paths are relative to the upstream checkout root.

--- a/packages/moonshine.rn/prebuilt/android/build-metadata.json
+++ b/packages/moonshine.rn/prebuilt/android/build-metadata.json
@@ -5,5 +5,6 @@
   "onnxRuntimeLibPathOverride": "",
   "onnxRuntimeIncludeDirOverride": "",
   "arm64ImportedOrtSymbolVersion": "stripped",
-  "arm64PackagedOrtSymbolVersion": "1.23.0"
+  "arm64PackagedOrtSymbolVersion": "1.23.0",
+  "aarSha256": "c68e66ec2cb69dd8967c7c05a3452f59579254930d234ab609bbff52b2b88711"
 }

--- a/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
+++ b/packages/moonshine.rn/prebuilt/android/moonshine-voice-source-release.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:650ccab79bf5ad0b3a4009b16162bfba5d381254572fff2b001f329dc3e77d38
-size 29275684
+oid sha256:c68e66ec2cb69dd8967c7c05a3452f59579254930d234ab609bbff52b2b88711
+size 29276023

--- a/packages/moonshine.rn/scripts/validate-native-release.mjs
+++ b/packages/moonshine.rn/scripts/validate-native-release.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
@@ -64,6 +65,10 @@ function readelfCandidates() {
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8')
 )
+
+function sha256File(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
 
 if (!packageJson.moonshineVersion) {
   throw new Error('package.json must define moonshineVersion for native release validation')
@@ -269,6 +274,18 @@ console.log('Repo-local generated prebuilt/ios/current/ artifacts are intentiona
 
 const localAarPath = path.join(PACKAGE_ROOT, ANDROID_AAR)
 if (fs.existsSync(localAarPath)) {
+  const metadataPath = path.join(PACKAGE_ROOT, 'prebuilt/android/build-metadata.json')
+  const androidMetadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
+  if (!/^[a-f0-9]{64}$/i.test(androidMetadata.aarSha256 || '')) {
+    throw new Error('Android build metadata must include aarSha256 for repo-local AAR reproducibility')
+  }
+  const actualAarSha256 = sha256File(localAarPath)
+  if (androidMetadata.aarSha256 !== actualAarSha256) {
+    throw new Error(
+      `Android AAR sha256 mismatch. metadata=${androidMetadata.aarSha256} actual=${actualAarSha256}`
+    )
+  }
+
   const androidAbiReports = inspectAndroidAar(localAarPath)
   const bundledOnnxAbis = androidAbiReports
     .filter((report) => report.bundlesOnnxRuntime)
@@ -277,6 +294,7 @@ if (fs.existsSync(localAarPath)) {
     .filter((report) => !report.bundlesOnnxRuntime)
     .map((report) => report.abi)
 
+  console.log(`Repo-local Android AAR sha256 verified: ${actualAarSha256}`)
   console.log(
     `Repo-local Android AAR ABIs inspected: ${androidAbiReports
       .map((report) => report.abi)

--- a/packages/moonshine.rn/src/services/MoonshineService.ts
+++ b/packages/moonshine.rn/src/services/MoonshineService.ts
@@ -22,12 +22,18 @@ import type {
   MoonshineProcessUtteranceResult,
   MoonshineTranscriptEvent,
   MoonshineTranscriptionResult,
+  MoonshineTranscriptionInput,
   MoonshineTranscribeParams,
 } from '../types/interfaces';
 import { OfflineProgressTracker } from './offlineProgressTracker';
 import { runWithAbortSignal } from './transcriptionCancellation';
 
 type MoonshineListener = (event: MoonshineTranscriptEvent) => void;
+
+function toBridgeSamples(samples: MoonshineTranscriptionInput): number[] {
+  return Array.isArray(samples) ? samples : Array.from(samples);
+}
+
 export class MoonshineTranscriber {
   public constructor(
     private readonly service: MoonshineService,
@@ -35,7 +41,7 @@ export class MoonshineTranscriber {
   ) {}
 
   public addAudio(
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.service.addAudioForTranscriber(
@@ -47,7 +53,7 @@ export class MoonshineTranscriber {
 
   public addAudioToStream(
     streamId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.service.addAudioToStreamForTranscriber(
@@ -161,7 +167,7 @@ export class MoonshineService {
   private readonly offlineProgressTracker = new OfflineProgressTracker();
 
   public addAudio(
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.ensureDefaultTranscriber().addAudio(samples, sampleRate);
@@ -169,19 +175,19 @@ export class MoonshineService {
 
   public addAudioForTranscriber(
     transcriberId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return requireNativeMoonshineModule().addAudioForTranscriber(
       transcriberId,
       sampleRate,
-      samples
+      toBridgeSamples(samples)
     );
   }
 
   public addAudioToStream(
     streamId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return this.ensureDefaultTranscriber().addAudioToStream(
@@ -194,14 +200,14 @@ export class MoonshineService {
   public addAudioToStreamForTranscriber(
     transcriberId: string,
     streamId: string,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     sampleRate: number
   ): Promise<{ success: boolean }> {
     return requireNativeMoonshineModule().addAudioToStreamForTranscriber(
       transcriberId,
       streamId,
       sampleRate,
-      samples
+      toBridgeSamples(samples)
     );
   }
 
@@ -546,13 +552,13 @@ export class MoonshineService {
   private transcribePcmForTranscriber(
     transcriberId: string,
     sampleRate: number,
-    samples: number[],
+    samples: MoonshineTranscriptionInput,
     options?: MoonshinePcmTranscribeOptions
   ): Promise<MoonshineTranscriptionResult> {
     return requireNativeMoonshineModule().transcribeFromSamplesForTranscriber(
       transcriberId,
       sampleRate,
-      samples,
+      toBridgeSamples(samples),
       options
     );
   }

--- a/packages/moonshine.rn/src/types/interfaces.ts
+++ b/packages/moonshine.rn/src/types/interfaces.ts
@@ -163,9 +163,9 @@ export interface MoonshineOfflineProgressOptions {
 }
 
 export interface MoonshinePcmTranscribeOptions {
-  // PCM is currently transported as number[] over the React Native bridge.
-  // Keep chunks reasonably small (roughly 100-250ms) until a JSI/ArrayBuffer
-  // path exists.
+  // PCM can be provided as number[] or Float32Array. Native legacy bridges may
+  // still materialize arrays internally, so keep chunks reasonably small
+  // (roughly 100-250ms) until a JSI/ArrayBuffer path exists.
   chunkDurationMs?: number;
   progress?: false | MoonshineOfflineProgressOptions;
 }

--- a/scripts/agentic/preflight.sh
+++ b/scripts/agentic/preflight.sh
@@ -20,6 +20,38 @@ cd "$APP_ROOT"
 PLATFORM="${PLATFORM:-ios}"
 APP_VARIANT_EFFECTIVE="${APP_VARIANT:-development}"
 
+load_env_defaults() {
+  local env_file="$1"
+  [ -f "$env_file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "$line" == \#* || "$line" != *=* ]] && continue
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    # Preserve explicit CLI environment such as IOS_SIMULATOR= for ios:device.
+    if [ -z "${!key+x}" ]; then
+      value="${value#"${value%%[![:space:]]*}"}"
+      value="${value%"${value##*[![:space:]]}"}"
+      if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+        value="${value:1:${#value}-2}"
+      elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+        value="${value:1:${#value}-2}"
+      fi
+      export "$key=$value"
+    fi
+  done < "$env_file"
+}
+
+load_env_defaults ".env"
+load_env_defaults ".env.local"
+load_env_defaults ".env.${APP_VARIANT_EFFECTIVE}"
+load_env_defaults ".env.${APP_VARIANT_EFFECTIVE}.local"
+IOS_DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-${APPLE_TEAM_ID:-}}"
+
 run_simctl_timeout() {
   python3 - "$@" <<'PY'
 import subprocess
@@ -316,12 +348,28 @@ if [ "$APP_INSTALLED" = false ]; then
   if [ "$PLATFORM" = "ios" ] && [ "${IOS_DEVICE_MODE:-simulator}" = "physical" ]; then
     resolve_ios_workspace_and_scheme "$APP_VARIANT_EFFECTIVE"
     info "Building iOS app for physical device ${IOS_DEVICE_UDID} using ${IOS_SCHEME_NAME}..."
+    BUILD_LOG=".agent/ios-device-build-$(date -u +%Y%m%dT%H%M%SZ).log"
+    mkdir -p .agent
+    XCODEBUILD_SIGNING_ARGS=()
+    if [ -n "${IOS_DEVELOPMENT_TEAM:-}" ]; then
+      XCODEBUILD_SIGNING_ARGS+=(DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM}")
+      XCODEBUILD_SIGNING_ARGS+=(CODE_SIGN_STYLE=Automatic)
+    fi
+    set +e
     xcodebuild -workspace "$IOS_WORKSPACE_PATH" -scheme "$IOS_SCHEME_NAME" \
       -destination "id=${IOS_DEVICE_UDID}" \
       -configuration Debug \
       -derivedDataPath ios/build-device \
       -allowProvisioningUpdates \
-      build 2>&1 | tail -5
+      -allowProvisioningDeviceRegistration \
+      "${XCODEBUILD_SIGNING_ARGS[@]}" \
+      build 2>&1 | tee "$BUILD_LOG"
+    XCODEBUILD_STATUS=${PIPESTATUS[0]}
+    set -e
+    if [ "$XCODEBUILD_STATUS" -ne 0 ]; then
+      fail "iOS device build failed; full log: ${APP_ROOT}/${BUILD_LOG}"
+      exit "$XCODEBUILD_STATUS"
+    fi
     APP_PATH="ios/build-device/Build/Products/Debug-iphoneos/${IOS_SCHEME_NAME}.app"
     if [ ! -d "$APP_PATH" ]; then
       fail "Built .app not found at $APP_PATH"
@@ -332,11 +380,20 @@ if [ "$APP_INSTALLED" = false ]; then
   elif [ "$PLATFORM" = "ios" ]; then
     resolve_ios_workspace_and_scheme "$APP_VARIANT_EFFECTIVE"
     info "Building iOS app for simulator ${SIM} (${SIM_UUID}) using ${IOS_SCHEME_NAME}..."
+    BUILD_LOG=".agent/ios-simulator-build-$(date -u +%Y%m%dT%H%M%SZ).log"
+    mkdir -p .agent
+    set +e
     xcodebuild -workspace "$IOS_WORKSPACE_PATH" -scheme "$IOS_SCHEME_NAME" \
       -destination "platform=iOS Simulator,id=${SIM_UUID}" \
       -configuration Debug \
       -derivedDataPath ios/build \
-      build 2>&1 | tail -5
+      build 2>&1 | tee "$BUILD_LOG"
+    XCODEBUILD_STATUS=${PIPESTATUS[0]}
+    set -e
+    if [ "$XCODEBUILD_STATUS" -ne 0 ]; then
+      fail "iOS simulator build failed; full log: ${APP_ROOT}/${BUILD_LOG}"
+      exit "$XCODEBUILD_STATUS"
+    fi
     APP_PATH="ios/build/Build/Products/Debug-iphonesimulator/${IOS_SCHEME_NAME}.app"
     if [ ! -d "$APP_PATH" ]; then
       fail "Built .app not found at $APP_PATH"


### PR DESCRIPTION
## Summary

This lands the content from the two stacked follow-up PRs onto `main`.

GitHub merged the stacked PRs into their intermediate base branches:

- #387 merged into `feat/audio-studio-stream-decode`
- #388 merged into `feat/moonshine-rn-long-streaming-memory`

After #386 landed on `main`, those follow-up changes were still not present on `main`. This branch was created from `main` and applies exactly the missing two-dot diff from the final stacked branch, avoiding duplicate core `streamAudioData` history/diff.

Included:

- Moonshine RN long-stream audio retention / upstream patching from #387
- Long-audio validation page, recipe, benchmark scripts/docs from #388

## Validation

- [x] `git diff --check origin/main..HEAD`
- [x] `yarn workspace @siteed/moonshine.rn typecheck`
- [x] `yarn workspace @siteed/moonshine.rn validate:native-release`
- [x] `yarn workspace audio-playground typecheck`
- [x] `node --check packages/audio-studio/scripts/validate-stream-long.mjs`
- [x] `node --check packages/audio-studio/scripts/summarize-stream-long.mjs`
- [x] `python3 -m json.tool apps/playground/scripts/agentic/teams/playground/recipes/long-audio-validation.json`
