### PR TITLE
fix(sherpa-onnx): package selected Android ORT runtime

### DIFF
--- a/packages/sherpa-onnx.rn/patches/OrtAndroidOverrides.patch
+++ b/packages/sherpa-onnx.rn/patches/OrtAndroidOverrides.patch
@@ -1,9 +1,31 @@
 diff --git a/build-android-arm64-v8a.sh b/build-android-arm64-v8a.sh
-index d590a990..1feb9ac2 100755
+index d590a990..5edaf1c6 100755
 --- a/build-android-arm64-v8a.sh
 +++ b/build-android-arm64-v8a.sh
-@@ -68,9 +68,15 @@ fi
- 
+@@ -22,6 +22,21 @@ else
+   dir=$PWD/build-android-arm64-v8a-static
+ fi
+
++if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_LIB_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
++fi
++
++if [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
++fi
++
++if [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_ROOT=$(cd "$SITEED_SHERPA_ONNX_ORT_ROOT" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_ROOT
++fi
++
+ mkdir -p $dir
+ cd $dir
+
+@@ -68,9 +83,15 @@ fi
+
  echo "ANDROID_NDK: $ANDROID_NDK"
  sleep 1
 -onnxruntime_version=1.24.3
@@ -12,58 +34,133 @@ index d590a990..1feb9ac2 100755
 +onnxruntime_version=${SITEED_SHERPA_ONNX_ORT_VERSION:-1.24.3}
 +
 +if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ] && [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
-+  export SHERPA_ONNXRUNTIME_LIB_DIR=$SITEED_SHERPA_ONNX_ORT_LIB_DIR
-+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
-+elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ $BUILD_SHARED_LIBS == ON ]; then
-+  export SHERPA_ONNXRUNTIME_LIB_DIR=$SITEED_SHERPA_ONNX_ORT_ROOT/jni/arm64-v8a/
-+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$SITEED_SHERPA_ONNX_ORT_ROOT/headers/
-+elif [ $BUILD_SHARED_LIBS == ON ]; then
++  export SHERPA_ONNXRUNTIME_LIB_DIR="$SITEED_SHERPA_ONNX_ORT_LIB_DIR"
++  export SHERPA_ONNXRUNTIME_INCLUDE_DIR="$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR"
++elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ "$BUILD_SHARED_LIBS" == ON ]; then
++  export SHERPA_ONNXRUNTIME_LIB_DIR="$SITEED_SHERPA_ONNX_ORT_ROOT/jni/arm64-v8a/"
++  export SHERPA_ONNXRUNTIME_INCLUDE_DIR="$SITEED_SHERPA_ONNX_ORT_ROOT/headers/"
++elif [ "$BUILD_SHARED_LIBS" == ON ]; then
    if [ ! -f $onnxruntime_version/jni/arm64-v8a/libonnxruntime.so ]; then
      mkdir -p $onnxruntime_version
      pushd $onnxruntime_version
+@@ -173,7 +194,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+ # make VERBOSE=1 -j4
+ make -j4
+ make install/strip
+-cp -fv $onnxruntime_version/jni/arm64-v8a/libonnxruntime.so install/lib 2>/dev/null || true
++if [ "$BUILD_SHARED_LIBS" == ON ]; then
++  cp -fv "$SHERPA_ONNXRUNTIME_LIB_DIR/libonnxruntime.so" install/lib
++fi
+
+ if [ $SHERPA_ONNX_ENABLE_RKNN == ON ]; then
+   cp -fv $SHERPA_ONNX_RKNN_TOOLKIT2_LIB_DIR/librknnrt.so install/lib
 diff --git a/build-android-armv7-eabi.sh b/build-android-armv7-eabi.sh
-index 327fca10..304b12d4 100755
+index 327fca10..86fe1d97 100755
 --- a/build-android-armv7-eabi.sh
 +++ b/build-android-armv7-eabi.sh
-@@ -69,9 +69,15 @@ fi
+@@ -22,6 +22,21 @@ else
+   dir=$PWD/build-android-armv7-eabi-static
+ fi
+
++if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_LIB_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
++fi
++
++if [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
++fi
++
++if [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_ROOT=$(cd "$SITEED_SHERPA_ONNX_ORT_ROOT" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_ROOT
++fi
++
+ mkdir -p $dir
+ cd $dir
+
+@@ -69,9 +84,15 @@ fi
  echo "ANDROID_NDK: $ANDROID_NDK"
  sleep 1
- 
+
 -onnxruntime_version=1.24.3
--
--if [ $BUILD_SHARED_LIBS == ON ]; then
 +onnxruntime_version=${SITEED_SHERPA_ONNX_ORT_VERSION:-1.24.3}
-+
+
+-if [ $BUILD_SHARED_LIBS == ON ]; then
 +if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ] && [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
-+  export SHERPA_ONNXRUNTIME_LIB_DIR=$SITEED_SHERPA_ONNX_ORT_LIB_DIR
-+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
-+elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ $BUILD_SHARED_LIBS == ON ]; then
-+  export SHERPA_ONNXRUNTIME_LIB_DIR=$SITEED_SHERPA_ONNX_ORT_ROOT/jni/armeabi-v7a/
-+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$SITEED_SHERPA_ONNX_ORT_ROOT/headers/
-+elif [ $BUILD_SHARED_LIBS == ON ]; then
++  export SHERPA_ONNXRUNTIME_LIB_DIR="$SITEED_SHERPA_ONNX_ORT_LIB_DIR"
++  export SHERPA_ONNXRUNTIME_INCLUDE_DIR="$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR"
++elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ "$BUILD_SHARED_LIBS" == ON ]; then
++  export SHERPA_ONNXRUNTIME_LIB_DIR="$SITEED_SHERPA_ONNX_ORT_ROOT/jni/armeabi-v7a/"
++  export SHERPA_ONNXRUNTIME_INCLUDE_DIR="$SITEED_SHERPA_ONNX_ORT_ROOT/headers/"
++elif [ "$BUILD_SHARED_LIBS" == ON ]; then
    if [ ! -f $onnxruntime_version/jni/armeabi-v7a/libonnxruntime.so ]; then
      mkdir -p $onnxruntime_version
      pushd $onnxruntime_version
+@@ -163,7 +184,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+ # make VERBOSE=1 -j4
+ make -j4
+ make install/strip
+-cp -fv $onnxruntime_version/jni/armeabi-v7a/libonnxruntime.so install/lib 2>/dev/null || true
++if [ "$BUILD_SHARED_LIBS" == ON ]; then
++  cp -fv "$SHERPA_ONNXRUNTIME_LIB_DIR/libonnxruntime.so" install/lib
++fi
+
+ if [ $SHERPA_ONNX_ENABLE_RKNN == ON ]; then
+   cp -fv $SHERPA_ONNX_RKNN_TOOLKIT2_LIB_DIR/librknnrt.so install/lib
 diff --git a/build-android-x86-64.sh b/build-android-x86-64.sh
-index ac755690..127c8b40 100755
+index ac755690..8f42d249 100755
 --- a/build-android-x86-64.sh
 +++ b/build-android-x86-64.sh
-@@ -69,9 +69,15 @@ fi
+@@ -22,6 +22,21 @@ else
+   dir=$PWD/build-android-x86-64-static
+ fi
+
++if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_LIB_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
++fi
++
++if [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
++fi
++
++if [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ]; then
++  SITEED_SHERPA_ONNX_ORT_ROOT=$(cd "$SITEED_SHERPA_ONNX_ORT_ROOT" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_ROOT
++fi
++
+ mkdir -p $dir
+ cd $dir
+
+@@ -69,9 +84,15 @@ fi
  echo "ANDROID_NDK: $ANDROID_NDK"
  sleep 1
- 
+
 -onnxruntime_version=1.24.3
--
--if [ $BUILD_SHARED_LIBS == ON ]; then
 +onnxruntime_version=${SITEED_SHERPA_ONNX_ORT_VERSION:-1.24.3}
-+
+
+-if [ $BUILD_SHARED_LIBS == ON ]; then
 +if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ] && [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
-+  export SHERPA_ONNXRUNTIME_LIB_DIR=$SITEED_SHERPA_ONNX_ORT_LIB_DIR
-+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
-+elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ $BUILD_SHARED_LIBS == ON ]; then
-+  export SHERPA_ONNXRUNTIME_LIB_DIR=$SITEED_SHERPA_ONNX_ORT_ROOT/jni/x86_64/
-+  export SHERPA_ONNXRUNTIME_INCLUDE_DIR=$SITEED_SHERPA_ONNX_ORT_ROOT/headers/
-+elif [ $BUILD_SHARED_LIBS == ON ]; then
++  export SHERPA_ONNXRUNTIME_LIB_DIR="$SITEED_SHERPA_ONNX_ORT_LIB_DIR"
++  export SHERPA_ONNXRUNTIME_INCLUDE_DIR="$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR"
++elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ "$BUILD_SHARED_LIBS" == ON ]; then
++  export SHERPA_ONNXRUNTIME_LIB_DIR="$SITEED_SHERPA_ONNX_ORT_ROOT/jni/x86_64/"
++  export SHERPA_ONNXRUNTIME_INCLUDE_DIR="$SITEED_SHERPA_ONNX_ORT_ROOT/headers/"
++elif [ "$BUILD_SHARED_LIBS" == ON ]; then
    if [ ! -f $onnxruntime_version/jni/x86_64/libonnxruntime.so ]; then
      mkdir -p $onnxruntime_version
      pushd $onnxruntime_version
+@@ -147,7 +168,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+ make -j4
+ make install/strip
+
+-cp -fv $onnxruntime_version/jni/x86_64/libonnxruntime.so install/lib 2>/dev/null || true
++if [ "$BUILD_SHARED_LIBS" == ON ]; then
++  cp -fv "$SHERPA_ONNXRUNTIME_LIB_DIR/libonnxruntime.so" install/lib
++fi
+ rm -rf install/share
+ rm -rf install/lib/pkgconfig
+ rm -rf install/lib/lib*.a


### PR DESCRIPTION
## Summary\n- update the local sherpa-onnx Android ORT override patch to copy libonnxruntime.so from the selected runtime path\n- resolve local ORT override paths before entering per-ABI build directories\n- remove the silent shared-library copy fallback for override builds\n\n## Validation\n- git apply --check packages/sherpa-onnx.rn/patches/OrtAndroidOverrides.patch against packages/sherpa-onnx.rn/third_party/sherpa-onnx\n- bash -n build-android-arm64-v8a.sh build-android-armv7-eabi.sh build-android-x86-64.sh after applying the patch\n- git diff --check