### PR TITLE
feat(sherpa): polish live diarization validation

### DIFF
--- a/apps/sherpa-voice/docs/diarization-validation.md
+++ b/apps/sherpa-voice/docs/diarization-validation.md
@@ -410,8 +410,8 @@ This gives local evidence that Sherpa ONNX can stay stable for 1-hour / 4-speake
 | Good diarization with Sherpa ONNX locally | Covered for selected fixed-count cases | 5-min DER 6.41%, 60-min DER 5.29%, 4-speaker short DER 6.33%, 4-speaker 60-min stress DER 7.75% | Natural long 4-speaker recording still desirable. |
 | Up to 4 speakers | Covered locally | `0-four-speakers-zh` fixed-4 and repeated 60-min fixed-4 both return 4 speakers with low confusion | Natural 4-speaker long recording still desirable. |
 | Up to 1 hour | Covered on Python, Android physical, iOS simulator, and iPhone 12 physical | real 60-min 2-speaker fixture scored at 5.29% DER in Python, 6.15% DER on Pixel 6a native, and 5.89% DER on iOS simulator/iPhone 12 native | Natural long 4-speaker recording still desirable. |
-| Correct speaker turns | Partially covered | low formal DER/JER and confusion versus EchoBridge/repeated references | Need human spot-check/UI evidence and live-audio turn behavior later. |
-| Live audio eventually | Not yet covered | none | Future work; current validation is offline file diarization. |
+| Correct speaker turns | Partially covered | low formal DER/JER and confusion versus EchoBridge/repeated references; live replay emits transcript-attributed `turn_finalized` events | Need broader natural multi-speaker live-mic spot checks. |
+| Live audio eventually | Covered for keep-up and controlled speech | Pixel 6a replay and live-mic recipes keep up; controlled macOS `say` capture produced one final speaker-attributed transcript | Not a formal DER benchmark; offline/windowed diarization remains the quality baseline. |
 | Update `sherpa-onnx.rn` accordingly | Implemented for offline file windows | RN/native exposes segmentation model filename, file windows, speaker embedding file windows, and app-level global re-ID | API cleanup and normal SherpaVoiceDev iOS provisioning remain. |
 
 ## Current recommendation
@@ -491,4 +491,32 @@ Representative command:
 cd apps/sherpa-voice
 (sleep 2; say -r 180 'This is a controlled live microphone validation. Speaker one is talking now. The live transcription should hear this sentence and keep up with the audio stream.') &
 node scripts/agentic/cdp-bridge.mjs --device 'Pixel 6a' eval "JSON.stringify(globalThis.__AGENTIC__?.testLiveMicTranscriptionDiarization?.({durationMs:18000,chunkDurationMs:100,asrModelId:'streaming-zipformer-en-20m-mobile',vadModelId:'silero-vad-v5',speakerIdModelId:'speaker-id-en-voxceleb'}))"
+```
+
+### Mobile defaults and tuning guidance
+
+Use two separate defaults: one for **offline quality diarization** and one for **live UX**.
+
+| Use case | Mid-range default (Pixel 6 / Pixel 6a class, iPhone 12 class) | New/high-end tuning |
+| --- | --- | --- |
+| Offline long diarization quality | 5-minute native file windows, fixed `numClusters` when known, `pyannote-segmentation-3-0/model.onnx`, `speaker-id-3dspeaker-eres2net-en`, 2 threads | Same quality profile first; optionally benchmark larger embeddings such as `speaker-id-nemo-titanet-large` before exposing as a user default |
+| Live transcription + turn attribution | `streaming-zipformer-en-20m-mobile`, `silero-vad-v5`, `speaker-id-en-voxceleb`, 100 ms chunks, `minTurnDurationMs=1000`, `speechPadMs=120`, `speakerThreshold=0.55`, 1-2 ASR/Speaker threads and VAD single-threaded | Try larger streaming ASR / extra ASR threads only if recipe evidence keeps average chunk processing below the chunk duration and queue depth <= 2 |
+| Live validation threshold | Replay realtime factor <= 1.0, mic max queue depth <= 2, drops = 0, final transcript count > 0 for controlled speech | Same pass criteria; higher quality models must still pass keep-up before becoming defaults |
+
+Do **not** default live UX to the offline diarization quality stack. The PyAnnote segmentation + ERes2Net profile is accurate for file/windowed diarization, but the live path uses VAD boundaries plus per-turn speaker embeddings so it can stream partial/final transcripts and speaker updates with bounded memory.
+
+Quantized segmentation should remain opt-in. The historical int8-first profile was faster/smaller but produced much worse quality on the 5-minute reference (`41.84% DER / 61.72% JER`) than `model.onnx + 3dspeaker_eres2net_en` (`6.41% DER / 8.86% JER`).
+
+### UI validation coverage
+
+The Sherpa Voice diarization screen now exposes the live path directly:
+
+- **Run Live Replay**: replays a selected 16 kHz mono WAV as 100 ms chunks and displays keep-up metrics, event counts, speaker-turn rows, and transcript previews.
+- **Record 10s Mic**: records real microphone chunks through the same `LiveAttributedTranscriptionSession` path and displays queue/backpressure metrics plus any transcript/speaker-turn output.
+
+Use the recipes for machine validation and the UI for human spot checks of turn boundaries, speaker-label stability, and UX clarity.
+
+```bash
+cd apps/sherpa-voice
+ADB_SERIAL=29071JEGR20638 yarn recipe:run scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-ui-replay.json --device 'Pixel 6a'
 ```

--- a/apps/sherpa-voice/scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-ui-replay.json
+++ b/apps/sherpa-voice/scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-ui-replay.json
@@ -1,0 +1,86 @@
+{
+  "title": "Sherpa Voice live transcription + speaker-turn UI replay validation",
+  "description": "Android development-app UI smoke test: drives the Speaker Diarization screen to replay a device-local 16 kHz mono WAV through streaming ASR, VAD, and Speaker ID, then waits for the live result panel. Metric assertions remain in live-transcription-diarization-replay.json; this recipe proves the UI wiring and result rendering. Requires streaming-zipformer-en-20m-mobile, silero-vad-v5, speaker-id-en-voxceleb, and files/validation/perps_controller_refactor_5m_16k_mono.wav.",
+  "validate": {
+    "workflow": {
+      "entry": "nav-diarization",
+      "pre_conditions": [
+        "sherpa.agentic_ready"
+      ],
+      "nodes": {
+        "nav-diarization": {
+          "action": "navigate",
+          "target": "/features/diarization",
+          "next": "assert-android"
+        },
+        "assert-android": {
+          "action": "eval_sync",
+          "description": "This UI smoke recipe uses an Android development-app sandbox path; fail early on other platforms.",
+          "expression": "JSON.stringify({ platform: globalThis.__AGENTIC__?.platform })",
+          "assert": {
+            "operator": "eq",
+            "field": "platform",
+            "value": "android"
+          },
+          "next": "check-validation-file"
+        },
+        "check-validation-file": {
+          "action": "eval_sync",
+          "description": "Fail early if the Android development-app replay WAV is missing.",
+          "expression": "JSON.stringify((function(){var A=globalThis.__AGENTIC__;if(!A||!A.checkFileExists||!A.getLastResult){return {status:\"error\",error:\"agentic bridge missing checkFileExists/getLastResult\"};}return A.checkFileExists(\"file:///data/user/0/net.siteed.sherpavoice.development/files/validation/perps_controller_refactor_5m_16k_mono.wav\");})())",
+          "assert": {
+            "operator": "eq",
+            "field": "status",
+            "value": "pending"
+          },
+          "next": "wait-validation-file"
+        },
+        "wait-validation-file": {
+          "action": "wait_for",
+          "description": "Confirm the Android development-app replay WAV exists before using the UI input.",
+          "expression": "JSON.stringify(globalThis.__AGENTIC__?.getLastResult?.() || {})",
+          "assert": {
+            "operator": "eq",
+            "field": "status",
+            "value": "success"
+          },
+          "fail_when": {
+            "operator": "eq",
+            "field": "status",
+            "value": "error"
+          },
+          "timeout_ms": 30000,
+          "poll_ms": 1000,
+          "next": "wait-live-input"
+        },
+        "wait-live-input": {
+          "action": "wait_for",
+          "test_id": "diar-live-audio-input",
+          "timeout_ms": 30000,
+          "next": "set-live-path"
+        },
+        "set-live-path": {
+          "action": "set_input",
+          "test_id": "diar-live-audio-input",
+          "value": "file:///data/user/0/net.siteed.sherpavoice.development/files/validation/perps_controller_refactor_5m_16k_mono.wav",
+          "next": "press-live-replay"
+        },
+        "press-live-replay": {
+          "action": "press",
+          "test_id": "diar-live-replay-btn",
+          "next": "wait-live-result"
+        },
+        "wait-live-result": {
+          "action": "wait_for",
+          "test_id": "diar-live-result",
+          "timeout_ms": 360000,
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/apps/sherpa-voice/src/app/(tabs)/features/diarization.tsx
+++ b/apps/sherpa-voice/src/app/(tabs)/features/diarization.tsx
@@ -16,6 +16,8 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
+import { AudioStudioModule, type AudioDataEvent } from '@siteed/audio-studio';
+import { LegacyEventEmitter } from 'expo-modules-core';
 import { InlineModelDownloader } from '../../../components/InlineModelDownloader';
 import {
   AudioPlayButton,
@@ -136,15 +138,143 @@ function SegmentList({ segments }: { segments: DiarizationSegment[] }) {
   );
 }
 
+type LiveMode = 'replay' | 'microphone';
+
+type LiveTurnPreview = {
+  turnId: string;
+  startMs: number;
+  endMs: number;
+  speakerId?: string;
+  text: string;
+};
+
+type LiveMicStats = {
+  chunks: number;
+  samples: number;
+  droppedChunks: number;
+  slowChunks: number;
+  maxQueueDepth: number;
+  maxChunkMs: number;
+  averageChunkMs: number;
+  peakAbs: number;
+  rms: number;
+};
+
 type LiveReplayResult = {
+  mode: LiveMode;
   audioDurationMs: number;
-  replayMs: number;
+  elapsedMs: number;
   realtimeFactor: number;
   keepsUp: boolean;
   summary: ReturnType<LiveAttributedTranscriptionSession['getSummary']>;
   eventCounts: Record<string, number>;
   segments: LiveTranscriptSegment[];
+  turns: LiveTurnPreview[];
+  stats?: LiveMicStats;
 };
+
+type RawAudioDataEvent = Partial<AudioDataEvent> & {
+  pcmFloat32?: Float32Array | number[];
+  buffer?: Float32Array | number[];
+  data?: Float32Array | number[] | { pcmFloat32?: Float32Array | number[] };
+};
+
+function extractFloat32Samples(eventData: RawAudioDataEvent): number[] | null {
+  const data = eventData.data;
+  const raw = eventData.pcmFloat32 ??
+    eventData.buffer ??
+    (data instanceof Float32Array || Array.isArray(data) ? data : data?.pcmFloat32);
+  if (raw instanceof Float32Array) return Array.from(raw);
+  if (Array.isArray(raw)) return raw.map((value) => Number(value));
+  return null;
+}
+
+function liveTurnsFromEvents(events: LiveAttributedTranscriptionEvent[]): LiveTurnPreview[] {
+  return events
+    .filter((event): event is Extract<LiveAttributedTranscriptionEvent, { type: 'turn_finalized' }> => event.type === 'turn_finalized')
+    .map((event) => ({
+      turnId: event.turnId,
+      startMs: event.startMs,
+      endMs: event.endMs,
+      speakerId: event.speakerId,
+      text: event.text,
+    }));
+}
+
+function shortSpeakerLabel(speakerId?: string): string {
+  return speakerId ?? 'speaker pending';
+}
+
+function LiveTranscriptPreview({ segments }: { segments: readonly LiveTranscriptSegment[] }) {
+  const theme = useTheme();
+  if (segments.length === 0) {
+    return (
+      <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+        No transcript segments yet. Use speech in the selected file or live microphone probe.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={{ gap: 6 }}>
+      {segments.map((segment) => (
+        <View
+          key={segment.segmentId}
+          style={{
+            padding: 8,
+            borderRadius: theme.roundness,
+            backgroundColor: theme.colors.surfaceVariant,
+          }}
+        >
+          <Text variant="labelSmall" style={{ color: theme.colors.primary }}>
+            {shortSpeakerLabel(segment.speakerId)} · {formatTime(segment.startMs / 1000)} – {formatTime(segment.endMs / 1000)} · {segment.final ? 'final' : 'partial'}
+          </Text>
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurface }}>
+            {segment.text || '(empty transcript)'}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function LiveTurnPreviewList({ turns }: { turns: readonly LiveTurnPreview[] }) {
+  const theme = useTheme();
+  if (turns.length === 0) {
+    return (
+      <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+        No finalized speaker turns yet.
+      </Text>
+    );
+  }
+
+  return (
+    <View style={{ gap: 6 }}>
+      {turns.slice(0, 8).map((turn) => (
+        <View key={turn.turnId} style={{ flexDirection: 'row', gap: 8 }}>
+          <Text variant="bodySmall" style={{ minWidth: 90, color: theme.colors.onSurfaceVariant, fontVariant: ['tabular-nums'] }}>
+            {formatTime(turn.startMs / 1000)} – {formatTime(turn.endMs / 1000)}
+          </Text>
+          <Text variant="bodySmall" style={{ flex: 1, color: theme.colors.onSurface }}>
+            {shortSpeakerLabel(turn.speakerId)} · {turn.text || '(no transcript text)'}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+    }),
+  ]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+}
 
 function LiveValidationSection({
   selectedAudio,
@@ -196,6 +326,53 @@ function LiveValidationSection({
     );
   }
 
+  const ensureLiveModelsReady = async () => {
+    if (!selectedAsrModelId || !selectedVadModelId || !selectedEmbModelId) {
+      throw new Error('Download/select streaming ASR, VAD, and speaker-id models first');
+    }
+    const asrState = getModelState(selectedAsrModelId);
+    const vadState = getModelState(selectedVadModelId);
+    const speakerState = getModelState(selectedEmbModelId);
+    if (!asrState?.localPath) throw new Error(`ASR model ${selectedAsrModelId} is not downloaded`);
+    if (!vadState?.localPath) throw new Error(`VAD model ${selectedVadModelId} is not downloaded`);
+    if (!speakerState?.localPath) throw new Error(`Speaker model ${selectedEmbModelId} is not downloaded`);
+
+    await initializeLiveTranscriptionDiarizationModels({
+      asrModelId: selectedAsrModelId,
+      vadModelId: selectedVadModelId,
+      speakerIdModelId: selectedEmbModelId,
+      asrModelDir: await resolveModelDir(asrState.localPath),
+      vadModelDir: await resolveModelDir(vadState.localPath),
+      speakerModelDir: await resolveModelDir(speakerState.localPath),
+      numThreads: DEFAULT_NUM_THREADS,
+    });
+  };
+
+  const createLiveSession = (
+    sampleRate: number,
+    eventCounts: Record<string, number>,
+    eventPreview: LiveAttributedTranscriptionEvent[]
+  ) =>
+    new LiveAttributedTranscriptionSession({
+      sampleRate,
+      speakerTurns: new LiveSpeakerTurnSession({
+        sampleRate,
+        vad: VAD,
+        speakerId: SpeakerId,
+        minTurnDurationMs: 1000,
+        speechPadMs: 120,
+        speakerThreshold: 0.55,
+        maxRingBufferDurationMs: 90_000,
+      }),
+      asr: ASR,
+      onEvent: (event: LiveAttributedTranscriptionEvent) => {
+        eventCounts[event.type] = (eventCounts[event.type] ?? 0) + 1;
+        if (event.type === 'turn_finalized' || eventPreview.length < 120) {
+          eventPreview.push(event);
+        }
+      },
+    });
+
   const handleRunLiveReplay = async () => {
     const effectiveAudioPath = liveAudioPath.trim() || selectedAudio?.localUri;
     if (!effectiveAudioPath) {
@@ -214,13 +391,6 @@ function LiveValidationSection({
     let session: LiveAttributedTranscriptionSession | null = null;
 
     try {
-      const asrState = getModelState(selectedAsrModelId);
-      const vadState = getModelState(selectedVadModelId);
-      const speakerState = getModelState(selectedEmbModelId);
-      if (!asrState?.localPath) throw new Error(`ASR model ${selectedAsrModelId} is not downloaded`);
-      if (!vadState?.localPath) throw new Error(`VAD model ${selectedVadModelId} is not downloaded`);
-      if (!speakerState?.localPath) throw new Error(`Speaker model ${selectedEmbModelId} is not downloaded`);
-
       setStatus('Reading WAV fixture...');
       const wav = await readMonoPcm16Wav(effectiveAudioPath);
       if (wav.sampleRate !== DEFAULT_LIVE_SAMPLE_RATE) {
@@ -233,33 +403,11 @@ function LiveValidationSection({
       const chunkSize = Math.round((chunkDurationMs / 1000) * wav.sampleRate);
 
       setStatus('Initializing ASR, VAD, and Speaker ID...');
-      await initializeLiveTranscriptionDiarizationModels({
-        asrModelId: selectedAsrModelId,
-        vadModelId: selectedVadModelId,
-        speakerIdModelId: selectedEmbModelId,
-        asrModelDir: await resolveModelDir(asrState.localPath),
-        vadModelDir: await resolveModelDir(vadState.localPath),
-        speakerModelDir: await resolveModelDir(speakerState.localPath),
-        numThreads: DEFAULT_NUM_THREADS,
-      });
+      await ensureLiveModelsReady();
 
       const eventCounts: Record<string, number> = {};
-      session = new LiveAttributedTranscriptionSession({
-        sampleRate: wav.sampleRate,
-        speakerTurns: new LiveSpeakerTurnSession({
-          sampleRate: wav.sampleRate,
-          vad: VAD,
-          speakerId: SpeakerId,
-          minTurnDurationMs: 1000,
-          speechPadMs: 120,
-          speakerThreshold: 0.55,
-          maxRingBufferDurationMs: 90_000,
-        }),
-        asr: ASR,
-        onEvent: (event: LiveAttributedTranscriptionEvent) => {
-          eventCounts[event.type] = (eventCounts[event.type] ?? 0) + 1;
-        },
-      });
+      const eventPreview: LiveAttributedTranscriptionEvent[] = [];
+      session = createLiveSession(wav.sampleRate, eventCounts, eventPreview);
 
       setStatus(`Replaying ${(audioDurationMs / 1000).toFixed(1)}s as ${chunkDurationMs}ms chunks...`);
       const startedAt = Date.now();
@@ -278,19 +426,193 @@ function LiveValidationSection({
         throw new Error(`Live replay emitted ${eventCounts.error} pipeline error event(s)`);
       }
       setResult({
+        mode: 'replay',
         audioDurationMs,
-        replayMs,
+        elapsedMs: replayMs,
         realtimeFactor,
         keepsUp: realtimeFactor <= 1,
         summary: session.getSummary(),
         eventCounts,
-        segments: state.segments.slice(0, 20), // UI preview only; summary keeps full counts.
+        segments: state.segments.slice(0, 8), // UI preview only; summary keeps full counts.
+        turns: liveTurnsFromEvents(eventPreview),
       });
       setStatus(`Live replay complete: ${realtimeFactor.toFixed(2)}x realtime`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setStatus('');
     } finally {
+      session?.release();
+      await Promise.all([
+        ASR.release().catch(() => {}),
+        VAD.release().catch(() => {}),
+        SpeakerId.release().catch(() => {}),
+      ]);
+      setRunning(false);
+    }
+  };
+
+  const handleRunLiveMic = async () => {
+    if (!selectedAsrModelId || !selectedVadModelId || !selectedEmbModelId) {
+      setError('Download/select streaming ASR, VAD, and speaker-id models first');
+      return;
+    }
+
+    const durationMs = 10_000;
+    const chunkDurationMs = 100;
+    const eventCounts: Record<string, number> = {};
+    const eventPreview: LiveAttributedTranscriptionEvent[] = [];
+    const stats = {
+      chunks: 0,
+      samples: 0,
+      droppedChunks: 0,
+      slowChunks: 0,
+      maxQueueDepth: 0,
+      maxChunkMs: 0,
+      totalChunkMs: 0,
+      peakAbs: 0,
+      sumSquares: 0,
+    };
+    let session: LiveAttributedTranscriptionSession | null = null;
+    let subscription: { remove: () => void } | null = null;
+    let chain = Promise.resolve();
+    let queueDepth = 0;
+    let nextSample = 0;
+    let stopped = false;
+    let abortQueuedChunks = false;
+    let fatalError: Error | null = null;
+
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    setStatus('Requesting microphone permission...');
+
+    try {
+      const permission = await AudioStudioModule.requestPermissionsAsync();
+      if (permission?.status !== 'granted') {
+        throw new Error('Microphone permission denied');
+      }
+
+      setStatus('Initializing ASR, VAD, and Speaker ID...');
+      await ensureLiveModelsReady();
+      session = createLiveSession(DEFAULT_LIVE_SAMPLE_RATE, eventCounts, eventPreview);
+
+      // AudioStudio uses the codebase-standard LegacyEventEmitter pattern; on
+      // new Expo modules this constructor returns the module event emitter.
+      const emitter = new LegacyEventEmitter(AudioStudioModule);
+      subscription = emitter.addListener('AudioData', (eventData: RawAudioDataEvent) => {
+        if (stopped || fatalError) {
+          stats.droppedChunks += 1;
+          return;
+        }
+        const samples = extractFloat32Samples(eventData);
+        if (!samples || samples.length === 0) {
+          stats.droppedChunks += 1;
+          return;
+        }
+        const startSample = nextSample;
+        nextSample += samples.length;
+        stats.samples += samples.length;
+        for (const sample of samples) {
+          const abs = Math.abs(sample);
+          stats.peakAbs = Math.max(stats.peakAbs, abs);
+          stats.sumSquares += sample * sample;
+        }
+        queueDepth += 1;
+        stats.maxQueueDepth = Math.max(stats.maxQueueDepth, queueDepth);
+        chain = chain
+          .then(async () => {
+            if (abortQueuedChunks) {
+              queueDepth -= 1;
+              return;
+            }
+            const chunkStartedAt = Date.now();
+            try {
+              await session?.acceptChunk({
+                samples,
+                sampleRate: DEFAULT_LIVE_SAMPLE_RATE,
+                startSample,
+              });
+              const elapsedMs = Date.now() - chunkStartedAt;
+              stats.chunks += 1;
+              stats.totalChunkMs += elapsedMs;
+              stats.maxChunkMs = Math.max(stats.maxChunkMs, elapsedMs);
+              if (elapsedMs > chunkDurationMs) {
+                stats.slowChunks += 1;
+              }
+            } finally {
+              queueDepth -= 1;
+            }
+          })
+          .catch((err: unknown) => {
+            fatalError ??= err instanceof Error ? err : new Error(String(err));
+            stopped = true;
+          });
+      });
+
+      setStatus(`Recording ${durationMs / 1000}s live microphone probe...`);
+      const startedAt = Date.now();
+      await AudioStudioModule.startRecording({
+        sampleRate: DEFAULT_LIVE_SAMPLE_RATE,
+        channels: 1,
+        encoding: 'pcm_16bit',
+        interval: chunkDurationMs,
+        // Request native buffers aligned with UI chunk cadence; native layers may
+        // clamp upward on devices that require a larger AudioRecord buffer.
+        bufferDurationSeconds: chunkDurationMs / 1000,
+        streamFormat: 'float32',
+        output: { primary: { enabled: false } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, durationMs));
+      await AudioStudioModule.stopRecording().catch(() => null);
+      stopped = true;
+      subscription.remove();
+      subscription = null;
+      await withTimeout(chain, 5_000, 'Timed out while draining live mic chunks');
+      await session.flush();
+      if (fatalError) throw fatalError;
+      if ((eventCounts.error ?? 0) > 0) {
+        throw new Error(`Live microphone probe emitted ${eventCounts.error} pipeline error event(s)`);
+      }
+
+      const elapsedMs = Date.now() - startedAt;
+      const state = session.getState();
+      const audioDurationMs = (stats.samples / DEFAULT_LIVE_SAMPLE_RATE) * 1000;
+      const averageChunkMs = stats.chunks > 0 ? stats.totalChunkMs / stats.chunks : 0;
+      const rms = stats.samples > 0 ? Math.sqrt(stats.sumSquares / stats.samples) : 0;
+      const realtimeFactor = stats.totalChunkMs / Math.max(audioDurationMs, 1);
+      const keepsUp = stats.maxQueueDepth <= 2 && averageChunkMs < chunkDurationMs;
+
+      setResult({
+        mode: 'microphone',
+        audioDurationMs,
+        elapsedMs,
+        realtimeFactor,
+        keepsUp,
+        summary: session.getSummary(),
+        eventCounts,
+        segments: state.segments.slice(0, 8),
+        turns: liveTurnsFromEvents(eventPreview),
+        stats: {
+          chunks: stats.chunks,
+          samples: stats.samples,
+          droppedChunks: stats.droppedChunks,
+          slowChunks: stats.slowChunks,
+          maxQueueDepth: stats.maxQueueDepth,
+          maxChunkMs: stats.maxChunkMs,
+          averageChunkMs,
+          peakAbs: stats.peakAbs,
+          rms,
+        },
+      });
+      setStatus(`Live microphone probe complete: avg ${averageChunkMs.toFixed(1)}ms/chunk`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setStatus('');
+    } finally {
+      stopped = true;
+      abortQueuedChunks = true;
+      subscription?.remove();
+      await AudioStudioModule.stopRecording().catch(() => null);
       session?.release();
       await Promise.all([
         ASR.release().catch(() => {}),
@@ -346,13 +668,24 @@ function LiveValidationSection({
         autoCapitalize="none"
         autoCorrect={false}
       />
-      <ThemedButton
-        testID="diar-live-replay-btn"
-        label={running ? 'Running live replay...' : 'Run Live Replay'}
-        variant="primary"
-        onPress={handleRunLiveReplay}
-        disabled={disabled || running || (!selectedAudio && liveAudioPath.trim().length === 0) || !selectedAsrModelId || !selectedVadModelId || !selectedEmbModelId}
-      />
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <ThemedButton
+          testID="diar-live-replay-btn"
+          label={running ? 'Running...' : 'Run Live Replay'}
+          variant="primary"
+          onPress={handleRunLiveReplay}
+          disabled={disabled || running || (!selectedAudio && liveAudioPath.trim().length === 0) || !selectedAsrModelId || !selectedVadModelId || !selectedEmbModelId}
+          style={{ flex: 1 }}
+        />
+        <ThemedButton
+          testID="diar-live-mic-btn"
+          label="Record 10s Mic"
+          variant="secondary"
+          onPress={handleRunLiveMic}
+          disabled={disabled || running || !selectedAsrModelId || !selectedVadModelId || !selectedEmbModelId}
+          style={{ flex: 1 }}
+        />
+      </View>
       {status ? (
         <Text variant="bodySmall" style={{ marginTop: 8, color: theme.colors.primary }}>{status}</Text>
       ) : null}
@@ -360,21 +693,38 @@ function LiveValidationSection({
         <Text variant="bodySmall" style={{ marginTop: 8, color: theme.colors.error }}>{error}</Text>
       ) : null}
       {result ? (
-        <View style={{ marginTop: 12, gap: 6 }}>
-          <Text variant="bodyMedium" style={{ color: result.keepsUp ? theme.colors.primary : theme.colors.error }}>
-            {result.keepsUp ? 'Keeps up' : 'Too slow'}: {result.realtimeFactor.toFixed(2)}x realtime ({result.replayMs}ms for {(result.audioDurationMs / 1000).toFixed(1)}s audio)
+        <View testID="diar-live-result" style={{ marginTop: 12, gap: 8 }}>
+          <Text variant="labelMedium" style={{ color: theme.colors.onSurface }}>
+            {result.mode === 'replay' ? 'Replay result' : 'Live microphone result'}
           </Text>
+          {result.mode === 'microphone' && result.stats ? (
+            <Text variant="bodyMedium" style={{ color: result.keepsUp ? theme.colors.primary : theme.colors.error }}>
+              {result.keepsUp ? 'Keeps up' : 'Too slow'}: avg {result.stats.averageChunkMs.toFixed(1)}ms/chunk, queue {result.stats.maxQueueDepth}, drops {result.stats.droppedChunks}
+            </Text>
+          ) : (
+            <Text variant="bodyMedium" style={{ color: result.keepsUp ? theme.colors.primary : theme.colors.error }}>
+              {result.keepsUp ? 'Keeps up' : 'Too slow'}: {result.realtimeFactor.toFixed(2)}x realtime ({(result.elapsedMs / 1000).toFixed(1)}s for {(result.audioDurationMs / 1000).toFixed(1)}s audio)
+            </Text>
+          )}
           <Text variant="bodySmall" style={{ color: theme.colors.onSurface }}>
             Segments: {result.summary.segmentCount} · Final: {result.summary.finalSegmentCount} · Speaker-attributed: {result.summary.speakerAttributedSegmentCount}
           </Text>
+          {result.stats ? (
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+              Mic: chunks={result.stats.chunks}, avg={result.stats.averageChunkMs.toFixed(1)}ms, max={result.stats.maxChunkMs}ms, queue={result.stats.maxQueueDepth}, drops={result.stats.droppedChunks}, peak={result.stats.peakAbs.toFixed(3)}, rms={result.stats.rms.toFixed(4)}
+            </Text>
+          ) : null}
           <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
             Events: {Object.entries(result.eventCounts).map(([key, value]) => `${key}=${value}`).join(', ')}
           </Text>
-          {result.segments.slice(0, 5).map((segment) => (
-            <Text key={segment.segmentId} variant="bodySmall" style={{ color: theme.colors.onSurface }}>
-              {segment.speakerId ?? 'speaker_pending'} · {segment.text || '(empty)'}
-            </Text>
-          ))}
+          <Text variant="labelSmall" style={{ color: theme.colors.onSurface }}>
+            Speaker turns
+          </Text>
+          <LiveTurnPreviewList turns={result.turns} />
+          <Text variant="labelSmall" style={{ color: theme.colors.onSurface }}>
+            Transcript preview
+          </Text>
+          <LiveTranscriptPreview segments={result.segments} />
         </View>
       ) : null}
     </Section>

--- a/packages/sherpa-onnx.rn/src/services/LiveAttributedTranscriptionSession.ts
+++ b/packages/sherpa-onnx.rn/src/services/LiveAttributedTranscriptionSession.ts
@@ -242,8 +242,7 @@ export class LiveAttributedTranscriptionSession {
         }
         if (reset.success) {
           this.asrHasAcceptedAudio = false;
-        }
-        if (!reset.success) {
+        } else {
           this.resetAsrBeforeNextChunk = true;
           this.emit({
             type: 'error',
@@ -282,6 +281,9 @@ export class LiveAttributedTranscriptionSession {
             : 'Speaker turn flush failed',
       });
     }
+    // Speaker turn flushing can synchronously finalize/discard turns and mutate
+    // the active ASR segment through handleSpeakerEvent(), so recompute before
+    // deciding whether the native ASR stream needs a reset.
     shouldResetAsr =
       shouldResetAsr || Boolean(this.currentSegmentId) || this.asrHasAcceptedAudio;
     await this.drainAsrTailPadding();

--- a/packages/sherpa-onnx.rn/src/services/LiveSpeakerTurnSession.ts
+++ b/packages/sherpa-onnx.rn/src/services/LiveSpeakerTurnSession.ts
@@ -36,6 +36,9 @@ function normalizeEmbedding(embedding: number[]): number[] {
     embedding.reduce((sum, value) => sum + value * value, 0)
   );
   if (magnitude === 0) {
+    // Keep a zero-vector embedding inert instead of inventing a direction.
+    // It will never be a confident centroid match, and a maxSpeakers fallback
+    // can still assign the turn to the nearest known speaker when requested.
     return embedding.map(() => 0);
   }
   return embedding.map((value) => value / magnitude);
@@ -363,8 +366,9 @@ export class LiveSpeakerTurnSession {
     if (this.config.speakerId.resetStream) {
       try {
         const reset = await this.config.speakerId.resetStream();
-        recoverable = reset.success;
-        if (!reset.success && reset.error) {
+        if (reset.success) {
+          recoverable = true;
+        } else if (reset.error) {
           composedError = `${composedError}; speaker stream reset failed: ${reset.error}`;
         }
       } catch (resetError) {


### PR DESCRIPTION
## Summary

- polish the live attributed transcription / speaker-turn sessions with clearer reset/recovery handling
- add Sherpa Voice live replay + 10s microphone validation UI with keep-up metrics, transcript preview, and speaker-turn preview
- add an Android UI replay recipe and document mobile default recommendations / benchmark evidence

## Validation

- `yarn workspace @siteed/sherpa-voice typecheck`
- `yarn workspace @siteed/sherpa-onnx.rn typecheck`
- `yarn workspace @siteed/sherpa-onnx.rn test LiveAttributedTranscriptionSession.test.ts LiveSpeakerTurnSession.test.ts --runInBand --no-cache`
- `yarn workspace @siteed/sherpa-voice recipe:schema scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-ui-replay.json scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-replay.json scripts/agentic/teams/sherpa/recipes/live-mic-transcription-diarization.json`
- `ADB_SERIAL=29071JEGR20638 yarn workspace @siteed/sherpa-voice android:device`
- `ADB_SERIAL=29071JEGR20638 yarn workspace @siteed/sherpa-voice recipe:run scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-replay.json --device 'Pixel 6a'`
- `ADB_SERIAL=29071JEGR20638 yarn workspace @siteed/sherpa-voice recipe:run scripts/agentic/teams/sherpa/recipes/live-mic-transcription-diarization.json --device 'Pixel 6a'`
- `ADB_SERIAL=29071JEGR20638 yarn workspace @siteed/sherpa-voice recipe:run scripts/agentic/teams/sherpa/recipes/live-transcription-diarization-ui-replay.json --device 'Pixel 6a'`
- `git diff --check`

## Review

- Claude: APPROVE `a66e30a494fe8fbd6390460489f85c7198383af7`
- Codex: APPROVE `a66e30a494fe8fbd6390460489f85c7198383af7`
