### PR TITLE
feat(sherpa): add live speaker turn session

### DIFF
--- a/.agent/session.env
+++ b/.agent/session.env
@@ -1,5 +1,0 @@
-SLOT_ID=macwork-audiolab-1
-WATCHER_PORT=7365
-ANDROID_AVD=Pixel8-Gamma
-ADB_SERIAL=emulator-5560
-IOS_SIMULATOR=audiolab-1

--- a/packages/sherpa-onnx.rn/src/__tests__/LiveSpeakerTurnSession.test.ts
+++ b/packages/sherpa-onnx.rn/src/__tests__/LiveSpeakerTurnSession.test.ts
@@ -128,6 +128,38 @@ describe('LiveSpeakerTurnSession', () => {
     ]);
   });
 
+  it('does not expose mutable speaker centroid embeddings through getState', async () => {
+    const events: LiveSpeakerTurnEvent[] = [];
+    const session = new LiveSpeakerTurnSession({
+      sampleRate: 16_000,
+      vad: createVadAdapter([true, false, false, true, false]),
+      speakerId: createSpeakerIdAdapter([
+        [1, 0],
+        [0.99, 0.01],
+      ]),
+      minTurnDurationMs: 10,
+      speakerThreshold: 0.95,
+      onEvent: (event) => events.push(event),
+    });
+
+    await session.acceptChunk({ samples: createChunk(1) });
+    await session.acceptChunk({ samples: createChunk(0) });
+
+    const state = session.getState();
+    state.speakers[0]!.embedding[0] = 0;
+    state.speakers[0]!.embedding[1] = 1;
+
+    await session.acceptChunk({ samples: createChunk(0) });
+    await session.acceptChunk({ samples: createChunk(1) });
+    await session.acceptChunk({ samples: createChunk(0) });
+
+    const finals = events.filter((event) => event.type === 'turn_final');
+    expect(finals.map((event) => event.speakerId)).toEqual([
+      'speaker_1',
+      'speaker_1',
+    ]);
+  });
+
   it('produces repeatable event streams for fixed replay input', async () => {
     async function runReplay(): Promise<LiveSpeakerTurnEvent[]> {
       const events: LiveSpeakerTurnEvent[] = [];

--- a/packages/sherpa-onnx.rn/src/__tests__/LiveSpeakerTurnSession.test.ts
+++ b/packages/sherpa-onnx.rn/src/__tests__/LiveSpeakerTurnSession.test.ts
@@ -1,0 +1,167 @@
+import { LiveSpeakerTurnSession } from '../services/LiveSpeakerTurnSession';
+import type {
+  LiveSpeakerTurnEvent,
+  LiveSpeakerTurnSpeakerIdAdapter,
+  LiveSpeakerTurnVadAdapter,
+  VadAcceptWaveformResult,
+} from '../types/interfaces';
+
+function createChunk(value: number, length = 160): number[] {
+  return Array.from({ length }, () => value);
+}
+
+function createVadAdapter(decisions: boolean[]): LiveSpeakerTurnVadAdapter {
+  let index = 0;
+  return {
+    async acceptWaveform(): Promise<VadAcceptWaveformResult> {
+      const isSpeechDetected = decisions[index] ?? false;
+      index += 1;
+      return {
+        success: true,
+        isSpeechDetected,
+        segments: [],
+      };
+    },
+  };
+}
+
+function createSpeakerIdAdapter(
+  embeddings: number[][]
+): LiveSpeakerTurnSpeakerIdAdapter & { processedSamples: number[] } {
+  let index = 0;
+  const processedSamples: number[] = [];
+  return {
+    processedSamples,
+    async processSamples(_sampleRate: number, samples: number[]) {
+      processedSamples.push(samples.length);
+      return {
+        success: true,
+        samplesProcessed: samples.length,
+      };
+    },
+    async computeEmbedding() {
+      const embedding = embeddings[index] ?? embeddings[embeddings.length - 1];
+      index += 1;
+      return {
+        success: true,
+        durationMs: 1,
+        embedding: embedding ?? [1, 0],
+        embeddingDim: embedding?.length ?? 2,
+      };
+    },
+  };
+}
+
+describe('LiveSpeakerTurnSession', () => {
+  it('emits a deterministic speaker turn event sequence from mocked VAD and Speaker ID adapters', async () => {
+    const events: LiveSpeakerTurnEvent[] = [];
+    const speakerId = createSpeakerIdAdapter([[1, 0]]);
+    const session = new LiveSpeakerTurnSession({
+      sampleRate: 16_000,
+      vad: createVadAdapter([false, true, true, false]),
+      speakerId,
+      minTurnDurationMs: 10,
+      speakerThreshold: 0.9,
+      onEvent: (event) => events.push(event),
+    });
+
+    await session.acceptChunk({ samples: createChunk(0) });
+    await session.acceptChunk({ samples: createChunk(1) });
+    await session.acceptChunk({ samples: createChunk(1) });
+    await session.acceptChunk({ samples: createChunk(0) });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'speech_start',
+      'speech_end',
+      'speaker_pending',
+      'speaker_resolved',
+      'turn_final',
+    ]);
+    expect(events[0]).toMatchObject({
+      type: 'speech_start',
+      turnId: 'turn_1',
+      startMs: 10,
+      startSample: 160,
+    });
+    expect(events[4]).toMatchObject({
+      type: 'turn_final',
+      turnId: 'turn_1',
+      speakerId: 'speaker_1',
+      startMs: 10,
+      endMs: 40,
+    });
+    expect(speakerId.processedSamples).toEqual([480]);
+    expect(session.getSummary()).toEqual({
+      eventCount: 5,
+      turnCount: 1,
+      speakerCount: 1,
+      durationMs: 40,
+    });
+  });
+
+  it('keeps same-speaker repeated turns mapped to a stable speaker id', async () => {
+    const events: LiveSpeakerTurnEvent[] = [];
+    const session = new LiveSpeakerTurnSession({
+      sampleRate: 16_000,
+      vad: createVadAdapter([true, false, false, true, false]),
+      speakerId: createSpeakerIdAdapter([
+        [1, 0],
+        [0.99, 0.01],
+      ]),
+      minTurnDurationMs: 10,
+      speakerThreshold: 0.95,
+      onEvent: (event) => events.push(event),
+    });
+
+    for (const value of [1, 0, 0, 1, 0]) {
+      await session.acceptChunk({ samples: createChunk(value) });
+    }
+
+    const finals = events.filter((event) => event.type === 'turn_final');
+    expect(finals).toHaveLength(2);
+    expect(finals.map((event) => event.speakerId)).toEqual([
+      'speaker_1',
+      'speaker_1',
+    ]);
+    expect(session.getState().speakers).toMatchObject([
+      { speakerId: 'speaker_1', turnCount: 2 },
+    ]);
+  });
+
+  it('produces repeatable event streams for fixed replay input', async () => {
+    async function runReplay(): Promise<LiveSpeakerTurnEvent[]> {
+      const events: LiveSpeakerTurnEvent[] = [];
+      const session = new LiveSpeakerTurnSession({
+        sampleRate: 16_000,
+        vad: createVadAdapter([true, false, true, false]),
+        speakerId: createSpeakerIdAdapter([
+          [1, 0],
+          [0, 1],
+        ]),
+        minTurnDurationMs: 10,
+        speakerThreshold: 0.95,
+        onEvent: (event) => events.push(event),
+      });
+
+      for (const value of [1, 0, 2, 0]) {
+        await session.acceptChunk({ samples: createChunk(value) });
+      }
+      return events;
+    }
+
+    await expect(runReplay()).resolves.toEqual(await runReplay());
+  });
+
+  it('rejects non-monotonic sample clocks', async () => {
+    const session = new LiveSpeakerTurnSession({
+      sampleRate: 16_000,
+      vad: createVadAdapter([false]),
+      speakerId: createSpeakerIdAdapter([[1, 0]]),
+    });
+
+    await session.acceptChunk({ samples: createChunk(0), startSample: 160 });
+    await expect(
+      session.acceptChunk({ samples: createChunk(0), startSample: 0 })
+    ).rejects.toThrow('non-monotonic startSample');
+  });
+});

--- a/packages/sherpa-onnx.rn/src/index.ts
+++ b/packages/sherpa-onnx.rn/src/index.ts
@@ -11,6 +11,7 @@ import { SpeakerIdService } from './services/SpeakerIdService';
 import { TtsService } from './services/TtsService';
 import { OnnxInferenceService } from './services/OnnxInferenceService';
 import { VadService } from './services/VadService';
+import { LiveSpeakerTurnSession } from './services/LiveSpeakerTurnSession';
 import type { ApiInterface } from './types/api';
 import type { SherpaOnnxInterface } from './types/interfaces';
 
@@ -44,6 +45,7 @@ const SherpaOnnx: SherpaOnnxInterface = {
   Diarization: diarizationService,
   Denoising: denoisingService,
   OnnxInference: onnxInferenceService,
+  LiveSpeakerTurnSession,
 };
 
 // Export the main interface
@@ -61,6 +63,7 @@ export const Punctuation = punctuationService;
 export const Diarization = diarizationService;
 export const Denoising = denoisingService;
 export const OnnxInference = onnxInferenceService;
+export { LiveSpeakerTurnSession };
 
 // Export types
 export * from './types/api';
@@ -77,8 +80,20 @@ export type { TypedTensorData } from './utils/tensorUtils';
 
 // Export OnnxSession class
 export { OnnxSession } from './services/OnnxInferenceService';
-export type { OnnxSessionRunFeeds, OnnxSessionRunOutputs } from './services/OnnxInferenceService';
+export type {
+  OnnxSessionRunFeeds,
+  OnnxSessionRunOutputs,
+} from './services/OnnxInferenceService';
 
 // Export web utilities
-export { loadWasmModule, configureSherpaOnnx, isSherpaOnnxReady, waitForReady } from './web/wasmLoader';
-export type { SherpaOnnxConfig, WasmLoadOptions, WasmLoadProgressEvent } from './web/wasmLoader';
+export {
+  loadWasmModule,
+  configureSherpaOnnx,
+  isSherpaOnnxReady,
+  waitForReady,
+} from './web/wasmLoader';
+export type {
+  SherpaOnnxConfig,
+  WasmLoadOptions,
+  WasmLoadProgressEvent,
+} from './web/wasmLoader';

--- a/packages/sherpa-onnx.rn/src/services/LiveSpeakerTurnSession.ts
+++ b/packages/sherpa-onnx.rn/src/services/LiveSpeakerTurnSession.ts
@@ -1,0 +1,437 @@
+import type {
+  LiveSpeakerTurnChunk,
+  LiveSpeakerTurnConfig,
+  LiveSpeakerTurnEvent,
+  LiveSpeakerTurnEventListener,
+  LiveSpeakerTurnSessionState,
+  LiveSpeakerTurnSpeakerCentroid,
+  LiveSpeakerTurnSummary,
+} from '../types/interfaces';
+
+interface BufferedChunk {
+  startSample: number;
+  samples: number[];
+}
+
+const DEFAULT_MIN_TURN_DURATION_MS = 250;
+const DEFAULT_SPEAKER_THRESHOLD = 0.5;
+const DEFAULT_MAX_RING_BUFFER_DURATION_MS = 60_000;
+const DEFAULT_CENTROID_UPDATE_ALPHA = 0.25;
+
+function samplesToMs(samples: number, sampleRate: number): number {
+  return (samples / sampleRate) * 1000;
+}
+
+function msToSamples(ms: number, sampleRate: number): number {
+  return Math.round((ms / 1000) * sampleRate);
+}
+
+function normalizeEmbedding(embedding: number[]): number[] {
+  const magnitude = Math.sqrt(
+    embedding.reduce((sum, value) => sum + value * value, 0)
+  );
+  if (magnitude === 0) {
+    return embedding.map(() => 0);
+  }
+  return embedding.map((value) => value / magnitude);
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const length = Math.min(a.length, b.length);
+  let score = 0;
+  for (let index = 0; index < length; index += 1) {
+    score += (a[index] ?? 0) * (b[index] ?? 0);
+  }
+  return score;
+}
+
+function movingAverageCentroid(
+  current: number[],
+  next: number[],
+  alpha: number
+): number[] {
+  const length = Math.max(current.length, next.length);
+  const merged: number[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const currentValue = current[index] ?? 0;
+    const nextValue = next[index] ?? 0;
+    merged.push(currentValue * (1 - alpha) + nextValue * alpha);
+  }
+  return normalizeEmbedding(merged);
+}
+
+/**
+ * Replayable live speaker-turn session built from VAD + Speaker ID adapters.
+ *
+ * This class intentionally stays in TypeScript and has no native dependency. It
+ * owns the event contract and deterministic sample-clock behavior so later PRs
+ * can wire real mobile audio sources without changing public events.
+ */
+export class LiveSpeakerTurnSession {
+  private readonly config: LiveSpeakerTurnConfig;
+  private readonly listeners = new Set<LiveSpeakerTurnEventListener>();
+  private readonly emittedEvents: LiveSpeakerTurnEvent[] = [];
+  private readonly ringBuffer: BufferedChunk[] = [];
+  private readonly centroids: LiveSpeakerTurnSpeakerCentroid[] = [];
+  private nextSample = 0;
+  private nextTurnIndex = 1;
+  private nextSpeakerIndex = 1;
+  private activeTurnId: string | null = null;
+  private activeTurnStartSample: number | null = null;
+  private speechActive = false;
+  private released = false;
+
+  constructor(config: LiveSpeakerTurnConfig) {
+    if (!Number.isFinite(config.sampleRate) || config.sampleRate <= 0) {
+      throw new Error('LiveSpeakerTurnSession requires a positive sampleRate');
+    }
+    this.config = config;
+    if (config.onEvent) {
+      this.listeners.add(config.onEvent);
+    }
+  }
+
+  public onEvent(listener: LiveSpeakerTurnEventListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public getState(): LiveSpeakerTurnSessionState {
+    return {
+      released: this.released,
+      speechActive: this.speechActive,
+      activeTurnId: this.activeTurnId,
+      nextSample: this.nextSample,
+      speakers: this.centroids.map((centroid) => ({ ...centroid })),
+      events: [...this.emittedEvents],
+    };
+  }
+
+  public async acceptChunk(chunk: LiveSpeakerTurnChunk): Promise<void> {
+    this.ensureNotReleased();
+
+    const sampleRate = chunk.sampleRate ?? this.config.sampleRate;
+    if (sampleRate !== this.config.sampleRate) {
+      throw new Error(
+        `LiveSpeakerTurnSession expected sampleRate ${this.config.sampleRate}, received ${sampleRate}`
+      );
+    }
+
+    const startSample = chunk.startSample ?? this.nextSample;
+    if (startSample < this.nextSample) {
+      throw new Error(
+        `LiveSpeakerTurnSession received non-monotonic startSample ${startSample}; next expected sample is ${this.nextSample}`
+      );
+    }
+
+    const samples = Array.from(chunk.samples);
+    this.appendToRingBuffer(startSample, samples);
+    this.nextSample = startSample + samples.length;
+
+    const vadResult = await this.config.vad.acceptWaveform(sampleRate, samples);
+    if (!vadResult.success) {
+      this.emit({
+        type: 'error',
+        error: vadResult.error ?? 'VAD failed while processing live chunk',
+      });
+      return;
+    }
+
+    if (vadResult.isSpeechDetected && !this.speechActive) {
+      this.startTurn(startSample);
+    }
+
+    if (!vadResult.isSpeechDetected && this.speechActive) {
+      await this.finishTurn(this.nextSample);
+    }
+  }
+
+  public async flush(): Promise<void> {
+    this.ensureNotReleased();
+    if (this.speechActive) {
+      await this.finishTurn(this.nextSample);
+    }
+  }
+
+  public reset(): void {
+    this.ensureNotReleased();
+    this.ringBuffer.splice(0, this.ringBuffer.length);
+    this.centroids.splice(0, this.centroids.length);
+    this.emittedEvents.splice(0, this.emittedEvents.length);
+    this.nextSample = 0;
+    this.nextTurnIndex = 1;
+    this.nextSpeakerIndex = 1;
+    this.activeTurnId = null;
+    this.activeTurnStartSample = null;
+    this.speechActive = false;
+  }
+
+  public release(): void {
+    if (this.released) {
+      return;
+    }
+    this.released = true;
+    this.emit({ type: 'released' });
+    this.listeners.clear();
+    this.ringBuffer.splice(0, this.ringBuffer.length);
+  }
+
+  public getSummary(): LiveSpeakerTurnSummary {
+    const turnFinalEvents = this.emittedEvents.filter(
+      (event) => event.type === 'turn_final'
+    );
+    const speakerIds = new Set(
+      turnFinalEvents
+        .map((event) => event.speakerId)
+        .filter((speakerId): speakerId is string => Boolean(speakerId))
+    );
+
+    return {
+      eventCount: this.emittedEvents.length,
+      turnCount: turnFinalEvents.length,
+      speakerCount: speakerIds.size,
+      durationMs: samplesToMs(this.nextSample, this.config.sampleRate),
+    };
+  }
+
+  private startTurn(startSample: number): void {
+    const turnId = `turn_${this.nextTurnIndex}`;
+    this.nextTurnIndex += 1;
+    this.activeTurnId = turnId;
+    this.activeTurnStartSample = startSample;
+    this.speechActive = true;
+    this.emit({
+      type: 'speech_start',
+      turnId,
+      startMs: samplesToMs(startSample, this.config.sampleRate),
+      startSample,
+    });
+  }
+
+  private async finishTurn(endSample: number): Promise<void> {
+    const turnId = this.activeTurnId;
+    const startSample = this.activeTurnStartSample;
+    if (!turnId || startSample === null) {
+      return;
+    }
+
+    this.speechActive = false;
+    this.activeTurnId = null;
+    this.activeTurnStartSample = null;
+
+    const minTurnSamples = msToSamples(
+      this.config.minTurnDurationMs ?? DEFAULT_MIN_TURN_DURATION_MS,
+      this.config.sampleRate
+    );
+    const speechPadSamples = msToSamples(
+      this.config.speechPadMs ?? 0,
+      this.config.sampleRate
+    );
+    const paddedStartSample = Math.max(0, startSample - speechPadSamples);
+    const paddedEndSample = endSample + speechPadSamples;
+    const durationSamples = endSample - startSample;
+
+    this.emit({
+      type: 'speech_end',
+      turnId,
+      startMs: samplesToMs(startSample, this.config.sampleRate),
+      endMs: samplesToMs(endSample, this.config.sampleRate),
+      startSample,
+      endSample,
+    });
+
+    if (durationSamples < minTurnSamples) {
+      this.emit({
+        type: 'turn_discarded',
+        turnId,
+        reason: 'too_short',
+        durationMs: samplesToMs(durationSamples, this.config.sampleRate),
+      });
+      return;
+    }
+
+    this.emit({ type: 'speaker_pending', turnId });
+    const turnSamples = this.samplesForRange(
+      paddedStartSample,
+      paddedEndSample
+    );
+    const processResult = await this.config.speakerId.processSamples(
+      this.config.sampleRate,
+      turnSamples
+    );
+    if (!processResult.success) {
+      this.emit({
+        type: 'error',
+        turnId,
+        error:
+          processResult.error ??
+          'Speaker ID failed while processing turn audio',
+      });
+      this.emitFinalTurn(turnId, startSample, endSample);
+      return;
+    }
+
+    const embeddingResult = await this.config.speakerId.computeEmbedding();
+    if (!embeddingResult.success) {
+      this.emit({
+        type: 'error',
+        turnId,
+        error:
+          embeddingResult.error ??
+          'Speaker ID failed while computing embedding',
+      });
+      this.emitFinalTurn(turnId, startSample, endSample);
+      return;
+    }
+
+    const assignment = this.assignSpeaker(embeddingResult.embedding);
+    this.emit({
+      type: 'speaker_resolved',
+      turnId,
+      speakerId: assignment.speakerId,
+      confidence: assignment.confidence,
+      provenance: assignment.provenance,
+    });
+    this.emitFinalTurn(turnId, startSample, endSample, assignment.speakerId);
+  }
+
+  private emitFinalTurn(
+    turnId: string,
+    startSample: number,
+    endSample: number,
+    speakerId?: string
+  ): void {
+    this.emit({
+      type: 'turn_final',
+      turnId,
+      startMs: samplesToMs(startSample, this.config.sampleRate),
+      endMs: samplesToMs(endSample, this.config.sampleRate),
+      startSample,
+      endSample,
+      speakerId,
+    });
+  }
+
+  private assignSpeaker(embedding: number[]): {
+    speakerId: string;
+    confidence: number;
+    provenance: 'centroid_match' | 'new_speaker';
+  } {
+    const normalizedEmbedding = normalizeEmbedding(embedding);
+    let bestMatch: LiveSpeakerTurnSpeakerCentroid | null = null;
+    let bestScore = -Infinity;
+
+    for (const centroid of this.centroids) {
+      const score = cosineSimilarity(normalizedEmbedding, centroid.embedding);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = centroid;
+      }
+    }
+
+    const threshold = this.config.speakerThreshold ?? DEFAULT_SPEAKER_THRESHOLD;
+    if (bestMatch && bestScore >= threshold) {
+      bestMatch.turnCount += 1;
+      if (this.config.centroidUpdate !== 'none') {
+        const alpha =
+          this.config.centroidUpdateAlpha ?? DEFAULT_CENTROID_UPDATE_ALPHA;
+        bestMatch.embedding = movingAverageCentroid(
+          bestMatch.embedding,
+          normalizedEmbedding,
+          alpha
+        );
+      }
+      return {
+        speakerId: bestMatch.speakerId,
+        confidence: bestScore,
+        provenance: 'centroid_match',
+      };
+    }
+
+    const maxSpeakers = this.config.maxSpeakers;
+    if (
+      typeof maxSpeakers === 'number' &&
+      this.centroids.length >= maxSpeakers &&
+      bestMatch
+    ) {
+      return {
+        speakerId: bestMatch.speakerId,
+        confidence: bestScore,
+        provenance: 'centroid_match',
+      };
+    }
+
+    const speakerId = `speaker_${this.nextSpeakerIndex}`;
+    this.nextSpeakerIndex += 1;
+    this.centroids.push({
+      speakerId,
+      embedding: normalizedEmbedding,
+      turnCount: 1,
+    });
+    return {
+      speakerId,
+      confidence: 1,
+      provenance: 'new_speaker',
+    };
+  }
+
+  private appendToRingBuffer(startSample: number, samples: number[]): void {
+    if (samples.length === 0) {
+      return;
+    }
+    this.ringBuffer.push({ startSample, samples });
+    const latestSample = startSample + samples.length;
+    const maxBufferSamples = msToSamples(
+      this.config.maxRingBufferDurationMs ??
+        DEFAULT_MAX_RING_BUFFER_DURATION_MS,
+      this.config.sampleRate
+    );
+    const oldestAllowedSample = Math.max(0, latestSample - maxBufferSamples);
+    while (this.ringBuffer.length > 0) {
+      const firstChunk = this.ringBuffer[0];
+      if (!firstChunk) {
+        return;
+      }
+      const firstChunkEnd = firstChunk.startSample + firstChunk.samples.length;
+      if (firstChunkEnd >= oldestAllowedSample) {
+        return;
+      }
+      this.ringBuffer.shift();
+    }
+  }
+
+  private samplesForRange(startSample: number, endSample: number): number[] {
+    const output: number[] = [];
+    for (const chunk of this.ringBuffer) {
+      const chunkStart = chunk.startSample;
+      const chunkEnd = chunk.startSample + chunk.samples.length;
+      const overlapStart = Math.max(startSample, chunkStart);
+      const overlapEnd = Math.min(endSample, chunkEnd);
+      if (overlapStart >= overlapEnd) {
+        continue;
+      }
+      output.push(
+        ...chunk.samples.slice(
+          overlapStart - chunkStart,
+          overlapEnd - chunkStart
+        )
+      );
+    }
+    return output;
+  }
+
+  private emit(event: LiveSpeakerTurnEvent): void {
+    this.emittedEvents.push(event);
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  private ensureNotReleased(): void {
+    if (this.released) {
+      throw new Error('LiveSpeakerTurnSession has been released');
+    }
+  }
+}

--- a/packages/sherpa-onnx.rn/src/services/LiveSpeakerTurnSession.ts
+++ b/packages/sherpa-onnx.rn/src/services/LiveSpeakerTurnSession.ts
@@ -104,7 +104,10 @@ export class LiveSpeakerTurnSession {
       speechActive: this.speechActive,
       activeTurnId: this.activeTurnId,
       nextSample: this.nextSample,
-      speakers: this.centroids.map((centroid) => ({ ...centroid })),
+      speakers: this.centroids.map((centroid) => ({
+        ...centroid,
+        embedding: [...centroid.embedding],
+      })),
       events: [...this.emittedEvents],
     };
   }

--- a/packages/sherpa-onnx.rn/src/types/interfaces.ts
+++ b/packages/sherpa-onnx.rn/src/types/interfaces.ts
@@ -10,6 +10,7 @@ import { LanguageIdService } from '../services/LanguageIdService';
 import { PunctuationService } from '../services/PunctuationService';
 import { DiarizationService } from '../services/DiarizationService';
 import { OnnxInferenceService } from '../services/OnnxInferenceService';
+import type { LiveSpeakerTurnSession } from '../services/LiveSpeakerTurnSession';
 
 /**
  * Provider type for model inference
@@ -1035,7 +1036,8 @@ export interface SpeakerIdFileProcessResult {
   error?: string;
 }
 
-export interface SpeakerIdFileWindowProcessResult extends SpeakerIdFileProcessResult {
+export interface SpeakerIdFileWindowProcessResult
+  extends SpeakerIdFileProcessResult {
   /**
    * Start offset of the processed window in milliseconds.
    */
@@ -1169,6 +1171,137 @@ export interface VadAcceptWaveformResult {
   /** Completed speech segments found in this chunk */
   segments: SpeechSegment[];
   error?: string;
+}
+
+// ----------------------------------------------------------------------------------
+// Live speaker turn interfaces
+// ----------------------------------------------------------------------------------
+
+export interface LiveSpeakerTurnChunk {
+  /** PCM samples for this chunk. Samples are expected to be mono float PCM. */
+  samples: ArrayLike<number>;
+  /** Optional per-chunk sample rate. Must match the session sampleRate when set. */
+  sampleRate?: number;
+  /** Optional absolute start sample. Omit for contiguous replay/live streams. */
+  startSample?: number;
+}
+
+export interface LiveSpeakerTurnVadAdapter {
+  acceptWaveform(
+    sampleRate: number,
+    samples: number[]
+  ): Promise<VadAcceptWaveformResult>;
+}
+
+export interface LiveSpeakerTurnSpeakerIdAdapter {
+  processSamples(
+    sampleRate: number,
+    samples: number[]
+  ): Promise<SpeakerIdProcessResult>;
+  computeEmbedding(): Promise<SpeakerEmbeddingResult>;
+}
+
+export type LiveSpeakerTurnProvenance = 'centroid_match' | 'new_speaker';
+
+export type LiveSpeakerTurnEvent =
+  | {
+      type: 'speech_start';
+      turnId: string;
+      startMs: number;
+      startSample: number;
+    }
+  | {
+      type: 'speech_end';
+      turnId: string;
+      startMs: number;
+      endMs: number;
+      startSample: number;
+      endSample: number;
+    }
+  | {
+      type: 'speaker_pending';
+      turnId: string;
+    }
+  | {
+      type: 'speaker_resolved';
+      turnId: string;
+      speakerId: string;
+      confidence: number;
+      provenance: LiveSpeakerTurnProvenance;
+    }
+  | {
+      type: 'turn_final';
+      turnId: string;
+      startMs: number;
+      endMs: number;
+      startSample: number;
+      endSample: number;
+      speakerId?: string;
+    }
+  | {
+      type: 'turn_discarded';
+      turnId: string;
+      reason: 'too_short';
+      durationMs: number;
+    }
+  | {
+      type: 'error';
+      error: string;
+      turnId?: string;
+    }
+  | {
+      type: 'released';
+    };
+
+export type LiveSpeakerTurnEventListener = (
+  event: LiveSpeakerTurnEvent
+) => void;
+
+export interface LiveSpeakerTurnConfig {
+  /** Session sample rate. All chunks must use this rate. */
+  sampleRate: number;
+  /** Adapter that provides VAD decisions. */
+  vad: LiveSpeakerTurnVadAdapter;
+  /** Adapter that computes one speaker embedding per finalized turn. */
+  speakerId: LiveSpeakerTurnSpeakerIdAdapter;
+  /** Optional event callback. Additional listeners can be registered with onEvent. */
+  onEvent?: LiveSpeakerTurnEventListener;
+  /** Minimum finalized speech duration before speaker embedding. Default: 250 ms. */
+  minTurnDurationMs?: number;
+  /** Extra audio included before/after turn boundaries for embedding. Default: 0 ms. */
+  speechPadMs?: number;
+  /** Cosine-similarity threshold for assigning a turn to an existing speaker. Default: 0.5. */
+  speakerThreshold?: number;
+  /** Optional cap on speakers. New turns fall back to the nearest centroid after the cap. */
+  maxSpeakers?: number;
+  /** Centroid update policy after a matched turn. Default: moving_average. */
+  centroidUpdate?: 'moving_average' | 'none';
+  /** Moving-average alpha for centroid updates. Default: 0.25. */
+  centroidUpdateAlpha?: number;
+  /** Bounded PCM buffer duration. Default: 60 seconds. */
+  maxRingBufferDurationMs?: number;
+}
+
+export interface LiveSpeakerTurnSpeakerCentroid {
+  speakerId: string;
+  embedding: number[];
+  turnCount: number;
+}
+
+export interface LiveSpeakerTurnSessionState {
+  released: boolean;
+  speechActive: boolean;
+  activeTurnId: string | null;
+  nextSample: number;
+  speakers: LiveSpeakerTurnSpeakerCentroid[];
+  events: LiveSpeakerTurnEvent[];
+}
+
+export interface LiveSpeakerTurnSummary {
+  eventCount: number;
+  turnCount: number;
+  speakerCount: number;
+  durationMs: number;
 }
 
 // ----------------------------------------------------------------------------------
@@ -1349,7 +1482,9 @@ export interface NativeSherpaOnnxInterface {
   releaseSpeakerId(): Promise<{ released: boolean }>;
 
   // Diarization methods
-  initDiarization(config: DiarizationModelConfig): Promise<DiarizationInitResult>;
+  initDiarization(
+    config: DiarizationModelConfig
+  ): Promise<DiarizationInitResult>;
   processDiarizationFile(
     filePath: string,
     numClusters: number,
@@ -1392,7 +1527,9 @@ export interface NativeSherpaOnnxInterface {
   releaseLanguageId(): Promise<{ released: boolean }>;
 
   // Punctuation methods
-  initPunctuation(config: PunctuationModelConfig): Promise<PunctuationInitResult>;
+  initPunctuation(
+    config: PunctuationModelConfig
+  ): Promise<PunctuationInitResult>;
   addPunctuation(text: string): Promise<PunctuationResult>;
   releasePunctuation(): Promise<{ released: boolean }>;
 
@@ -1444,6 +1581,7 @@ export interface SherpaOnnxInterface extends ApiInterface {
   Diarization: DiarizationService;
   Denoising: import('../services/DenoisingService').DenoisingService;
   OnnxInference: OnnxInferenceService;
+  LiveSpeakerTurnSession: typeof LiveSpeakerTurnSession;
 }
 
 // ----------------------------------------------------------------------------------

--- a/packages/sherpa-onnx.rn/src/web/features/diarization.ts
+++ b/packages/sherpa-onnx.rn/src/web/features/diarization.ts
@@ -1,7 +1,10 @@
 import { loadCombinedWasm, detectWasmBasePath } from '../wasmLoader';
 import { fetchAndDecodeAudio } from '../audioUtils';
 import type { OfflineSpeakerDiarizationInstance } from '../wasmTypes';
-import type { DiarizationFileInput, DiarizationFileWindowInput } from '../../types/api';
+import type {
+  DiarizationFileInput,
+  DiarizationFileWindowInput,
+} from '../../types/api';
 import { type Constructor, withDownloadProgress } from './mixinUtils';
 import { WasmWorkerManager } from '../workers/WasmWorkerManager';
 
@@ -9,7 +12,7 @@ export function DiarizationMixin<TBase extends Constructor>(Base: TBase) {
   return class extends Base {
     public diarization: OfflineSpeakerDiarizationInstance | null = null;
     public diarizationWorker: WasmWorkerManager | null = null;
-    private diarizationClustering = { numClusters: -1, threshold: 0.5 };
+    public diarizationClustering = { numClusters: -1, threshold: 0.5 };
 
     async initDiarization(config: any): Promise<{
       success: boolean;
@@ -18,7 +21,8 @@ export function DiarizationMixin<TBase extends Constructor>(Base: TBase) {
     }> {
       try {
         const debug = config?.debug ? 1 : 0;
-        const modelDir = config?.modelDir || config?.segmentationModelDir || '/wasm/speakers';
+        const modelDir =
+          config?.modelDir || config?.segmentationModelDir || '/wasm/speakers';
         const fetchBase = config?.modelBaseUrl || modelDir;
 
         // Try worker path first for non-blocking inference
@@ -37,10 +41,15 @@ export function DiarizationMixin<TBase extends Constructor>(Base: TBase) {
               minDurationOff: config?.minDurationOff,
             });
             this.diarizationWorker = mgr;
-            console.log(`[Diarization] Worker initialized: sampleRate=${result.sampleRate}`);
+            console.log(
+              `[Diarization] Worker initialized: sampleRate=${result.sampleRate}`
+            );
             return { success: true, sampleRate: result.sampleRate };
           } catch (e) {
-            console.warn('[Diarization] Worker init failed, falling back to main thread:', e);
+            console.warn(
+              '[Diarization] Worker init failed, falling back to main thread:',
+              e
+            );
           }
         }
 
@@ -208,9 +217,18 @@ export function DiarizationMixin<TBase extends Constructor>(Base: TBase) {
         const startedAt = performance.now();
         const decoded = await fetchAndDecodeAudio(filePath);
         const sampleRate = this.diarization?.sampleRate ?? 16000;
-        const startSample = Math.max(0, Math.floor((startTimeMs / 1000) * sampleRate));
-        const sampleCount = Math.max(0, Math.floor((durationMs / 1000) * sampleRate));
-        const samples = decoded.samples.subarray(startSample, startSample + sampleCount);
+        const startSample = Math.max(
+          0,
+          Math.floor((startTimeMs / 1000) * sampleRate)
+        );
+        const sampleCount = Math.max(
+          0,
+          Math.floor((durationMs / 1000) * sampleRate)
+        );
+        const samples = decoded.samples.subarray(
+          startSample,
+          startSample + sampleCount
+        );
         const offsetSeconds = startTimeMs / 1000;
 
         let segments: Array<{ start: number; end: number; speaker: number }>;
@@ -222,7 +240,8 @@ export function DiarizationMixin<TBase extends Constructor>(Base: TBase) {
           segments = result.segments;
         } else {
           const previousClustering = this.diarizationClustering;
-          const shouldOverrideClustering = numClusters !== -1 || threshold !== 0.5;
+          const shouldOverrideClustering =
+            numClusters !== -1 || threshold !== 0.5;
           if (shouldOverrideClustering) {
             this.diarization!.setConfig({
               clustering: { numClusters, threshold },
@@ -255,7 +274,10 @@ export function DiarizationMixin<TBase extends Constructor>(Base: TBase) {
           samples: samples.length,
         };
       } catch (error) {
-        console.error('[Diarization] processDiarizationFileWindow failed:', error);
+        console.error(
+          '[Diarization] processDiarizationFileWindow failed:',
+          error
+        );
         return {
           success: false,
           segments: [],


### PR DESCRIPTION
## Summary
- Add `LiveSpeakerTurnSession`, a TypeScript-first live speaker-turn event contract over mockable VAD + Speaker ID adapters.
- Add deterministic replay tests for speech turn events, stable speaker assignment, repeatability, and sample-clock validation.
- Export the session and live speaker-turn types from `@siteed/sherpa-onnx.rn`.
- Fix web diarization declaration emit by making the exported mixin clustering state public; runtime behavior is unchanged.

## Validation
- `yarn workspace @siteed/sherpa-onnx.rn typecheck`
- `yarn workspace @siteed/sherpa-onnx.rn test LiveSpeakerTurnSession.test.ts --runInBand`
- `yarn workspace @siteed/sherpa-onnx.rn test --runInBand`
- `cd packages/sherpa-onnx.rn && yarn eslint src/services/LiveSpeakerTurnSession.ts src/__tests__/LiveSpeakerTurnSession.test.ts src/types/interfaces.ts src/index.ts src/web/features/diarization.ts`
- `yarn workspace @siteed/sherpa-onnx.rn prepare`
- `git diff --check`

## Notes
- This is PR 1 from the live speaker-turn plan: package API/event contract and mocked deterministic replay tests only.
- No native Android/iOS changes and no app UI changes are included.
