### PR TITLE
feat(playground): add mobile ASR recommendation workflow

### DIFF
--- a/apps/playground/scripts/agentic/direct-asr-benchmark.mjs
+++ b/apps/playground/scripts/agentic/direct-asr-benchmark.mjs
@@ -15,6 +15,12 @@ const REPORT_DIR = path.join(APP_ROOT, '.agent', 'reports');
 const MODEL_CACHE_DIR =
   process.env.BENCHMARK_MODEL_CACHE_DIR ||
   path.join(APP_ROOT, '.agent', 'model-cache');
+const MOBILE_RECOMMENDATION_MODEL_IDS = readMobileRecommendationModelIds();
+const PERPS_ECHOBRIDGE_CLIP_IDS = ['perps-controller-refactor-5m-echobridge-medium'];
+const MOBILE_RECOMMENDATION_PERPS_PRESET = {
+  clipIds: PERPS_ECHOBRIDGE_CLIP_IDS,
+  modelIds: MOBILE_RECOMMENDATION_MODEL_IDS,
+};
 const DEVICE = process.env.BENCHMARK_DEVICE || process.env.AGENTIC_DEVICE || '';
 const SERIAL = process.env.ANDROID_SERIAL || process.env.ADB_SERIAL || '';
 const APP_VARIANT = process.env.APP_VARIANT || 'development';
@@ -83,31 +89,23 @@ const PRESETS = {
     modelIds: ['moonshine-small-streaming-en', 'moonshine-medium-streaming-en'],
   },
   'moonshine-echobridge-perps-5m': {
-    clipIds: ['perps-controller-refactor-5m-echobridge-medium'],
+    clipIds: PERPS_ECHOBRIDGE_CLIP_IDS,
     modelIds: ['moonshine-small-streaming-en', 'moonshine-medium-streaming-en'],
   },
   'sherpa-echobridge-perps-5m': {
-    clipIds: ['perps-controller-refactor-5m-echobridge-medium'],
+    clipIds: PERPS_ECHOBRIDGE_CLIP_IDS,
     modelIds: ['sherpa-qwen3-asr-0.6b-int8'],
   },
   'sherpa-whisper-echobridge-perps-5m': {
-    clipIds: ['perps-controller-refactor-5m-echobridge-medium'],
+    clipIds: PERPS_ECHOBRIDGE_CLIP_IDS,
     modelIds: ['sherpa-whisper-small', 'sherpa-whisper-medium-int8'],
   },
   'sherpa-whisper-fp32-echobridge-perps-5m': {
-    clipIds: ['perps-controller-refactor-5m-echobridge-medium'],
+    clipIds: PERPS_ECHOBRIDGE_CLIP_IDS,
     modelIds: ['sherpa-whisper-medium'],
   },
-  'moonshine-sherpa-echobridge-perps-5m': {
-    clipIds: ['perps-controller-refactor-5m-echobridge-medium'],
-    modelIds: [
-      'moonshine-small-streaming-en',
-      'moonshine-medium-streaming-en',
-      'sherpa-qwen3-asr-0.6b-int8',
-      'sherpa-whisper-small',
-      'sherpa-whisper-medium-int8',
-    ],
-  },
+  'mobile-asr-recommendation-echobridge-perps-5m': MOBILE_RECOMMENDATION_PERPS_PRESET,
+  'moonshine-sherpa-echobridge-perps-5m': MOBILE_RECOMMENDATION_PERPS_PRESET,
 };
 
 const ALL_MODELS = [
@@ -119,6 +117,19 @@ const ALL_MODELS = [
   { id: 'sherpa-whisper-medium-int8', live: false },
   { id: 'sherpa-whisper-medium', live: false },
 ];
+const ALL_MODEL_IDS = new Set(ALL_MODELS.map((model) => model.id));
+const unknownMobileRecommendationModelIds = MOBILE_RECOMMENDATION_MODEL_IDS.filter(
+  (modelId) => !ALL_MODEL_IDS.has(modelId)
+);
+if (unknownMobileRecommendationModelIds.length > 0) {
+  throw new Error(
+    `Unknown mobile recommendation model ids in asrMobileRecommendationModelIds.json: ${unknownMobileRecommendationModelIds.join(', ')}`
+  );
+}
+// Shared with ASR_MOBILE_RECOMMENDATION_MODEL_IDS in
+// apps/playground/src/utils/asrBenchmarkModels.ts via asrMobileRecommendationModelIds.json.
+// It intentionally excludes FP32 Whisper Medium and Whisper Small (whisper.rn) unless explicitly requested.
+const DEFAULT_MODEL_IDS = new Set(MOBILE_RECOMMENDATION_MODEL_IDS);
 const configuredPreset = String(process.env.BENCHMARK_PRESET || '').trim();
 const presetConfig = configuredPreset ? PRESETS[configuredPreset] : null;
 if (configuredPreset && !presetConfig) {
@@ -126,11 +137,15 @@ if (configuredPreset && !presetConfig) {
     `Unknown BENCHMARK_PRESET=${configuredPreset}. Available presets: ${Object.keys(PRESETS).join(', ')}`
   );
 }
+const configuredModelsRaw = String(process.env.BENCHMARK_MODELS || '').trim();
+const shouldRunAllModels = configuredModelsRaw.toLowerCase() === 'all';
 const configuredModelIds = new Set(
   String(
-    process.env.BENCHMARK_MODELS ||
-      presetConfig?.modelIds?.join(',') ||
-      ''
+    shouldRunAllModels
+      ? ''
+      : configuredModelsRaw ||
+          presetConfig?.modelIds?.join(',') ||
+          ''
   )
     .split(',')
     .map((value) => value.trim())
@@ -146,10 +161,11 @@ const configuredClipIds = new Set(
     .map((value) => value.trim())
     .filter(Boolean)
 );
-const OFFLINE_MODELS =
-  configuredModelIds.size > 0
+const OFFLINE_MODELS = shouldRunAllModels
+  ? ALL_MODELS
+  : configuredModelIds.size > 0
     ? ALL_MODELS.filter((model) => configuredModelIds.has(model.id))
-    : ALL_MODELS;
+    : ALL_MODELS.filter((model) => DEFAULT_MODEL_IDS.has(model.id));
 const SIMULATED_MODELS = OFFLINE_MODELS.filter((model) => model.live);
 const EVAL_CLIPS =
   configuredClipIds.size > 0
@@ -160,6 +176,24 @@ fs.mkdirSync(REPORT_DIR, { recursive: true });
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readMobileRecommendationModelIds() {
+  const configPath = path.join(APP_ROOT, 'src/utils/asrMobileRecommendationModelIds.json');
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length === 0 ||
+      !parsed.every((modelId) => typeof modelId === 'string' && modelId.length > 0)
+    ) {
+      throw new Error('expected a non-empty string array');
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load ${configPath}: ${message}`);
+  }
 }
 
 function run(command, args, { cwd = REPO_ROOT, parseJson = false, maxBuffer = 50 * 1024 * 1024 } = {}) {

--- a/apps/playground/src/app/asr-benchmark.tsx
+++ b/apps/playground/src/app/asr-benchmark.tsx
@@ -30,6 +30,33 @@ const getStyles = (theme: AppTheme) =>
         sectionBody: {
             color: theme.colors.onSurfaceVariant,
         },
+        recommendationGrid: {
+            gap: theme.spacing.gap,
+        },
+        recommendationCard: {
+            gap: 4,
+            padding: theme.padding.s,
+            backgroundColor: theme.colors.surfaceVariant,
+            borderRadius: theme.roundness,
+        },
+        badgeRow: {
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            gap: 6,
+            marginTop: 6,
+        },
+        badge: {
+            alignSelf: 'flex-start',
+            paddingHorizontal: 8,
+            paddingVertical: 3,
+            borderRadius: theme.roundness,
+            backgroundColor: theme.colors.secondaryContainer,
+        },
+        badgeText: {
+            color: theme.colors.onSecondaryContainer,
+            fontSize: 11,
+            fontWeight: '700',
+        },
         row: {
             flexDirection: 'row',
             flexWrap: 'wrap',
@@ -136,6 +163,7 @@ export default function AsrBenchmarkScreen() {
         benchmarkModels,
         clearResults,
         error,
+        mobileRecommendationModels,
         mode,
         modelStatuses,
         prepareSelectedModel,
@@ -163,11 +191,21 @@ export default function AsrBenchmarkScreen() {
 
     const visibleModels = mode === 'simulated' ? simulatedBenchmarkModels : benchmarkModels
     const modeSwitchDisabled = processing || simulationIsRunning
+    const mobileRecommendationModelIds = useMemo(
+        () => mobileRecommendationModels.map((model) => model.id),
+        [mobileRecommendationModels],
+    )
+    const mobileRecommendationModelCountLabel =
+        mobileRecommendationModels.length === 1
+            ? '1 mobile-safe row'
+            : `${mobileRecommendationModels.length} mobile-safe rows`
 
     useEffect(() => {
         setAgenticPageState({
             benchmarkModelCount: benchmarkModels.length,
             error: error || null,
+            mobileRecommendationModelCount: mobileRecommendationModelIds.length,
+            mobileRecommendationModelIds,
             simulatedBenchmarkModelCount: simulatedBenchmarkModels.length,
             simulatedCommittedText: simulatedCommittedText || null,
             simulatedInterimText: simulatedInterimText || null,
@@ -197,6 +235,7 @@ export default function AsrBenchmarkScreen() {
     }, [
         benchmarkModels.length,
         error,
+        mobileRecommendationModelIds,
         mode,
         modelStatuses,
         processing,
@@ -224,9 +263,38 @@ export default function AsrBenchmarkScreen() {
             <View style={styles.section}>
                 <Text style={styles.sectionTitle}>ASR Benchmark</Text>
                 <Text style={styles.sectionBody}>
-                    Dev-only benchmark surface for Moonshine vs Whisper in the generic playground
-                    app.
+                    Dev-only recommendation surface for live Moonshine transcription, Sherpa speaker
+                    turns, segmented offline Sherpa ASR, and EchoBridge Whisper parity.
                 </Text>
+            </View>
+
+            <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Mobile Recommendation Workflow</Text>
+                <View style={styles.recommendationGrid}>
+                    {[
+                        {
+                            title: 'Live transcript',
+                            body: 'Use Moonshine Small Streaming by default. Try Moonshine Medium only when the device can afford slower startup and extra CPU.',
+                        },
+                        {
+                            title: 'Live speaker turns',
+                            body: 'Use Sherpa VAD + Speaker ID for tentative live speaker turns, then rely on offline diarization for final quality.',
+                        },
+                        {
+                            title: 'Post-recording quality',
+                            body: 'Use segmented Sherpa offline ASR after recording. Qwen3 INT8 is the practical non-Whisper candidate; Whisper Medium INT8 is the EchoBridge parity row.',
+                        },
+                        {
+                            title: 'Default matrix',
+                            body: `Run Practical Matrix uses ${mobileRecommendationModelCountLabel} and skips opt-in / avoid-default models such as FP32 Whisper Medium and Whisper Small (whisper.rn).`,
+                        },
+                    ].map((item) => (
+                        <View key={item.title} style={styles.recommendationCard}>
+                            <Text style={styles.selectorTitle}>{item.title}</Text>
+                            <Text style={styles.selectorBody}>{item.body}</Text>
+                        </View>
+                    ))}
+                </View>
             </View>
 
             <View style={styles.section}>
@@ -304,7 +372,33 @@ export default function AsrBenchmarkScreen() {
                                 <Text style={styles.selectorBody}>
                                     {model.engine} • {downloaded ? 'downloaded' : 'not downloaded'}
                                 </Text>
+                                {model.recommendationLabel ? (
+                                    <View style={styles.badgeRow}>
+                                        <View style={styles.badge}>
+                                            <Text style={styles.badgeText}>
+                                                {model.recommendationTier === 'avoid-default'
+                                                    ? `Default-off: ${model.recommendationLabel}`
+                                                    : model.recommendationLabel}
+                                            </Text>
+                                        </View>
+                                        {model.estimatedSizeLabel ? (
+                                            <View style={styles.badge}>
+                                                <Text style={styles.badgeText}>
+                                                    {model.estimatedSizeLabel}
+                                                </Text>
+                                            </View>
+                                        ) : null}
+                                    </View>
+                                ) : null}
+                                {model.recommendedUse ? (
+                                    <Text style={styles.selectorBody}>{model.recommendedUse}</Text>
+                                ) : null}
                                 <Text style={styles.selectorBody}>{model.rationale}</Text>
+                                {model.warningLabel ? (
+                                    <Text style={styles.selectorBody}>
+                                        Note: {model.warningLabel}
+                                    </Text>
+                                ) : null}
                             </Pressable>
                         )
                     })}
@@ -433,9 +527,13 @@ export default function AsrBenchmarkScreen() {
                                         },
                                     ]}
                                 >
-                                    Run Matrix
+                                    Run Practical Matrix
                                 </Text>
                             </Pressable>
+                            <Text style={styles.sectionBody}>
+                                Runs {mobileRecommendationModelCountLabel}; skips opt-in /
+                                avoid-default models.
+                            </Text>
 
                             <Pressable
                                 testID="asr-benchmark-run-word-timestamps"

--- a/apps/playground/src/hooks/useAsrBenchmark.ts
+++ b/apps/playground/src/hooks/useAsrBenchmark.ts
@@ -6,6 +6,7 @@ import { baseLogger } from '../config'
 import {
     ASR_BENCHMARK_MODELS,
     ASR_BENCHMARK_SAMPLES,
+    ASR_MOBILE_RECOMMENDATION_MODEL_IDS,
     type AsrBenchmarkEngine,
     type AsrBenchmarkMode,
     type AsrBenchmarkSample,
@@ -19,6 +20,7 @@ import {
 } from '../utils/asrBenchmarkRuntime'
 
 const logger = baseLogger.extend('AsrBenchmark')
+const mobileRecommendationModelIdSet = new Set(ASR_MOBILE_RECOMMENDATION_MODEL_IDS)
 
 export interface AsrBenchmarkResult {
     commitCount?: number
@@ -116,6 +118,13 @@ export function useAsrBenchmark() {
         () => benchmarkModels.filter((model) => model.liveCapable),
         [benchmarkModels],
     )
+    const mobileRecommendationModels = useMemo(
+        () =>
+            benchmarkModels.filter((model) =>
+                mobileRecommendationModelIdSet.has(model.id),
+            ),
+        [benchmarkModels],
+    )
 
     const refreshModelStatuses = useCallback(async () => {
         const nextStatuses: Record<string, BenchmarkModelStatus> = {}
@@ -211,7 +220,6 @@ export function useAsrBenchmark() {
             setError('Select a sample audio file first')
             return
         }
-
         setProcessing(true)
         setError(null)
         try {
@@ -264,11 +272,15 @@ export function useAsrBenchmark() {
             setError('Select a sample audio file first')
             return
         }
+        if (mobileRecommendationModels.length === 0) {
+            setError('No mobile recommendation benchmark models are configured')
+            return
+        }
 
         setProcessing(true)
         setError(null)
         try {
-            for (const model of benchmarkModels) {
+            for (const model of mobileRecommendationModels) {
                 setStatusMessage(`Running ${model.name} on ${selectedSample.name}...`)
                 const startedAt = nowMs()
                 try {
@@ -312,7 +324,7 @@ export function useAsrBenchmark() {
             setStatusMessage('')
             setProcessing(false)
         }
-    }, [appendResult, benchmarkModels, refreshModelStatuses, selectedSample])
+    }, [appendResult, mobileRecommendationModels, refreshModelStatuses, selectedSample])
 
     const runSelectedSimulatedBenchmark = useCallback(async () => {
         if (!selectedModel) {
@@ -477,6 +489,7 @@ export function useAsrBenchmark() {
         benchmarkModels,
         clearResults,
         error,
+        mobileRecommendationModels,
         mode,
         modelStatuses,
         prepareSelectedModel,

--- a/apps/playground/src/utils/asrBenchmarkModels.ts
+++ b/apps/playground/src/utils/asrBenchmarkModels.ts
@@ -1,6 +1,8 @@
 import type { MoonshineModelArch } from '@siteed/moonshine.rn'
 import type { AsrModelConfig } from '@siteed/sherpa-onnx.rn'
 
+import mobileRecommendationModelIdsJson from './asrMobileRecommendationModelIds.json'
+
 export type AsrBenchmarkEngine = 'moonshine' | 'whisper' | 'sherpa'
 export type AsrBenchmarkMode = 'sample' | 'simulated'
 
@@ -34,12 +36,17 @@ export interface SherpaBenchmarkDescriptor {
 export interface AsrBenchmarkModel {
     description: string
     engine: AsrBenchmarkEngine
+    estimatedSizeLabel?: string
     id: string
     liveCapable: boolean
     moonshine?: MoonshineBenchmarkDescriptor
     name: string
     rationale: string
+    recommendationLabel?: string
+    recommendationTier?: 'recommended' | 'alternate' | 'avoid-default'
+    recommendedUse?: string
     sherpa?: SherpaBenchmarkDescriptor
+    warningLabel?: string
     whisper?: WhisperBenchmarkDescriptor
 }
 
@@ -125,7 +132,11 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         name: 'Moonshine Small Streaming',
         description: 'Primary Moonshine live contender for on-device English transcription.',
         engine: 'moonshine',
+        estimatedSizeLabel: '~230 MB on device',
         liveCapable: true,
+        recommendationLabel: 'Live default',
+        recommendationTier: 'recommended',
+        recommendedUse: 'Live low-latency transcript',
         rationale:
             'The smaller serious Moonshine candidate. Fast enough to be practical while still competitive on device.',
         moonshine: {
@@ -140,8 +151,13 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         name: 'Moonshine Medium Streaming',
         description: 'Highest-quality official Moonshine streaming contender for English.',
         engine: 'moonshine',
+        estimatedSizeLabel: '~420 MB on device',
         liveCapable: true,
+        recommendationLabel: 'Live quality alternate',
+        recommendationTier: 'alternate',
+        recommendedUse: 'Live transcript when startup/CPU budget allows',
         rationale: 'Current Moonshine quality ceiling for live English speech on device.',
+        warningLabel: 'Slower startup on full-file replay',
         moonshine: {
             modelArch: 'medium-streaming',
             slug: 'medium-streaming-en',
@@ -154,8 +170,13 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         name: 'Whisper Small (whisper.rn)',
         description: 'Whisper.cpp-backed English small model through whisper.rn.',
         engine: 'whisper',
+        estimatedSizeLabel: '~466 MB on device',
         liveCapable: true,
+        recommendationLabel: 'Legacy baseline',
+        recommendationTier: 'avoid-default',
+        recommendedUse: 'Compatibility baseline only; excluded from practical matrix',
         rationale: 'Best practical open Whisper contender already available in playground.',
+        warningLabel: 'Pseudo-streaming replay re-decodes cumulative audio and can hang long runs',
         whisper: {
             filename: 'ggml-small.en.bin',
             url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin',
@@ -168,9 +189,14 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         description:
             'Best currently validated Sherpa ONNX offline ASR candidate for on-device long-form transcription.',
         engine: 'sherpa',
+        estimatedSizeLabel: '~1.0 GB on device',
         liveCapable: false,
+        recommendationLabel: 'Post-recording default',
+        recommendationTier: 'recommended',
+        recommendedUse: 'Offline segmented post-recording transcript quality',
         rationale:
             'Runs offline on Android from the downloaded sherpa-onnx Qwen3 0.6B INT8 package; intended as the quality comparison point against Moonshine live models.',
+        warningLabel: 'Offline-only; not a live transcript model',
         sherpa: {
             modelDir:
                 'models/qwen3-asr-0.6B-int8-2026-03-25/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25',
@@ -206,9 +232,14 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         description:
             'Sherpa ONNX offline Whisper small baseline, using the same Sherpa ASR API as Qwen3.',
         engine: 'sherpa',
+        estimatedSizeLabel: '~1.3 GB on device',
         liveCapable: false,
+        recommendationLabel: 'Whisper baseline',
+        recommendationTier: 'alternate',
+        recommendedUse: 'EchoBridge parity baseline',
         rationale:
             'Practical Whisper parity baseline already available from the Sherpa model zoo; useful to separate model quality from wrapper/runtime behavior.',
+        warningLabel: 'Offline-only and slower than Qwen3 on Pixel 6a',
         sherpa: {
             modelDir: 'models/whisper-small-multilingual/sherpa-onnx-whisper-small',
             releaseBetweenSegments: true,
@@ -223,9 +254,14 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         description:
             'Sherpa ONNX offline Whisper medium parity/stress-test model against the EchoBridge Whisper medium reference.',
         engine: 'sherpa',
+        estimatedSizeLabel: '~3.7 GB on device',
         liveCapable: false,
+        recommendationLabel: 'Opt-in stress test',
+        recommendationTier: 'avoid-default',
+        recommendedUse: 'FP32 Whisper parity stress testing only',
         rationale:
             'Closest on-device Sherpa Whisper comparison to the EchoBridge Whisper medium backend reference; expected to be slow/heavy on mid-range phones.',
+        warningLabel: 'Not a default mobile model; Pixel 6a run did not complete',
         sherpa: {
             modelDir: 'models/whisper-medium-multilingual/sherpa-onnx-whisper-medium',
             releaseBetweenSegments: true,
@@ -239,9 +275,14 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
         name: 'Sherpa Whisper Medium INT8',
         description: 'Quantized Sherpa ONNX Whisper medium variant for mobile feasibility checks.',
         engine: 'sherpa',
+        estimatedSizeLabel: '~3.7 GB on device',
         liveCapable: false,
+        recommendationLabel: 'EchoBridge parity default',
+        recommendationTier: 'recommended',
+        recommendedUse: 'Whisper-vs-EchoBridge parity benchmark',
         rationale:
             'Uses the same Whisper medium export as the parity model but selects INT8 encoder/decoder files to measure the mobile quality/speed trade-off.',
+        warningLabel: 'Very slow offline model; backend-reference score is not human WER',
         sherpa: {
             modelDir: 'models/whisper-medium-multilingual/sherpa-onnx-whisper-medium',
             releaseBetweenSegments: true,
@@ -257,6 +298,19 @@ export const ASR_BENCHMARK_MODELS: AsrBenchmarkModel[] = [
 ]
 
 export const ASR_BENCHMARK_MODEL_IDS = ASR_BENCHMARK_MODELS.map((model) => model.id)
+const mobileRecommendationModelIds = mobileRecommendationModelIdsJson as string[]
+const benchmarkModelIdSet = new Set(ASR_BENCHMARK_MODEL_IDS)
+const unknownMobileRecommendationModelIds = mobileRecommendationModelIds.filter(
+    (modelId) => !benchmarkModelIdSet.has(modelId),
+)
+
+if (unknownMobileRecommendationModelIds.length > 0) {
+    throw new Error(
+        `Unknown ASR mobile recommendation model ids: ${unknownMobileRecommendationModelIds.join(', ')}`,
+    )
+}
+
+export const ASR_MOBILE_RECOMMENDATION_MODEL_IDS = mobileRecommendationModelIds
 
 export const ASR_BENCHMARK_SAMPLES: AsrBenchmarkSample[] = [
     {

--- a/apps/playground/src/utils/asrMobileRecommendationModelIds.json
+++ b/apps/playground/src/utils/asrMobileRecommendationModelIds.json
@@ -1,0 +1,7 @@
+[
+    "moonshine-small-streaming-en",
+    "moonshine-medium-streaming-en",
+    "sherpa-qwen3-asr-0.6b-int8",
+    "sherpa-whisper-small",
+    "sherpa-whisper-medium-int8"
+]

--- a/docs/ASR_BENCHMARK.md
+++ b/docs/ASR_BENCHMARK.md
@@ -1,16 +1,14 @@
 # ASR Benchmark
 
 ## Purpose
-This benchmark isolates Recorder-like ASR experiments in `apps/sherpa-voice` without changing the existing demo screen.
+This document tracks two related mobile ASR benchmark surfaces:
 
-The page is designed to compare:
-- practical live mobile models
-- practical offline baselines
-- heavier offline reference models
+- Audio Playground `/asr-benchmark`: the current recommendation workflow for live Moonshine transcription, Sherpa live speaker turns, segmented Sherpa offline ASR, and EchoBridge parity checks.
+- `apps/sherpa-voice`: the legacy Recorder-like Sherpa ASR matrix, kept as historical model-selection evidence.
 
-It intentionally does not benchmark only the likely winner. The matrix keeps weaker but useful baselines in place so tradeoffs are visible.
+The matrices intentionally do not benchmark only the likely winner. They keep weaker but useful baselines in place so tradeoffs are visible.
 
-## Current Matrix
+## Sherpa Voice Legacy Matrix
 - `streaming-zipformer-en-20m-mobile`
   Purpose: compact live mobile baseline
 - `streaming-zipformer-en-general`
@@ -102,15 +100,50 @@ Audio Playground now includes the `moonshine-sherpa-echobridge-perps-5m` direct 
 
 The Sherpa offline path uses the reusable `SegmentedOfflineAsrSession` JS helper from `@siteed/sherpa-onnx.rn`. It does not require a new native API: bounded PCM windows are submitted through `ASR.recognizeFromSamples`, segment/progress events are emitted, and Android can release/reinitialize the Sherpa ASR runtime between windows. The direct WAV benchmark still loads the 5-minute WAV into JS memory first for scoring parity; use `/long-audio-validation` for the progressive decoder path that proves compressed long audio can be decoded and transcribed window-by-window.
 
+## Audio Playground Mobile Recommendation Workflow
+
+The dev-only Audio Playground `/asr-benchmark` page is the combined recommendation surface for live Moonshine transcription, live Sherpa speaker turns, segmented Sherpa offline ASR, and EchoBridge Whisper parity.
+
+| Use case | Recommended default | Alternate | Avoid/default-off |
+| --- | --- | --- | --- |
+| Live low-latency transcript | Moonshine Small Streaming | Moonshine Medium Streaming on faster devices | Sherpa offline models for live UX |
+| Live speaker turns | Sherpa VAD + Speaker ID through `LiveSpeakerTurnSession` | Offline diarization for final quality | Treating live speaker ID as final diarization |
+| Post-recording transcript quality | Sherpa Qwen3-ASR 0.6B INT8 segmented offline | Sherpa Whisper Medium INT8 when Whisper parity is desired | Running offline models without segmentation/progress |
+| EchoBridge parity testing | Sherpa Whisper Medium INT8 | Sherpa Whisper Small | Interpreting Whisper-vs-Whisper scores as human WER |
+| Legacy compatibility | Manual `whisper.rn` small runs only | none | Practical default matrix runs |
+| Stress testing | Opt-in Sherpa Whisper Medium FP32 preset | Larger-memory device profile | Default Pixel 6a matrix runs |
+
+Use `Run Practical Matrix` in the page to run the mobile-safe model set. It intentionally excludes FP32 Sherpa Whisper Medium. The direct runner mirrors that behavior when no `BENCHMARK_MODELS` are provided, exposes a named practical preset, keeps `moonshine-sherpa-echobridge-perps-5m` as an alias for the same set, and accepts `BENCHMARK_MODELS=all` for the full legacy sweep:
+
+```bash
+cd apps/playground
+ADB_SERIAL=29071JEGR20638 \
+BENCHMARK_DEVICE="Pixel 6a - 16 - API 36" \
+BENCHMARK_PRESET=mobile-asr-recommendation-echobridge-perps-5m \
+node scripts/agentic/direct-asr-benchmark.mjs
+```
+
+Run the FP32 Whisper Medium stress row only when explicitly requested:
+
+```bash
+cd apps/playground
+ADB_SERIAL=29071JEGR20638 \
+BENCHMARK_DEVICE="Pixel 6a - 16 - API 36" \
+BENCHMARK_ALLOW_MODEL_DOWNLOAD=1 \
+BENCHMARK_OFFLINE_TIMEOUT_MS=3600000 \
+BENCHMARK_PRESET=sherpa-whisper-fp32-echobridge-perps-5m \
+node scripts/agentic/direct-asr-benchmark.mjs
+```
+
 Measured on Pixel 6a (`Pixel 6a - 16 - API 36`):
 
 | Model | Mode | WER vs EchoBridge | CER vs EchoBridge | Runtime/session | Notes |
 | --- | --- | ---: | ---: | ---: | --- |
-| Sherpa Whisper Medium INT8 | offline segmented | 19.5% | 16.3% | 475.0 s | 10 × 30 s segments; closest successful on-device Whisper-vs-EchoBridge parity row in this run |
-| Sherpa Whisper Small | offline segmented | 29.3% | 22.7% | 229.2 s | 10 × 30 s segments; useful Whisper baseline, slower than Qwen3 and slightly lower quality here |
-| Sherpa Qwen3-ASR 0.6B INT8 direct replay | offline segmented | 28.1% | 22.8% | 207.4 s | 10 × 30 s segments; best validated on-device text-quality candidate; not live-streaming |
-| Moonshine Medium Streaming | offline/file | 38.0% | 28.2% | 183.9 s | live-capable; quality below Qwen3 |
-| Moonshine Small Streaming | offline/file | 45.8% | 35.7% | 95.2 s | faster fallback |
+| Sherpa Whisper Medium INT8 | offline segmented | 19.5% | 16.3% | 502.4 s | 10 × 30 s segments; closest successful on-device Whisper-vs-EchoBridge parity row in this run |
+| Sherpa Whisper Small | offline segmented | 29.3% | 22.7% | 255.7 s | 10 × 30 s segments; useful Whisper baseline, slower than Qwen3 and slightly lower quality here |
+| Sherpa Qwen3-ASR 0.6B INT8 direct replay | offline segmented | 28.1% | 22.8% | 267.9 s | 10 × 30 s segments; best validated on-device text-quality candidate; not live-streaming |
+| Moonshine Medium Streaming | offline/file | 37.4% | 27.9% | 212.4 s | live-capable; quality below Qwen3 |
+| Moonshine Small Streaming | offline/file | 47.3% | 36.7% | 112.0 s | faster fallback |
 
 Whisper parity note: the EchoBridge reference transcript is produced by a server-side Whisper `medium.en` pipeline, so Sherpa Whisper Medium is a runtime/parity stress check rather than an independent human-labelled accuracy target. In this Pixel 6a run the INT8 Sherpa Whisper Medium row completed; the FP32 Sherpa Whisper Medium row was staged but did not produce a completed direct benchmark report before the dev target was lost, so it is kept behind the opt-in `sherpa-whisper-fp32-echobridge-perps-5m` preset and is not a recommended mobile default yet.
 

--- a/docs/MOONSHINE_SHERPA_LIVE.md
+++ b/docs/MOONSHINE_SHERPA_LIVE.md
@@ -90,20 +90,22 @@ node scripts/agentic/direct-asr-benchmark.mjs
 
 Reference source: EchoBridge server `WhisperService` with `medium.en` on the 5-minute `perps_controller_refactor_5m_16k_mono.wav` fixture. This is a backend-reference score, not human-labelled WER.
 
+The offline/file and simulated-live Moonshine rows come from separate passes within the same Pixel 6a direct replay report. The small WER/CER differences are expected because simulated live commits incremental streaming text instead of scoring a single full-file transcript.
+
 | Mode | Model | WER vs EchoBridge | CER vs EchoBridge | Init | Runtime | First partial | First commit | Commits |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Offline/file segmented | Sherpa Whisper Medium INT8 | 19.5% | 16.3% | 6.5 s | 475.0 s | n/a | n/a | n/a |
-| Offline/file segmented | Sherpa Whisper Small | 29.3% | 22.7% | 3.5 s | 229.2 s | n/a | n/a | n/a |
-| Offline/file segmented | Sherpa Qwen3-ASR 0.6B INT8 | 28.1% | 22.8% | 4.8 s | 207.4 s | n/a | n/a | n/a |
-| Offline/file | Moonshine Medium Streaming | 38.0% | 28.2% | 33.4 s | 183.9 s | n/a | n/a | n/a |
-| Offline/file | Moonshine Small Streaming | 45.8% | 35.7% | 0.8 s | 95.2 s | n/a | n/a | n/a |
-| Simulated live | Moonshine Medium Streaming | 38.0% | 28.2% | 1.7 s | 300.8 s | 4.2 s | 4.5 s | 90 |
-| Simulated live | Moonshine Small Streaming | 46.4% | 35.8% | 2.0 s | 300.8 s | 4.2 s | 4.5 s | 91 |
+| Offline/file segmented | Sherpa Whisper Medium INT8 | 19.5% | 16.3% | 13.8 s | 502.4 s | n/a | n/a | n/a |
+| Offline/file segmented | Sherpa Whisper Small | 29.3% | 22.7% | 7.8 s | 255.7 s | n/a | n/a | n/a |
+| Offline/file segmented | Sherpa Qwen3-ASR 0.6B INT8 | 28.1% | 22.8% | 11.3 s | 267.9 s | n/a | n/a | n/a |
+| Offline/file | Moonshine Medium Streaming | 37.4% | 27.9% | 3.0 s | 212.4 s | n/a | n/a | n/a |
+| Offline/file | Moonshine Small Streaming | 47.3% | 36.7% | 1.0 s | 112.0 s | n/a | n/a | n/a |
+| Simulated live | Moonshine Medium Streaming | 38.0% | 28.2% | 1.5 s | 300.8 s | 4.2 s | 4.4 s | 90 |
+| Simulated live | Moonshine Small Streaming | 46.4% | 35.8% | 1.6 s | 300.8 s | 4.2 s | 4.6 s | 91 |
 
 Findings from this replay:
 
 - Sherpa Whisper Medium INT8 is the best completed backend-reference score in this benchmark: 19.5% WER. Treat it as a Whisper runtime/parity row, because the EchoBridge reference itself is server-side Whisper `medium.en`, not a human transcript.
-- Sherpa Qwen3-ASR 0.6B INT8 remains the best non-Whisper Sherpa candidate validated here: 28.1% WER vs 38.0% for Moonshine medium.
+- Sherpa Qwen3-ASR 0.6B INT8 remains the best non-Whisper Sherpa candidate validated here: 28.1% WER vs 37.4% for offline/file Moonshine medium.
 - Qwen3 is offline-only and is run through `SegmentedOfflineAsrSession`: PCM is submitted to Sherpa `ASR.recognizeFromSamples` in 30-second segments, progress is emitted after each finalized segment, and Android can release/reinitialize between segments to avoid retained native heap. The direct benchmark loads the 5-minute WAV first for reproducible scoring; `/long-audio-validation` validates the progressive decoder path.
 - `/long-audio-validation` also validates the progressive decoder path: the first 60 seconds of the staged fixture completed on Pixel 6a with 241 decoder chunks, 2 Sherpa segments, 409 transcript chars, and 44.5 s wall time.
 - Medium is the better Moonshine quality default when the device can afford it, but startup is much slower for full-file transcription.
@@ -112,6 +114,8 @@ Findings from this replay:
 
 ## Recommended use
 
-- Use this page for UX validation of live transcript + tentative speaker attribution.
+- Use the Record tab Moonshine + Sherpa mode for UX validation of live transcript + tentative speaker attribution.
+- Use `/asr-benchmark` for the combined mobile recommendation workflow and `Run Practical Matrix` for the default mobile-safe benchmark set.
 - Use Sherpa offline diarization for final speaker-turn quality comparisons.
-- Use Sherpa Qwen3/offline ASR benchmarks for post-recording transcription quality; Qwen3 is not the live-streaming path.
+- Use segmented Sherpa offline ASR for post-recording transcription quality; Qwen3 is the practical non-Whisper row and Whisper Medium INT8 is the EchoBridge parity row.
+- Keep FP32 Sherpa Whisper Medium opt-in only until it has a completed mobile run on the target device class.


### PR DESCRIPTION
## Summary

- add a dev-only `/asr-benchmark` mobile recommendation workflow that combines live Moonshine transcript UX, Sherpa live speaker-turn positioning, segmented Sherpa offline ASR, and EchoBridge parity rows
- share the mobile-safe recommendation model allowlist between the UI and direct runner via `asrMobileRecommendationModelIds.json`
- add the `mobile-asr-recommendation-echobridge-perps-5m` direct benchmark preset, keep the older `moonshine-sherpa-echobridge-perps-5m` alias, and document `BENCHMARK_MODELS=all` for full sweeps
- update ASR docs with practical Pixel 6a results and clear defaults/default-off guidance

## Validation

| Check | Result |
| --- | --- |
| Typecheck | `yarn workspace audio-playground typecheck` ✅ |
| Targeted lint | `yarn workspace audio-playground exec eslint src/app/asr-benchmark.tsx src/hooks/useAsrBenchmark.ts src/utils/asrBenchmarkModels.ts src/utils/asrBenchmarkRuntime.ts --quiet` ✅ |
| Direct runner syntax | `node --check apps/playground/scripts/agentic/direct-asr-benchmark.mjs` ✅ |
| Diff hygiene | `git diff --check main...HEAD` ✅ |
| Android launch | `ADB_SERIAL=29071JEGR20638 yarn workspace audio-playground android:device:launch` ✅ |
| Pixel 6a benchmark | `BENCHMARK_PRESET=mobile-asr-recommendation-echobridge-perps-5m ... node apps/playground/scripts/agentic/direct-asr-benchmark.mjs` ✅ |

Pixel 6a benchmark evidence generated locally:

- `apps/playground/.agent/reports/direct-asr-benchmark-2026-05-17T05-28-47-347Z.json`
- `apps/playground/.agent/reports/direct-asr-benchmark-2026-05-17T05-28-47-347Z.md`

Summary from that run:

| Model | Mode | WER vs EchoBridge | CER vs EchoBridge | Runtime |
| --- | --- | ---: | ---: | ---: |
| Sherpa Whisper Medium INT8 | segmented offline | 19.5% | 16.3% | 502.4s |
| Sherpa Qwen3-ASR 0.6B INT8 | segmented offline | 28.1% | 22.8% | 267.9s |
| Sherpa Whisper Small | segmented offline | 29.3% | 22.7% | 255.7s |
| Moonshine Medium Streaming | file replay | 37.4% | 27.9% | 212.4s |
| Moonshine Small Streaming | file replay | 47.3% | 36.7% | 112.0s |

## Cross-review

Final reviewed HEAD: `ad9cf4dd1d0309064fb3ea540783c3617a6c39e5`

| Reviewer | Artifact | Verdict |
| --- | --- | --- |
| Claude | `.omx/artifacts/claude-fresh-full-code-review-request-for-audiolab-branch-feat-asr--2026-05-17T06-09-21-113Z.md` | APPROVE |
| Codex | `.omc/artifacts/ask/codex-fresh-full-code-review-request-for-audiolab-branch-feat-asr--2026-05-17T06-11-56-672Z.md` | APPROVE |

No `.agent` benchmark reports, model caches, or generated artifacts are committed.
