### PR TITLE
fix(sherpa-onnx): normalize selected ORT override paths

### DIFF
--- a/packages/sherpa-onnx.rn/patches/OrtAndroidOverrides.patch
+++ b/packages/sherpa-onnx.rn/patches/OrtAndroidOverrides.patch
@@ -1,22 +1,29 @@
 diff --git a/build-android-arm64-v8a.sh b/build-android-arm64-v8a.sh
-index d590a990..5edaf1c6 100755
+index d590a990..add55cef 100755
 --- a/build-android-arm64-v8a.sh
 +++ b/build-android-arm64-v8a.sh
-@@ -22,6 +22,21 @@ else
+@@ -22,6 +22,28 @@ else
    dir=$PWD/build-android-arm64-v8a-static
  fi
 
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ]; then
++if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ] && [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_LIB_DIR does not exist: $SITEED_SHERPA_ONNX_ORT_LIB_DIR"
++    exit 1
++  fi
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR does not exist: $SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR"
++    exit 1
++  fi
 +  SITEED_SHERPA_ONNX_ORT_LIB_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" && pwd)
-+  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
-+fi
-+
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
 +  SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
 +  export SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
-+fi
-+
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ]; then
++elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ "$BUILD_SHARED_LIBS" == ON ]; then
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_ROOT" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_ROOT does not exist: $SITEED_SHERPA_ONNX_ORT_ROOT"
++    exit 1
++  fi
 +  SITEED_SHERPA_ONNX_ORT_ROOT=$(cd "$SITEED_SHERPA_ONNX_ORT_ROOT" && pwd)
 +  export SITEED_SHERPA_ONNX_ORT_ROOT
 +fi
@@ -24,7 +31,7 @@ index d590a990..5edaf1c6 100755
  mkdir -p $dir
  cd $dir
 
-@@ -68,9 +83,15 @@ fi
+@@ -68,9 +90,15 @@ fi
 
  echo "ANDROID_NDK: $ANDROID_NDK"
  sleep 1
@@ -43,7 +50,7 @@ index d590a990..5edaf1c6 100755
    if [ ! -f $onnxruntime_version/jni/arm64-v8a/libonnxruntime.so ]; then
      mkdir -p $onnxruntime_version
      pushd $onnxruntime_version
-@@ -173,7 +194,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+@@ -173,7 +201,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
  # make VERBOSE=1 -j4
  make -j4
  make install/strip
@@ -55,24 +62,31 @@ index d590a990..5edaf1c6 100755
  if [ $SHERPA_ONNX_ENABLE_RKNN == ON ]; then
    cp -fv $SHERPA_ONNX_RKNN_TOOLKIT2_LIB_DIR/librknnrt.so install/lib
 diff --git a/build-android-armv7-eabi.sh b/build-android-armv7-eabi.sh
-index 327fca10..86fe1d97 100755
+index 327fca10..04293514 100755
 --- a/build-android-armv7-eabi.sh
 +++ b/build-android-armv7-eabi.sh
-@@ -22,6 +22,21 @@ else
+@@ -22,6 +22,28 @@ else
    dir=$PWD/build-android-armv7-eabi-static
  fi
 
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ]; then
++if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ] && [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_LIB_DIR does not exist: $SITEED_SHERPA_ONNX_ORT_LIB_DIR"
++    exit 1
++  fi
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR does not exist: $SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR"
++    exit 1
++  fi
 +  SITEED_SHERPA_ONNX_ORT_LIB_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" && pwd)
-+  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
-+fi
-+
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
 +  SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
 +  export SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
-+fi
-+
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ]; then
++elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ "$BUILD_SHARED_LIBS" == ON ]; then
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_ROOT" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_ROOT does not exist: $SITEED_SHERPA_ONNX_ORT_ROOT"
++    exit 1
++  fi
 +  SITEED_SHERPA_ONNX_ORT_ROOT=$(cd "$SITEED_SHERPA_ONNX_ORT_ROOT" && pwd)
 +  export SITEED_SHERPA_ONNX_ORT_ROOT
 +fi
@@ -80,7 +94,7 @@ index 327fca10..86fe1d97 100755
  mkdir -p $dir
  cd $dir
 
-@@ -69,9 +84,15 @@ fi
+@@ -69,9 +91,15 @@ fi
  echo "ANDROID_NDK: $ANDROID_NDK"
  sleep 1
 
@@ -98,7 +112,7 @@ index 327fca10..86fe1d97 100755
    if [ ! -f $onnxruntime_version/jni/armeabi-v7a/libonnxruntime.so ]; then
      mkdir -p $onnxruntime_version
      pushd $onnxruntime_version
-@@ -163,7 +184,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+@@ -163,7 +191,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
  # make VERBOSE=1 -j4
  make -j4
  make install/strip
@@ -110,24 +124,31 @@ index 327fca10..86fe1d97 100755
  if [ $SHERPA_ONNX_ENABLE_RKNN == ON ]; then
    cp -fv $SHERPA_ONNX_RKNN_TOOLKIT2_LIB_DIR/librknnrt.so install/lib
 diff --git a/build-android-x86-64.sh b/build-android-x86-64.sh
-index ac755690..8f42d249 100755
+index ac755690..e1c7faa8 100755
 --- a/build-android-x86-64.sh
 +++ b/build-android-x86-64.sh
-@@ -22,6 +22,21 @@ else
+@@ -22,6 +22,28 @@ else
    dir=$PWD/build-android-x86-64-static
  fi
 
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ]; then
++if [ -n "${SITEED_SHERPA_ONNX_ORT_LIB_DIR:-}" ] && [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_LIB_DIR does not exist: $SITEED_SHERPA_ONNX_ORT_LIB_DIR"
++    exit 1
++  fi
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR does not exist: $SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR"
++    exit 1
++  fi
 +  SITEED_SHERPA_ONNX_ORT_LIB_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_LIB_DIR" && pwd)
-+  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
-+fi
-+
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR:-}" ]; then
 +  SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR=$(cd "$SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR" && pwd)
++  export SITEED_SHERPA_ONNX_ORT_LIB_DIR
 +  export SITEED_SHERPA_ONNX_ORT_INCLUDE_DIR
-+fi
-+
-+if [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ]; then
++elif [ -n "${SITEED_SHERPA_ONNX_ORT_ROOT:-}" ] && [ "$BUILD_SHARED_LIBS" == ON ]; then
++  if [ ! -d "$SITEED_SHERPA_ONNX_ORT_ROOT" ]; then
++    echo "Error: SITEED_SHERPA_ONNX_ORT_ROOT does not exist: $SITEED_SHERPA_ONNX_ORT_ROOT"
++    exit 1
++  fi
 +  SITEED_SHERPA_ONNX_ORT_ROOT=$(cd "$SITEED_SHERPA_ONNX_ORT_ROOT" && pwd)
 +  export SITEED_SHERPA_ONNX_ORT_ROOT
 +fi
@@ -135,7 +156,7 @@ index ac755690..8f42d249 100755
  mkdir -p $dir
  cd $dir
 
-@@ -69,9 +84,15 @@ fi
+@@ -69,9 +91,15 @@ fi
  echo "ANDROID_NDK: $ANDROID_NDK"
  sleep 1
 
@@ -153,7 +174,7 @@ index ac755690..8f42d249 100755
    if [ ! -f $onnxruntime_version/jni/x86_64/libonnxruntime.so ]; then
      mkdir -p $onnxruntime_version
      pushd $onnxruntime_version
-@@ -147,7 +168,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+@@ -147,7 +175,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
  make -j4
  make install/strip
 


### PR DESCRIPTION
## Summary
- Update the local sherpa-onnx Android ORT override patch to normalize only the selected override mode.
- Add explicit errors for missing ORT override directories.
- Keep behavior aligned with the upstream sherpa-onnx PR #3617 follow-up.

## Validation
- `git apply --check packages/sherpa-onnx.rn/patches/OrtAndroidOverrides.patch` against `packages/sherpa-onnx.rn/third_party/sherpa-onnx`
- `bash -n build-android-arm64-v8a.sh build-android-armv7-eabi.sh build-android-x86-64.sh` after applying the patch
- `git diff --check`
