### PR TITLE
fix(audio-studio): expose max-duration auto-stop result

### DIFF
--- a/apps/playground/scripts/agentic/teams/playground/recipes/record-max-duration-validation.json
+++ b/apps/playground/scripts/agentic/teams/playground/recipes/record-max-duration-validation.json
@@ -76,7 +76,7 @@
         },
         "start-auto-stop-recording": {
           "action": "eval_async",
-          "expression": "globalThis.__AGENTIC__?.startRecording?.({ interval: 1000, intervalAnalysis: 1000, sampleRate: 16000, encoding: 'pcm_16bit', enableProcessing: false, maxDurationMs: 1200, autoStopOnMaxDuration: true, output: { primary: { enabled: false }, compressed: { enabled: false } } }).then(function(result) { return JSON.stringify(result); })",
+          "expression": "globalThis.__AGENTIC__?.startRecording?.({ interval: 1000, intervalAnalysis: 500, sampleRate: 16000, encoding: 'pcm_16bit', enableProcessing: true, maxDurationMs: 2200, autoStopOnMaxDuration: true, output: { primary: { enabled: false }, compressed: { enabled: false } } }).then(function(result) { return JSON.stringify(result); })",
           "assert": {
             "operator": "falsy",
             "field": "error"
@@ -102,6 +102,30 @@
                 "operator": "eq",
                 "field": "maxDurationReached",
                 "value": true
+              },
+              {
+                "operator": "eq",
+                "field": "lastRecordingReason",
+                "value": "maxDuration"
+              },
+              {
+                "operator": "not_null",
+                "field": "lastRecording"
+              },
+              {
+                "operator": "gt",
+                "field": "lastRecording.durationMs",
+                "value": 0
+              },
+              {
+                "operator": "length_gt",
+                "field": "lastRecording.analysisData.dataPoints",
+                "value": 0
+              },
+              {
+                "operator": "gt",
+                "field": "lastRecordingAnalysisPointCount",
+                "value": 0
               }
             ]
           },

--- a/apps/playground/src/agentic-bridge.ts
+++ b/apps/playground/src/agentic-bridge.ts
@@ -21,7 +21,13 @@ import {
     type AgenticHudStep,
 } from '@siteed/agentic-dev'
 
-import type { UseAudioRecorderState } from '@siteed/audio-studio'
+import type {
+    AudioAnalysis,
+    AudioRecording,
+    RecordingConfig,
+    RecordingStopReason,
+    UseAudioRecorderState,
+} from '@siteed/audio-studio'
 import {
     extractPreview,
     extractAudioData,
@@ -73,6 +79,9 @@ const stepHudStore = createAgenticHudStore()
 
 // Recorder instance wired by AgenticBridgeSync
 let _recorder: UseAudioRecorderState | null = null
+let _lastRecording: AudioRecording | undefined
+let _lastRecordingReason: RecordingStopReason | undefined
+let _lastRecordingAnalysisPointCount = 0
 
 export interface AgenticAudioPlayerProbeState {
     pointsReceived: number
@@ -180,6 +189,27 @@ function stripFunctions(obj: Record<string, unknown>): Record<string, unknown> {
         }
     }
     return clean
+}
+
+function createAgenticAnalysisSnapshot(analysis: AudioAnalysis): AudioAnalysis & {
+    dataPointsCount: number
+} {
+    const dataPoints = Array.isArray(analysis.dataPoints) ? analysis.dataPoints : []
+
+    return {
+        ...analysis,
+        dataPoints: dataPoints.slice(0, 3),
+        dataPointsCount: dataPoints.length,
+    }
+}
+
+function createAgenticRecordingSnapshot(recording: AudioRecording): AudioRecording {
+    const analysisData = recording.analysisData
+
+    return {
+        ...recording,
+        analysisData: analysisData ? createAgenticAnalysisSnapshot(analysisData) : undefined,
+    }
 }
 
 // --- Async result store for fire-and-store pattern (CDP awaitPromise:false) ---
@@ -971,6 +1001,9 @@ if (__DEV__) {
         getState: () => {
             return {
                 ..._audioState,
+                lastRecording: _lastRecording,
+                lastRecordingReason: _lastRecordingReason ?? _audioState.lastRecordingReason,
+                lastRecordingAnalysisPointCount: _lastRecordingAnalysisPointCount,
                 pageState: _pageState,
                 route: _routeInfo.pathname,
                 segments: _routeInfo.segments,
@@ -1024,7 +1057,23 @@ if (__DEV__) {
             }
             try {
                 const safeConfig = stripFunctions(config)
-                const result = await _recorder.startRecording(safeConfig as never)
+                _lastRecording = undefined
+                _lastRecordingReason = undefined
+                _lastRecordingAnalysisPointCount = 0
+
+                const bridgeConfig: RecordingConfig = {
+                    ...(safeConfig as RecordingConfig),
+                    onRecordingStopped: (recording, reason) => {
+                        _lastRecordingReason = reason
+                        _lastRecordingAnalysisPointCount =
+                            recording.analysisData?.dataPoints?.length ?? 0
+                        _lastRecording =
+                            reason === 'maxDuration'
+                                ? createAgenticRecordingSnapshot(recording)
+                                : undefined
+                    },
+                }
+                const result = await _recorder.startRecording(bridgeConfig)
                 return result
             } catch (e) {
                 return { error: String(e) }

--- a/apps/playground/src/components/AgenticBridgeSync.tsx
+++ b/apps/playground/src/components/AgenticBridgeSync.tsx
@@ -9,11 +9,7 @@ import { useEffect } from 'react'
 
 import { useSharedAudioRecorder } from '@siteed/audio-studio'
 
-import {
-    setAgenticAudioState,
-    setAgenticRecorder,
-    setAgenticRouteInfo,
-} from '../agentic-bridge'
+import { setAgenticAudioState, setAgenticRecorder, setAgenticRouteInfo } from '../agentic-bridge'
 
 export function AgenticBridgeSync() {
     if (!__DEV__) return null
@@ -30,10 +26,10 @@ function AgenticBridgeSyncInner() {
         isPaused,
         durationMs,
         size,
-        analysisData,
         compression,
         maxDurationMs,
         maxDurationReached,
+        lastRecordingReason,
     } = recorder
 
     // Wire the recorder instance into the bridge on mount
@@ -51,20 +47,20 @@ function AgenticBridgeSyncInner() {
             isPaused,
             durationMs,
             size,
-            analysisData,
             compression,
             maxDurationMs,
             maxDurationReached,
+            lastRecordingReason,
         })
     }, [
         isRecording,
         isPaused,
         durationMs,
         size,
-        analysisData,
         compression,
         maxDurationMs,
         maxDurationReached,
+        lastRecordingReason,
     ])
 
     return null

--- a/documentation_site/docs/api-reference/API/README.md
+++ b/documentation_site/docs/api-reference/API/README.md
@@ -77,6 +77,7 @@
 - [EncodingType](type-aliases/EncodingType.md)
 - [~~PCMFormat~~](type-aliases/PCMFormat.md)
 - [RecordingInterruptionReason](type-aliases/RecordingInterruptionReason.md)
+- [RecordingStopReason](type-aliases/RecordingStopReason.md)
 - [SampleRate](type-aliases/SampleRate.md)
 
 ## Variables

--- a/documentation_site/docs/api-reference/API/classes/AudioDeviceManager.md
+++ b/documentation_site/docs/api-reference/API/classes/AudioDeviceManager.md
@@ -6,7 +6,7 @@
 
 # Class: AudioDeviceManager
 
-Defined in: [src/AudioDeviceManager.ts:78](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L78)
+Defined in: [src/AudioDeviceManager.ts:78](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L78)
 
 Class that provides a cross-platform API for managing audio input devices
 
@@ -40,7 +40,7 @@ This is intentional to distinguish between different event categories.
 
 > **new AudioDeviceManager**(`options?`): `AudioDeviceManager`
 
-Defined in: [src/AudioDeviceManager.ts:96](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L96)
+Defined in: [src/AudioDeviceManager.ts:96](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L96)
 
 #### Parameters
 
@@ -60,7 +60,7 @@ Defined in: [src/AudioDeviceManager.ts:96](https://github.com/deeeed/audiolab/bl
 
 > **addDeviceChangeListener**(`listener`): () => `void`
 
-Defined in: [src/AudioDeviceManager.ts:334](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L334)
+Defined in: [src/AudioDeviceManager.ts:334](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L334)
 
 Register a listener for device changes
 
@@ -84,7 +84,7 @@ Function to remove the listener
 
 > **cleanup**(): `void`
 
-Defined in: [src/AudioDeviceManager.ts:448](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L448)
+Defined in: [src/AudioDeviceManager.ts:448](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L448)
 
 Clean up timeouts and listeners (useful for testing or cleanup)
 
@@ -98,7 +98,7 @@ Clean up timeouts and listeners (useful for testing or cleanup)
 
 > **forceRefreshDevices**(): `Promise`\<[`AudioDevice`](../interfaces/AudioDevice.md)[]\>
 
-Defined in: [src/AudioDeviceManager.ts:475](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L475)
+Defined in: [src/AudioDeviceManager.ts:475](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L475)
 
 Force refresh devices without debouncing (for device events)
 
@@ -114,7 +114,7 @@ Promise resolving to the updated device list (AudioDevice[])
 
 > **getAvailableDevices**(`options?`): `Promise`\<[`AudioDevice`](../interfaces/AudioDevice.md)[]\>
 
-Defined in: [src/AudioDeviceManager.ts:208](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L208)
+Defined in: [src/AudioDeviceManager.ts:208](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L208)
 
 Get all available audio input devices
 
@@ -140,7 +140,7 @@ Promise resolving to an array of audio devices conforming to AudioDevice interfa
 
 > **getCurrentDevice**(): `Promise`\<[`AudioDevice`](../interfaces/AudioDevice.md) \| `null`\>
 
-Defined in: [src/AudioDeviceManager.ts:238](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L238)
+Defined in: [src/AudioDeviceManager.ts:238](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L238)
 
 Get the currently selected audio input device
 
@@ -156,7 +156,7 @@ Promise resolving to the current device (conforming to AudioDevice) or null
 
 > **getLogger**(): [`ConsoleLike`](../type-aliases/ConsoleLike.md) \| `undefined`
 
-Defined in: [src/AudioDeviceManager.ts:199](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L199)
+Defined in: [src/AudioDeviceManager.ts:199](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L199)
 
 Get the current logger instance
 
@@ -172,7 +172,7 @@ The logger instance or undefined if not set
 
 > **getRawDevices**(): [`AudioDevice`](../interfaces/AudioDevice.md)[]
 
-Defined in: [src/AudioDeviceManager.ts:433](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L433)
+Defined in: [src/AudioDeviceManager.ts:433](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L433)
 
 Get the raw device list (including temporarily disconnected devices)
 
@@ -188,7 +188,7 @@ Array of all available devices from native layer
 
 > **getTemporarilyDisconnectedDeviceIds**(): `ReadonlySet`\<`string`\>
 
-Defined in: [src/AudioDeviceManager.ts:441](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L441)
+Defined in: [src/AudioDeviceManager.ts:441](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L441)
 
 Get the IDs of temporarily disconnected devices
 
@@ -204,7 +204,7 @@ Set of device IDs that are temporarily hidden from UI
 
 > **initializeDeviceDetection**(): `void`
 
-Defined in: [src/AudioDeviceManager.ts:177](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L177)
+Defined in: [src/AudioDeviceManager.ts:177](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L177)
 
 Initialize or reinitialize device detection
 Useful for restarting device detection if initial setup failed
@@ -219,7 +219,7 @@ Useful for restarting device detection if initial setup failed
 
 > **initWithLogger**(`logger`): `AudioDeviceManager`
 
-Defined in: [src/AudioDeviceManager.ts:160](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L160)
+Defined in: [src/AudioDeviceManager.ts:160](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L160)
 
 Initialize the device manager with a logger
 
@@ -243,7 +243,7 @@ The manager instance for chaining
 
 > **markDeviceAsDisconnected**(`deviceId`, `notify?`): `void`
 
-Defined in: [src/AudioDeviceManager.ts:355](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L355)
+Defined in: [src/AudioDeviceManager.ts:355](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L355)
 
 Mark a device as temporarily disconnected (for UI filtering)
 
@@ -271,7 +271,7 @@ Whether to notify listeners immediately (default: true)
 
 > **markDeviceAsReconnected**(`deviceId`): `void`
 
-Defined in: [src/AudioDeviceManager.ts:392](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L392)
+Defined in: [src/AudioDeviceManager.ts:392](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L392)
 
 Mark a device as reconnected (remove from disconnected set)
 
@@ -293,7 +293,7 @@ The ID of the device that was reconnected
 
 > **notifyListeners**(): `void`
 
-Defined in: [src/AudioDeviceManager.ts:778](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L778)
+Defined in: [src/AudioDeviceManager.ts:778](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L778)
 
 Notify all registered listeners about device changes.
 
@@ -307,7 +307,7 @@ Notify all registered listeners about device changes.
 
 > **refreshDevices**(): `Promise`\<[`AudioDevice`](../interfaces/AudioDevice.md)[]\>
 
-Defined in: [src/AudioDeviceManager.ts:500](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L500)
+Defined in: [src/AudioDeviceManager.ts:500](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L500)
 
 Refresh the list of available devices with debouncing and notify listeners.
 
@@ -323,7 +323,7 @@ Promise resolving to the updated device list (AudioDevice[])
 
 > **resetToDefaultDevice**(): `Promise`\<`boolean`\>
 
-Defined in: [src/AudioDeviceManager.ts:307](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L307)
+Defined in: [src/AudioDeviceManager.ts:307](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L307)
 
 Reset to the default audio input device
 
@@ -339,7 +339,7 @@ Promise resolving to a boolean indicating success
 
 > **selectDevice**(`deviceId`): `Promise`\<`boolean`\>
 
-Defined in: [src/AudioDeviceManager.ts:272](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L272)
+Defined in: [src/AudioDeviceManager.ts:272](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L272)
 
 Select a specific audio input device for recording
 
@@ -363,7 +363,7 @@ Promise resolving to a boolean indicating success
 
 > **setLogger**(`logger`): `void`
 
-Defined in: [src/AudioDeviceManager.ts:169](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L169)
+Defined in: [src/AudioDeviceManager.ts:169](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L169)
 
 Set the logger instance
 

--- a/documentation_site/docs/api-reference/API/classes/AudioExtractionError.md
+++ b/documentation_site/docs/api-reference/API/classes/AudioExtractionError.md
@@ -6,7 +6,7 @@
 
 # Class: AudioExtractionError
 
-Defined in: [src/errors/AudioExtractionError.ts:20](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L20)
+Defined in: [src/errors/AudioExtractionError.ts:20](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L20)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/errors/AudioExtractionError.ts:20](https://github.com/deeeed/au
 
 > **new AudioExtractionError**(`payload`): `AudioExtractionError`
 
-Defined in: [src/errors/AudioExtractionError.ts:25](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L25)
+Defined in: [src/errors/AudioExtractionError.ts:25](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L25)
 
 #### Parameters
 
@@ -52,7 +52,7 @@ Defined in: node\_modules/typescript/lib/lib.es2022.error.d.ts:24
 
 > `readonly` **code**: [`AudioExtractionErrorCode`](../type-aliases/AudioExtractionErrorCode.md)
 
-Defined in: [src/errors/AudioExtractionError.ts:21](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L21)
+Defined in: [src/errors/AudioExtractionError.ts:21](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L21)
 
 ***
 
@@ -60,7 +60,7 @@ Defined in: [src/errors/AudioExtractionError.ts:21](https://github.com/deeeed/au
 
 > `readonly` `optional` **fileUri?**: `string`
 
-Defined in: [src/errors/AudioExtractionError.ts:23](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L23)
+Defined in: [src/errors/AudioExtractionError.ts:23](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L23)
 
 ***
 
@@ -92,7 +92,7 @@ Defined in: node\_modules/typescript/lib/lib.es5.d.ts:1074
 
 > `readonly` `optional` **nativeMessage?**: `string`
 
-Defined in: [src/errors/AudioExtractionError.ts:22](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L22)
+Defined in: [src/errors/AudioExtractionError.ts:22](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L22)
 
 ***
 
@@ -134,7 +134,7 @@ not capture any frames.
 
 > **toJSON**(): [`AudioExtractionErrorPayload`](../interfaces/AudioExtractionErrorPayload.md)
 
-Defined in: [src/errors/AudioExtractionError.ts:33](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L33)
+Defined in: [src/errors/AudioExtractionError.ts:33](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L33)
 
 #### Returns
 

--- a/documentation_site/docs/api-reference/API/classes/AudioStreamError.md
+++ b/documentation_site/docs/api-reference/API/classes/AudioStreamError.md
@@ -6,7 +6,7 @@
 
 # Class: AudioStreamError
 
-Defined in: [src/errors/AudioStreamError.ts:33](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L33)
+Defined in: [src/errors/AudioStreamError.ts:33](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L33)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/errors/AudioStreamError.ts:33](https://github.com/deeeed/audiol
 
 > **new AudioStreamError**(`payload`): `AudioStreamError`
 
-Defined in: [src/errors/AudioStreamError.ts:41](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L41)
+Defined in: [src/errors/AudioStreamError.ts:41](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L41)
 
 #### Parameters
 
@@ -52,7 +52,7 @@ Defined in: node\_modules/typescript/lib/lib.es2022.error.d.ts:24
 
 > `readonly` **code**: [`AudioStreamErrorCode`](../type-aliases/AudioStreamErrorCode.md)
 
-Defined in: [src/errors/AudioStreamError.ts:34](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L34)
+Defined in: [src/errors/AudioStreamError.ts:34](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L34)
 
 ***
 
@@ -60,7 +60,7 @@ Defined in: [src/errors/AudioStreamError.ts:34](https://github.com/deeeed/audiol
 
 > `readonly` `optional` **fileUri?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:36](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L36)
+Defined in: [src/errors/AudioStreamError.ts:36](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L36)
 
 ***
 
@@ -92,7 +92,7 @@ Defined in: node\_modules/typescript/lib/lib.es5.d.ts:1074
 
 > `readonly` `optional` **nativeCode?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:38](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L38)
+Defined in: [src/errors/AudioStreamError.ts:38](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L38)
 
 ***
 
@@ -100,7 +100,7 @@ Defined in: [src/errors/AudioStreamError.ts:38](https://github.com/deeeed/audiol
 
 > `readonly` `optional` **nativeMessage?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:39](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L39)
+Defined in: [src/errors/AudioStreamError.ts:39](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L39)
 
 ***
 
@@ -108,7 +108,7 @@ Defined in: [src/errors/AudioStreamError.ts:39](https://github.com/deeeed/audiol
 
 > `readonly` `optional` **platform?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:37](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L37)
+Defined in: [src/errors/AudioStreamError.ts:37](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L37)
 
 ***
 
@@ -116,7 +116,7 @@ Defined in: [src/errors/AudioStreamError.ts:37](https://github.com/deeeed/audiol
 
 > `readonly` **recoverable**: `boolean`
 
-Defined in: [src/errors/AudioStreamError.ts:35](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L35)
+Defined in: [src/errors/AudioStreamError.ts:35](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L35)
 
 ***
 
@@ -158,7 +158,7 @@ not capture any frames.
 
 > **toJSON**(): [`AudioStreamErrorPayload`](../interfaces/AudioStreamErrorPayload.md)
 
-Defined in: [src/errors/AudioStreamError.ts:52](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L52)
+Defined in: [src/errors/AudioStreamError.ts:52](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L52)
 
 #### Returns
 

--- a/documentation_site/docs/api-reference/API/functions/addMaxDurationReachedListener.md
+++ b/documentation_site/docs/api-reference/API/functions/addMaxDurationReachedListener.md
@@ -8,7 +8,7 @@
 
 > **addMaxDurationReachedListener**(`listener`): `EventSubscription`
 
-Defined in: [src/events.ts:68](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/events.ts#L68)
+Defined in: [src/events.ts:68](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/events.ts#L68)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/computeMelFrameWasm.md
+++ b/documentation_site/docs/api-reference/API/functions/computeMelFrameWasm.md
@@ -8,7 +8,7 @@
 
 > **computeMelFrameWasm**(`_samples`): `number`[] \| `null`
 
-Defined in: [src/AudioAnalysis/melSpectrogramWasm.ts:16](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/melSpectrogramWasm.ts#L16)
+Defined in: [src/AudioAnalysis/melSpectrogramWasm.ts:16](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/melSpectrogramWasm.ts#L16)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/convertPCMToFloat32.md
+++ b/documentation_site/docs/api-reference/API/functions/convertPCMToFloat32.md
@@ -8,7 +8,7 @@
 
 > **convertPCMToFloat32**(`__namedParameters`): `Promise`\<\{ `max`: `number`; `min`: `number`; `pcmValues`: `Float32Array`; \}\>
 
-Defined in: [src/utils/convertPCMToFloat32.ts:69](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/convertPCMToFloat32.ts#L69)
+Defined in: [src/utils/convertPCMToFloat32.ts:69](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/convertPCMToFloat32.ts#L69)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/extractAudioAnalysis.md
+++ b/documentation_site/docs/api-reference/API/functions/extractAudioAnalysis.md
@@ -8,7 +8,7 @@
 
 > **extractAudioAnalysis**(`props`): `Promise`\<[`AudioAnalysis`](../interfaces/AudioAnalysis.md)\>
 
-Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:107](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L107)
+Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:107](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L107)
 
 Extracts detailed audio analysis from the specified audio file or buffer.
 Supports either time-based or byte-based ranges for flexibility in analysis.

--- a/documentation_site/docs/api-reference/API/functions/extractAudioData.md
+++ b/documentation_site/docs/api-reference/API/functions/extractAudioData.md
@@ -8,7 +8,7 @@
 
 > **extractAudioData**(`props`): `Promise`\<[`ExtractedAudioData`](../interfaces/ExtractedAudioData.md)\>
 
-Defined in: [src/AudioAnalysis/extractAudioData.ts:13](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractAudioData.ts#L13)
+Defined in: [src/AudioAnalysis/extractAudioData.ts:13](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractAudioData.ts#L13)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/extractMelSpectrogram.md
+++ b/documentation_site/docs/api-reference/API/functions/extractMelSpectrogram.md
@@ -8,7 +8,7 @@
 
 > **extractMelSpectrogram**(`options`): `Promise`\<[`MelSpectrogram`](../interfaces/MelSpectrogram.md)\>
 
-Defined in: [src/AudioAnalysis/extractMelSpectrogram.ts:33](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractMelSpectrogram.ts#L33)
+Defined in: [src/AudioAnalysis/extractMelSpectrogram.ts:33](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractMelSpectrogram.ts#L33)
 
 **`Experimental`**
 

--- a/documentation_site/docs/api-reference/API/functions/extractPreview.md
+++ b/documentation_site/docs/api-reference/API/functions/extractPreview.md
@@ -8,7 +8,7 @@
 
 > **extractPreview**(`options`): `Promise`\<[`AudioAnalysis`](../interfaces/AudioAnalysis.md)\>
 
-Defined in: [src/AudioAnalysis/extractPreview.ts:88](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractPreview.ts#L88)
+Defined in: [src/AudioAnalysis/extractPreview.ts:88](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractPreview.ts#L88)
 
 Generates a simplified preview of the audio waveform for quick visualization.
 Ideal for UI rendering with a specified number of points.

--- a/documentation_site/docs/api-reference/API/functions/extractPreviewBars.md
+++ b/documentation_site/docs/api-reference/API/functions/extractPreviewBars.md
@@ -8,7 +8,7 @@
 
 > **extractPreviewBars**(`__namedParameters`): `Promise`\<[`PreviewBarsResult`](../interfaces/PreviewBarsResult.md)\>
 
-Defined in: [src/AudioAnalysis/extractPreviewBars.ts:133](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractPreviewBars.ts#L133)
+Defined in: [src/AudioAnalysis/extractPreviewBars.ts:133](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractPreviewBars.ts#L133)
 
 Extracts compact waveform preview bars for UI rendering.
 

--- a/documentation_site/docs/api-reference/API/functions/extractRawWavAnalysis.md
+++ b/documentation_site/docs/api-reference/API/functions/extractRawWavAnalysis.md
@@ -8,7 +8,7 @@
 
 > **extractRawWavAnalysis**(`props`): `Promise`\<[`AudioAnalysis`](../interfaces/AudioAnalysis.md)\>
 
-Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:241](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L241)
+Defined in: [src/AudioAnalysis/extractAudioAnalysis.ts:241](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractAudioAnalysis.ts#L241)
 
 Analyzes WAV files without decoding, preserving original PCM values.
 Use this function when you need to ensure the analysis matches other software by avoiding any transformations.

--- a/documentation_site/docs/api-reference/API/functions/getAudioDecodeCapabilities.md
+++ b/documentation_site/docs/api-reference/API/functions/getAudioDecodeCapabilities.md
@@ -8,7 +8,7 @@
 
 > **getAudioDecodeCapabilities**(): `Promise`\<[`AudioDecodeCapabilities`](../interfaces/AudioDecodeCapabilities.md)\>
 
-Defined in: [src/streamAudioData.ts:305](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L305)
+Defined in: [src/streamAudioData.ts:305](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L305)
 
 Discover what the running platform supports.
 

--- a/documentation_site/docs/api-reference/API/functions/getFallbackBitDepth.md
+++ b/documentation_site/docs/api-reference/API/functions/getFallbackBitDepth.md
@@ -8,7 +8,7 @@
 
 > **getFallbackBitDepth**(`requestedBitDepth`): [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/constants/platformLimitations.ts:79](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L79)
+Defined in: [src/constants/platformLimitations.ts:79](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L79)
 
 Get a fallback bit depth if the requested one is not supported
 

--- a/documentation_site/docs/api-reference/API/functions/getFallbackEncoding.md
+++ b/documentation_site/docs/api-reference/API/functions/getFallbackEncoding.md
@@ -8,7 +8,7 @@
 
 > **getFallbackEncoding**(`requestedEncoding`): [`EncodingType`](../type-aliases/EncodingType.md)
 
-Defined in: [src/constants/platformLimitations.ts:65](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L65)
+Defined in: [src/constants/platformLimitations.ts:65](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L65)
 
 Get a fallback encoding if the requested one is not supported
 

--- a/documentation_site/docs/api-reference/API/functions/getPlatformCapabilities.md
+++ b/documentation_site/docs/api-reference/API/functions/getPlatformCapabilities.md
@@ -8,7 +8,7 @@
 
 > **getPlatformCapabilities**(): [`PlatformCapabilities`](../interfaces/PlatformCapabilities.md)
 
-Defined in: [src/constants/platformLimitations.ts:42](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L42)
+Defined in: [src/constants/platformLimitations.ts:42](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L42)
 
 Get the current platform's audio capabilities
 

--- a/documentation_site/docs/api-reference/API/functions/getWavFileInfo.md
+++ b/documentation_site/docs/api-reference/API/functions/getWavFileInfo.md
@@ -8,7 +8,7 @@
 
 > **getWavFileInfo**(`arrayBuffer`): `Promise`\<[`WavFileInfo`](../interfaces/WavFileInfo.md)\>
 
-Defined in: [src/utils/getWavFileInfo.ts:47](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L47)
+Defined in: [src/utils/getWavFileInfo.ts:47](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L47)
 
 Extracts metadata from a WAV buffer.
 

--- a/documentation_site/docs/api-reference/API/functions/initMelStreamingWasm.md
+++ b/documentation_site/docs/api-reference/API/functions/initMelStreamingWasm.md
@@ -8,7 +8,7 @@
 
 > **initMelStreamingWasm**(`_sampleRate`, `_nMels?`, `_fftLength?`, `_windowSizeSamples?`, `_hopLengthSamples?`, `_fMin?`, `_fMax?`): `Promise`\<`void`\>
 
-Defined in: [src/AudioAnalysis/melSpectrogramWasm.ts:4](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/melSpectrogramWasm.ts#L4)
+Defined in: [src/AudioAnalysis/melSpectrogramWasm.ts:4](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/melSpectrogramWasm.ts#L4)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/isBitDepthSupported.md
+++ b/documentation_site/docs/api-reference/API/functions/isBitDepthSupported.md
@@ -8,7 +8,7 @@
 
 > **isBitDepthSupported**(`bitDepth`): `boolean`
 
-Defined in: [src/constants/platformLimitations.ts:57](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L57)
+Defined in: [src/constants/platformLimitations.ts:57](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L57)
 
 Check if a specific bit depth is supported on the current platform
 

--- a/documentation_site/docs/api-reference/API/functions/isEncodingSupported.md
+++ b/documentation_site/docs/api-reference/API/functions/isEncodingSupported.md
@@ -8,7 +8,7 @@
 
 > **isEncodingSupported**(`encoding`): `boolean`
 
-Defined in: [src/constants/platformLimitations.ts:49](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L49)
+Defined in: [src/constants/platformLimitations.ts:49](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L49)
 
 Check if a specific encoding is supported on the current platform
 

--- a/documentation_site/docs/api-reference/API/functions/mapExtractionError.md
+++ b/documentation_site/docs/api-reference/API/functions/mapExtractionError.md
@@ -8,7 +8,7 @@
 
 > **mapExtractionError**(`err`, `fileUri?`): [`AudioExtractionError`](../classes/AudioExtractionError.md)
 
-Defined in: [src/errors/AudioExtractionError.ts:111](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L111)
+Defined in: [src/errors/AudioExtractionError.ts:111](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L111)
 
 Map a thrown native/JS value into an AudioExtractionError with a stable code.
 Heuristics inspect message text and known native error codes.

--- a/documentation_site/docs/api-reference/API/functions/mapStreamError.md
+++ b/documentation_site/docs/api-reference/API/functions/mapStreamError.md
@@ -8,7 +8,7 @@
 
 > **mapStreamError**(`err`, `fileUri?`, `platform?`): [`AudioStreamError`](../classes/AudioStreamError.md)
 
-Defined in: [src/errors/AudioStreamError.ts:151](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L151)
+Defined in: [src/errors/AudioStreamError.ts:151](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L151)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/setMelSpectrogramWasmUrl.md
+++ b/documentation_site/docs/api-reference/API/functions/setMelSpectrogramWasmUrl.md
@@ -8,7 +8,7 @@
 
 > **setMelSpectrogramWasmUrl**(`url`): `void`
 
-Defined in: [src/AudioAnalysis/wasmConfig.ts:17](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/wasmConfig.ts#L17)
+Defined in: [src/AudioAnalysis/wasmConfig.ts:17](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/wasmConfig.ts#L17)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/streamAudioData.md
+++ b/documentation_site/docs/api-reference/API/functions/streamAudioData.md
@@ -8,7 +8,7 @@
 
 > **streamAudioData**(`options`, `callbacks`): `Promise`\<[`StreamAudioDataResult`](../interfaces/StreamAudioDataResult.md)\>
 
-Defined in: [src/streamAudioData.ts:291](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L291)
+Defined in: [src/streamAudioData.ts:291](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L291)
 
 Stream decoded audio from a stored file as bounded Float32 PCM chunks.
 

--- a/documentation_site/docs/api-reference/API/functions/trimAudio.md
+++ b/documentation_site/docs/api-reference/API/functions/trimAudio.md
@@ -8,7 +8,7 @@
 
 > **trimAudio**(`options`, `progressCallback?`): `Promise`\<[`TrimAudioResult`](../interfaces/TrimAudioResult.md)\>
 
-Defined in: [src/trimAudio.ts:74](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/trimAudio.ts#L74)
+Defined in: [src/trimAudio.ts:74](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/trimAudio.ts#L74)
 
 **`Experimental`**
 

--- a/documentation_site/docs/api-reference/API/functions/useAudioDevices.md
+++ b/documentation_site/docs/api-reference/API/functions/useAudioDevices.md
@@ -8,7 +8,7 @@
 
 > **useAudioDevices**(): `object`
 
-Defined in: [src/hooks/useAudioDevices.ts:9](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/hooks/useAudioDevices.ts#L9)
+Defined in: [src/hooks/useAudioDevices.ts:9](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/hooks/useAudioDevices.ts#L9)
 
 React hook for managing audio input devices
 

--- a/documentation_site/docs/api-reference/API/functions/useAudioRecorder.md
+++ b/documentation_site/docs/api-reference/API/functions/useAudioRecorder.md
@@ -8,7 +8,7 @@
 
 > **useAudioRecorder**(`__namedParameters?`): `UseAudioRecorderState`
 
-Defined in: [src/useAudioRecorder.tsx:187](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/useAudioRecorder.tsx#L187)
+Defined in: [src/useAudioRecorder.tsx:203](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/useAudioRecorder.tsx#L203)
 
 ## Parameters
 

--- a/documentation_site/docs/api-reference/API/functions/useSharedAudioRecorder.md
+++ b/documentation_site/docs/api-reference/API/functions/useSharedAudioRecorder.md
@@ -8,7 +8,7 @@
 
 > **useSharedAudioRecorder**(): [`UseAudioRecorderState`](../interfaces/UseAudioRecorderState.md)
 
-Defined in: [src/AudioRecorder.provider.tsx:49](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioRecorder.provider.tsx#L49)
+Defined in: [src/AudioRecorder.provider.tsx:49](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioRecorder.provider.tsx#L49)
 
 ## Returns
 

--- a/documentation_site/docs/api-reference/API/functions/validateRecordingConfig.md
+++ b/documentation_site/docs/api-reference/API/functions/validateRecordingConfig.md
@@ -8,7 +8,7 @@
 
 > **validateRecordingConfig**(`config`): `object`
 
-Defined in: [src/constants/platformLimitations.ts:91](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L91)
+Defined in: [src/constants/platformLimitations.ts:91](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L91)
 
 Validate and adjust recording configuration based on platform limitations
 

--- a/documentation_site/docs/api-reference/API/functions/writeWavHeader.md
+++ b/documentation_site/docs/api-reference/API/functions/writeWavHeader.md
@@ -8,7 +8,7 @@
 
 > **writeWavHeader**(`options`): `ArrayBuffer`
 
-Defined in: [src/utils/writeWavHeader.ts:36](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L36)
+Defined in: [src/utils/writeWavHeader.ts:36](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L36)
 
 Writes or updates a WAV (RIFF) header based on the provided options.
 

--- a/documentation_site/docs/api-reference/API/interfaces/AndroidConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AndroidConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: AndroidConfig
 
-Defined in: [src/AudioStudio.types.ts:274](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L274)
+Defined in: [src/AudioStudio.types.ts:276](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L276)
 
 Android platform specific configuration options
 
@@ -16,7 +16,7 @@ Android platform specific configuration options
 
 > `optional` **audioFocusStrategy?**: `"background"` \| `"interactive"` \| `"communication"` \| `"none"`
 
-Defined in: [src/AudioStudio.types.ts:285](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L285)
+Defined in: [src/AudioStudio.types.ts:287](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L287)
 
 Audio focus strategy for handling interruptions and background behavior
 

--- a/documentation_site/docs/api-reference/API/interfaces/AudioAnalysis.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioAnalysis.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioAnalysis
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:114](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L114)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:114](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L114)
 
 Represents the complete data from the audio analysis.
 
@@ -16,7 +16,7 @@ Represents the complete data from the audio analysis.
 
 > **amplitudeRange**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:136](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L136)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:136](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L136)
 
 #### max
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:136](https://github.com/de
 
 > **bitDepth**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:131](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L131)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:131](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L131)
 
 Bit depth used for audio analysis processing.
 
@@ -53,7 +53,7 @@ The actual recorded file will maintain the requested bit depth (8, 16, or 32).
 
 > **dataPoints**: [`DataPoint`](DataPoint.md)[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L135)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L135)
 
 ***
 
@@ -61,7 +61,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:135](https://github.com/de
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:116](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L116)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:116](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L116)
 
 ***
 
@@ -69,7 +69,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:116](https://github.com/de
 
 > **extractionTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:144](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L144)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:144](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L144)
 
 ***
 
@@ -77,7 +77,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:144](https://github.com/de
 
 > **numberOfChannels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:133](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L133)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:133](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L133)
 
 ***
 
@@ -85,7 +85,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:133](https://github.com/de
 
 > **rmsRange**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:140](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L140)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:140](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L140)
 
 #### max
 
@@ -101,7 +101,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:140](https://github.com/de
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:134](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L134)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:134](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L134)
 
 ***
 
@@ -109,7 +109,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:134](https://github.com/de
 
 > **samples**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:132](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L132)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:132](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L132)
 
 ***
 
@@ -117,7 +117,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:132](https://github.com/de
 
 > **segmentDurationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:115](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L115)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:115](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L115)
 
 ***
 
@@ -125,7 +125,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:115](https://github.com/de
 
 > `optional` **speechAnalysis?**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:146](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L146)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:146](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L146)
 
 #### speakerChanges
 

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDataEventFloat32.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDataEventFloat32.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDataEventFloat32
 
-Defined in: [src/AudioStudio.types.ts:67](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L67)
+Defined in: [src/AudioStudio.types.ts:67](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L67)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/AudioStudio.types.ts:67](https://github.com/deeeed/audiolab/blo
 
 > `optional` **compression?**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/AudioStudio.types.ts:55](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L55)
+Defined in: [src/AudioStudio.types.ts:55](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L55)
 
 Information about compression if enabled, including the compressed data chunk
 
@@ -40,7 +40,7 @@ Base64 (native) or Blob (web) encoded compressed data chunk
 
 > **data**: `Float32Array`
 
-Defined in: [src/AudioStudio.types.ts:69](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L69)
+Defined in: [src/AudioStudio.types.ts:69](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L69)
 
 Audio data as Float32Array with samples in [-1, 1] range
 
@@ -50,7 +50,7 @@ Audio data as Float32Array with samples in [-1, 1] range
 
 > **eventDataSize**: `number`
 
-Defined in: [src/AudioStudio.types.ts:51](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L51)
+Defined in: [src/AudioStudio.types.ts:51](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L51)
 
 Size of the current data chunk in bytes
 
@@ -64,7 +64,7 @@ Size of the current data chunk in bytes
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:49](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L49)
+Defined in: [src/AudioStudio.types.ts:49](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L49)
 
 URI to the file being recorded
 
@@ -78,7 +78,7 @@ URI to the file being recorded
 
 > **position**: `number`
 
-Defined in: [src/AudioStudio.types.ts:47](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L47)
+Defined in: [src/AudioStudio.types.ts:47](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L47)
 
 Current position in the audio stream in bytes
 
@@ -92,7 +92,7 @@ Current position in the audio stream in bytes
 
 > **streamFormat**: `"float32"`
 
-Defined in: [src/AudioStudio.types.ts:70](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L70)
+Defined in: [src/AudioStudio.types.ts:70](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L70)
 
 ***
 
@@ -100,7 +100,7 @@ Defined in: [src/AudioStudio.types.ts:70](https://github.com/deeeed/audiolab/blo
 
 > **totalSize**: `number`
 
-Defined in: [src/AudioStudio.types.ts:53](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L53)
+Defined in: [src/AudioStudio.types.ts:53](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L53)
 
 Total size of the recording so far in bytes
 

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDataEventRaw.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDataEventRaw.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDataEventRaw
 
-Defined in: [src/AudioStudio.types.ts:61](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L61)
+Defined in: [src/AudioStudio.types.ts:61](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L61)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/AudioStudio.types.ts:61](https://github.com/deeeed/audiolab/blo
 
 > `optional` **compression?**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/AudioStudio.types.ts:55](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L55)
+Defined in: [src/AudioStudio.types.ts:55](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L55)
 
 Information about compression if enabled, including the compressed data chunk
 
@@ -40,7 +40,7 @@ Base64 (native) or Blob (web) encoded compressed data chunk
 
 > **data**: `string` \| `Float32Array`\<`ArrayBufferLike`\> \| `Int16Array`\<`ArrayBufferLike`\>
 
-Defined in: [src/AudioStudio.types.ts:63](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L63)
+Defined in: [src/AudioStudio.types.ts:63](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L63)
 
 Audio data as base64 string (native), Float32Array (web), or Int16Array (web)
 
@@ -50,7 +50,7 @@ Audio data as base64 string (native), Float32Array (web), or Int16Array (web)
 
 > **eventDataSize**: `number`
 
-Defined in: [src/AudioStudio.types.ts:51](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L51)
+Defined in: [src/AudioStudio.types.ts:51](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L51)
 
 Size of the current data chunk in bytes
 
@@ -64,7 +64,7 @@ Size of the current data chunk in bytes
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:49](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L49)
+Defined in: [src/AudioStudio.types.ts:49](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L49)
 
 URI to the file being recorded
 
@@ -78,7 +78,7 @@ URI to the file being recorded
 
 > **position**: `number`
 
-Defined in: [src/AudioStudio.types.ts:47](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L47)
+Defined in: [src/AudioStudio.types.ts:47](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L47)
 
 Current position in the audio stream in bytes
 
@@ -92,7 +92,7 @@ Current position in the audio stream in bytes
 
 > `optional` **streamFormat?**: `"raw"`
 
-Defined in: [src/AudioStudio.types.ts:64](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L64)
+Defined in: [src/AudioStudio.types.ts:64](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L64)
 
 ***
 
@@ -100,7 +100,7 @@ Defined in: [src/AudioStudio.types.ts:64](https://github.com/deeeed/audiolab/blo
 
 > **totalSize**: `number`
 
-Defined in: [src/AudioStudio.types.ts:53](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L53)
+Defined in: [src/AudioStudio.types.ts:53](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L53)
 
 Total size of the recording so far in bytes
 

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDecodeCapabilities.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDecodeCapabilities.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDecodeCapabilities
 
-Defined in: [src/streamAudioData.ts:108](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L108)
+Defined in: [src/streamAudioData.ts:108](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L108)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/streamAudioData.ts:108](https://github.com/deeeed/audiolab/blob
 
 > `optional` **knownLimitations?**: `string`[]
 
-Defined in: [src/streamAudioData.ts:117](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L117)
+Defined in: [src/streamAudioData.ts:117](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L117)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/streamAudioData.ts:117](https://github.com/deeeed/audiolab/blob
 
 > **platform**: `"ios"` \| `"android"` \| `"web"`
 
-Defined in: [src/streamAudioData.ts:109](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L109)
+Defined in: [src/streamAudioData.ts:109](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L109)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [src/streamAudioData.ts:109](https://github.com/deeeed/audiolab/blob
 
 > **supportedInputFormats**: `string`[]
 
-Defined in: [src/streamAudioData.ts:110](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L110)
+Defined in: [src/streamAudioData.ts:110](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L110)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/streamAudioData.ts:110](https://github.com/deeeed/audiolab/blob
 
 > **supportedOutputFormats**: `"float32"`[]
 
-Defined in: [src/streamAudioData.ts:111](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L111)
+Defined in: [src/streamAudioData.ts:111](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L111)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [src/streamAudioData.ts:111](https://github.com/deeeed/audiolab/blob
 
 > **supportsBackpressure**: `boolean`
 
-Defined in: [src/streamAudioData.ts:113](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L113)
+Defined in: [src/streamAudioData.ts:113](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L113)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/streamAudioData.ts:113](https://github.com/deeeed/audiolab/blob
 
 > **supportsCancellation**: `boolean`
 
-Defined in: [src/streamAudioData.ts:112](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L112)
+Defined in: [src/streamAudioData.ts:112](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L112)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/streamAudioData.ts:112](https://github.com/deeeed/audiolab/blob
 
 > **supportsChannelMixing**: `boolean`
 
-Defined in: [src/streamAudioData.ts:116](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L116)
+Defined in: [src/streamAudioData.ts:116](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L116)
 
 ***
 
@@ -70,7 +70,7 @@ Defined in: [src/streamAudioData.ts:116](https://github.com/deeeed/audiolab/blob
 
 > **supportsTargetSampleRate**: `boolean`
 
-Defined in: [src/streamAudioData.ts:115](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L115)
+Defined in: [src/streamAudioData.ts:115](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L115)
 
 ***
 
@@ -78,4 +78,4 @@ Defined in: [src/streamAudioData.ts:115](https://github.com/deeeed/audiolab/blob
 
 > **supportsTimeRange**: `boolean`
 
-Defined in: [src/streamAudioData.ts:114](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L114)
+Defined in: [src/streamAudioData.ts:114](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L114)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDevice.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDevice.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDevice
 
-Defined in: [src/AudioStudio.types.ts:337](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L337)
+Defined in: [src/AudioStudio.types.ts:339](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L339)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:337](https://github.com/deeeed/audiolab/bl
 
 > **capabilities**: [`AudioDeviceCapabilities`](AudioDeviceCapabilities.md)
 
-Defined in: [src/AudioStudio.types.ts:347](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L347)
+Defined in: [src/AudioStudio.types.ts:349](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L349)
 
 Audio capabilities for the device
 
@@ -24,7 +24,7 @@ Audio capabilities for the device
 
 > **id**: `string`
 
-Defined in: [src/AudioStudio.types.ts:339](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L339)
+Defined in: [src/AudioStudio.types.ts:341](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L341)
 
 Unique identifier for the device
 
@@ -34,7 +34,7 @@ Unique identifier for the device
 
 > **isAvailable**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:349](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L349)
+Defined in: [src/AudioStudio.types.ts:351](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L351)
 
 Whether the device is currently available
 
@@ -44,7 +44,7 @@ Whether the device is currently available
 
 > **isDefault**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:345](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L345)
+Defined in: [src/AudioStudio.types.ts:347](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L347)
 
 Whether this is the system default device
 
@@ -54,7 +54,7 @@ Whether this is the system default device
 
 > **name**: `string`
 
-Defined in: [src/AudioStudio.types.ts:341](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L341)
+Defined in: [src/AudioStudio.types.ts:343](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L343)
 
 Human-readable name of the device
 
@@ -64,6 +64,6 @@ Human-readable name of the device
 
 > **type**: `string`
 
-Defined in: [src/AudioStudio.types.ts:343](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L343)
+Defined in: [src/AudioStudio.types.ts:345](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L345)
 
 Device type (builtin_mic, bluetooth, etc.)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioDeviceCapabilities.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioDeviceCapabilities.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioDeviceCapabilities
 
-Defined in: [src/AudioStudio.types.ts:322](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L322)
+Defined in: [src/AudioStudio.types.ts:324](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L324)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:322](https://github.com/deeeed/audiolab/bl
 
 > **bitDepths**: `number`[]
 
-Defined in: [src/AudioStudio.types.ts:328](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L328)
+Defined in: [src/AudioStudio.types.ts:330](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L330)
 
 Supported bit depths for the device
 
@@ -24,7 +24,7 @@ Supported bit depths for the device
 
 > **channelCounts**: `number`[]
 
-Defined in: [src/AudioStudio.types.ts:326](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L326)
+Defined in: [src/AudioStudio.types.ts:328](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L328)
 
 Supported channel counts for the device
 
@@ -34,7 +34,7 @@ Supported channel counts for the device
 
 > `optional` **hasAutomaticGainControl?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:334](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L334)
+Defined in: [src/AudioStudio.types.ts:336](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L336)
 
 Whether the device supports automatic gain control
 
@@ -44,7 +44,7 @@ Whether the device supports automatic gain control
 
 > `optional` **hasEchoCancellation?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:330](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L330)
+Defined in: [src/AudioStudio.types.ts:332](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L332)
 
 Whether the device supports echo cancellation
 
@@ -54,7 +54,7 @@ Whether the device supports echo cancellation
 
 > `optional` **hasNoiseSuppression?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:332](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L332)
+Defined in: [src/AudioStudio.types.ts:334](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L334)
 
 Whether the device supports noise suppression
 
@@ -64,6 +64,6 @@ Whether the device supports noise suppression
 
 > **sampleRates**: `number`[]
 
-Defined in: [src/AudioStudio.types.ts:324](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L324)
+Defined in: [src/AudioStudio.types.ts:326](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L326)
 
 Supported sample rates for the device

--- a/documentation_site/docs/api-reference/API/interfaces/AudioExtractionErrorPayload.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioExtractionErrorPayload.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioExtractionErrorPayload
 
-Defined in: [src/errors/AudioExtractionError.ts:13](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L13)
+Defined in: [src/errors/AudioExtractionError.ts:13](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L13)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/errors/AudioExtractionError.ts:13](https://github.com/deeeed/au
 
 > **code**: [`AudioExtractionErrorCode`](../type-aliases/AudioExtractionErrorCode.md)
 
-Defined in: [src/errors/AudioExtractionError.ts:14](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L14)
+Defined in: [src/errors/AudioExtractionError.ts:14](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L14)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/errors/AudioExtractionError.ts:14](https://github.com/deeeed/au
 
 > `optional` **fileUri?**: `string`
 
-Defined in: [src/errors/AudioExtractionError.ts:17](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L17)
+Defined in: [src/errors/AudioExtractionError.ts:17](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L17)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [src/errors/AudioExtractionError.ts:17](https://github.com/deeeed/au
 
 > **message**: `string`
 
-Defined in: [src/errors/AudioExtractionError.ts:15](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L15)
+Defined in: [src/errors/AudioExtractionError.ts:15](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L15)
 
 ***
 
@@ -38,4 +38,4 @@ Defined in: [src/errors/AudioExtractionError.ts:15](https://github.com/deeeed/au
 
 > `optional` **nativeMessage?**: `string`
 
-Defined in: [src/errors/AudioExtractionError.ts:16](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L16)
+Defined in: [src/errors/AudioExtractionError.ts:16](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L16)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioFeatures.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioFeatures.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioFeatures
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:41](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L41)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:41](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L41)
 
 Represents various audio features extracted from an audio signal.
 
@@ -16,7 +16,7 @@ Represents various audio features extracted from an audio signal.
 
 > `optional` **chromagram?**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:52](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L52)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:52](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L52)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:52](https://github.com/dee
 
 > `optional` **crc32?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:59](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L59)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:59](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L59)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:59](https://github.com/dee
 
 > `optional` **energy?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:42](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L42)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:42](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L42)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:42](https://github.com/dee
 
 > `optional` **hnr?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:54](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L54)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:54](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L54)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:54](https://github.com/dee
 
 > `optional` **maxAmplitude?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:46](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L46)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:46](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L46)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:46](https://github.com/dee
 
 > `optional` **melSpectrogram?**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:55](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L55)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:55](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L55)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:55](https://github.com/dee
 
 > `optional` **mfcc?**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:43](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L43)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:43](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L43)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:43](https://github.com/dee
 
 > `optional` **minAmplitude?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:45](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L45)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:45](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L45)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:45](https://github.com/dee
 
 > `optional` **pitch?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:58](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L58)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:58](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L58)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:58](https://github.com/dee
 
 > `optional` **rms?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:44](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L44)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:44](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L44)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:44](https://github.com/dee
 
 > `optional` **spectralBandwidth?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:51](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L51)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:51](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L51)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:51](https://github.com/dee
 
 > `optional` **spectralCentroid?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:48](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L48)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:48](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L48)
 
 ***
 
@@ -112,7 +112,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:48](https://github.com/dee
 
 > `optional` **spectralContrast?**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:56](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L56)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:56](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L56)
 
 ***
 
@@ -120,7 +120,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:56](https://github.com/dee
 
 > `optional` **spectralFlatness?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:49](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L49)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:49](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L49)
 
 ***
 
@@ -128,7 +128,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:49](https://github.com/dee
 
 > `optional` **spectralRolloff?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:50](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L50)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:50](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L50)
 
 ***
 
@@ -136,7 +136,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:50](https://github.com/dee
 
 > `optional` **tempo?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:53](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L53)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:53](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L53)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:53](https://github.com/dee
 
 > `optional` **tonnetz?**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:57](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L57)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:57](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L57)
 
 ***
 
@@ -152,4 +152,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:57](https://github.com/dee
 
 > `optional` **zcr?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:47](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L47)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:47](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L47)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioFeaturesOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioFeaturesOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioFeaturesOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:67](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L67)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:67](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L67)
 
 Options to specify which audio features to extract.
 Note: Advanced features (spectral features, chromagram, pitch, etc.) are experimental,
@@ -18,7 +18,7 @@ especially during live recording, due to high processing requirements.
 
 > `optional` **chromagram?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:79](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L79)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:79](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L79)
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:79](https://github.com/dee
 
 > `optional` **crc32?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:88](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L88)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:88](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L88)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:88](https://github.com/dee
 
 > `optional` **energy?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:69](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L69)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:69](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L69)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:69](https://github.com/dee
 
 > `optional` **hnr?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:81](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L81)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:81](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L81)
 
 ***
 
@@ -50,7 +50,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:81](https://github.com/dee
 
 > `optional` **melSpectrogram?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:82](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L82)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:82](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L82)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:82](https://github.com/dee
 
 > `optional` **mfcc?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:74](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L74)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:74](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L74)
 
 ***
 
@@ -66,7 +66,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:74](https://github.com/dee
 
 > `optional` **pitch?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:85](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L85)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:85](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L85)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:85](https://github.com/dee
 
 > `optional` **rms?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:70](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L70)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:70](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L70)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:70](https://github.com/dee
 
 > `optional` **spectralBandwidth?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:78](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L78)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:78](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L78)
 
 ***
 
@@ -90,7 +90,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:78](https://github.com/dee
 
 > `optional` **spectralCentroid?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:75](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L75)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:75](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L75)
 
 ***
 
@@ -98,7 +98,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:75](https://github.com/dee
 
 > `optional` **spectralContrast?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:83](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L83)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:83](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L83)
 
 ***
 
@@ -106,7 +106,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:83](https://github.com/dee
 
 > `optional` **spectralFlatness?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:76](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L76)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:76](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L76)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:76](https://github.com/dee
 
 > `optional` **spectralRolloff?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:77](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L77)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:77](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L77)
 
 ***
 
@@ -122,7 +122,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:77](https://github.com/dee
 
 > `optional` **tempo?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:80](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L80)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:80](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L80)
 
 ***
 
@@ -130,7 +130,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:80](https://github.com/dee
 
 > `optional` **tonnetz?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:84](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L84)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:84](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L84)
 
 ***
 
@@ -138,4 +138,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:84](https://github.com/dee
 
 > `optional` **zcr?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:71](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L71)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:71](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L71)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioFeaturesWasmResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioFeaturesWasmResult.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioFeaturesWasmResult
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:299](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L299)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:299](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L299)
 
 Result type for WASM-based audio feature extraction.
 
@@ -16,7 +16,7 @@ Result type for WASM-based audio feature extraction.
 
 > **chromagram**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:305](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L305)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:305](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L305)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:305](https://github.com/de
 
 > **mfcc**: `number`[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:304](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L304)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:304](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L304)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:304](https://github.com/de
 
 > **spectralBandwidth**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:303](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L303)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:303](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L303)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:303](https://github.com/de
 
 > **spectralCentroid**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:300](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L300)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:300](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L300)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:300](https://github.com/de
 
 > **spectralFlatness**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:301](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L301)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:301](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L301)
 
 ***
 
@@ -56,4 +56,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:301](https://github.com/de
 
 > **spectralRolloff**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:302](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L302)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:302](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L302)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioRangeOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioRangeOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioRangeOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:161](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L161)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:161](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L161)
 
 Options for specifying a time range within an audio file.
 
@@ -21,7 +21,7 @@ Options for specifying a time range within an audio file.
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:165](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L165)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:165](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L165)
 
 End time in milliseconds
 
@@ -31,6 +31,6 @@ End time in milliseconds
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:163](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L163)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:163](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L163)
 
 Start time in milliseconds

--- a/documentation_site/docs/api-reference/API/interfaces/AudioRecording.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioRecording.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioRecording
 
-Defined in: [src/AudioStudio.types.ts:146](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L146)
+Defined in: [src/AudioStudio.types.ts:146](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L146)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:146](https://github.com/deeeed/audiolab/bl
 
 > `optional` **analysisData?**: [`AudioAnalysis`](AudioAnalysis.md)
 
-Defined in: [src/AudioStudio.types.ts:171](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L171)
+Defined in: [src/AudioStudio.types.ts:171](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L171)
 
 Full analysis data for the recording if processing was enabled and
 `keepFullAnalysis` was not set to `false`.
@@ -25,7 +25,7 @@ Full analysis data for the recording if processing was enabled and
 
 > **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/AudioStudio.types.ts:160](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L160)
+Defined in: [src/AudioStudio.types.ts:160](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L160)
 
 Bit depth of the audio (8, 16, or 32 bits)
 
@@ -35,7 +35,7 @@ Bit depth of the audio (8, 16, or 32 bits)
 
 > **channels**: `number`
 
-Defined in: [src/AudioStudio.types.ts:158](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L158)
+Defined in: [src/AudioStudio.types.ts:158](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L158)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -45,7 +45,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **compression?**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/AudioStudio.types.ts:173](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L173)
+Defined in: [src/AudioStudio.types.ts:173](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L173)
 
 Information about compression if enabled, including the URI to the compressed file
 
@@ -63,7 +63,7 @@ URI to the compressed audio file
 
 > `optional` **createdAt?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:164](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L164)
+Defined in: [src/AudioStudio.types.ts:164](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L164)
 
 Timestamp when the recording was created
 
@@ -73,7 +73,7 @@ Timestamp when the recording was created
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:152](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L152)
+Defined in: [src/AudioStudio.types.ts:152](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L152)
 
 Duration of the recording in milliseconds
 
@@ -83,7 +83,7 @@ Duration of the recording in milliseconds
 
 > **filename**: `string`
 
-Defined in: [src/AudioStudio.types.ts:150](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L150)
+Defined in: [src/AudioStudio.types.ts:150](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L150)
 
 Filename of the recorded audio
 
@@ -93,7 +93,7 @@ Filename of the recorded audio
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:148](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L148)
+Defined in: [src/AudioStudio.types.ts:148](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L148)
 
 URI to the recorded audio file
 
@@ -103,7 +103,7 @@ URI to the recorded audio file
 
 > **mimeType**: `string`
 
-Defined in: [src/AudioStudio.types.ts:156](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L156)
+Defined in: [src/AudioStudio.types.ts:156](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L156)
 
 MIME type of the recorded audio
 
@@ -113,7 +113,7 @@ MIME type of the recorded audio
 
 > **sampleRate**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/AudioStudio.types.ts:162](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L162)
+Defined in: [src/AudioStudio.types.ts:162](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L162)
 
 Sample rate of the audio in Hz
 
@@ -123,7 +123,7 @@ Sample rate of the audio in Hz
 
 > **size**: `number`
 
-Defined in: [src/AudioStudio.types.ts:154](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L154)
+Defined in: [src/AudioStudio.types.ts:154](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L154)
 
 Size of the recording in bytes
 
@@ -133,6 +133,6 @@ Size of the recording in bytes
 
 > `optional` **transcripts?**: [`TranscriberData`](TranscriberData.md)[]
 
-Defined in: [src/AudioStudio.types.ts:166](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L166)
+Defined in: [src/AudioStudio.types.ts:166](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L166)
 
 Array of transcription data if available

--- a/documentation_site/docs/api-reference/API/interfaces/AudioSessionConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioSessionConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioSessionConfig
 
-Defined in: [src/AudioStudio.types.ts:210](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L210)
+Defined in: [src/AudioStudio.types.ts:212](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L212)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:210](https://github.com/deeeed/audiolab/bl
 
 > `optional` **category?**: `"Ambient"` \| `"SoloAmbient"` \| `"Playback"` \| `"Record"` \| `"PlayAndRecord"` \| `"MultiRoute"`
 
-Defined in: [src/AudioStudio.types.ts:220](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L220)
+Defined in: [src/AudioStudio.types.ts:222](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L222)
 
 Audio session category that defines the audio behavior
 - 'Ambient': Audio continues with silent switch, mixes with other audio
@@ -30,7 +30,7 @@ Audio session category that defines the audio behavior
 
 > `optional` **categoryOptions?**: (`"MixWithOthers"` \| `"DuckOthers"` \| `"InterruptSpokenAudioAndMixWithOthers"` \| `"AllowBluetooth"` \| `"AllowBluetoothA2DP"` \| `"AllowAirPlay"` \| `"DefaultToSpeaker"`)[]
 
-Defined in: [src/AudioStudio.types.ts:257](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L257)
+Defined in: [src/AudioStudio.types.ts:259](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L259)
 
 Options that modify the behavior of the audio session category
 - 'MixWithOthers': Allows mixing with other active audio sessions
@@ -47,7 +47,7 @@ Options that modify the behavior of the audio session category
 
 > `optional` **mode?**: `"Default"` \| `"VoiceChat"` \| `"VideoChat"` \| `"GameChat"` \| `"VideoRecording"` \| `"Measurement"` \| `"MoviePlayback"` \| `"SpokenAudio"`
 
-Defined in: [src/AudioStudio.types.ts:238](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L238)
+Defined in: [src/AudioStudio.types.ts:240](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L240)
 
 Audio session mode that defines the behavior for specific use cases
 - 'Default': Standard audio behavior

--- a/documentation_site/docs/api-reference/API/interfaces/AudioStreamErrorPayload.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioStreamErrorPayload.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioStreamErrorPayload
 
-Defined in: [src/errors/AudioStreamError.ts:16](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L16)
+Defined in: [src/errors/AudioStreamError.ts:16](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L16)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/errors/AudioStreamError.ts:16](https://github.com/deeeed/audiol
 
 > **code**: [`AudioStreamErrorCode`](../type-aliases/AudioStreamErrorCode.md)
 
-Defined in: [src/errors/AudioStreamError.ts:17](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L17)
+Defined in: [src/errors/AudioStreamError.ts:17](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L17)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/errors/AudioStreamError.ts:17](https://github.com/deeeed/audiol
 
 > `optional` **fileUri?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:20](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L20)
+Defined in: [src/errors/AudioStreamError.ts:20](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L20)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [src/errors/AudioStreamError.ts:20](https://github.com/deeeed/audiol
 
 > **message**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:18](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L18)
+Defined in: [src/errors/AudioStreamError.ts:18](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L18)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/errors/AudioStreamError.ts:18](https://github.com/deeeed/audiol
 
 > `optional` **nativeCode?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:22](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L22)
+Defined in: [src/errors/AudioStreamError.ts:22](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L22)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [src/errors/AudioStreamError.ts:22](https://github.com/deeeed/audiol
 
 > `optional` **nativeMessage?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:23](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L23)
+Defined in: [src/errors/AudioStreamError.ts:23](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L23)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/errors/AudioStreamError.ts:23](https://github.com/deeeed/audiol
 
 > `optional` **platform?**: `string`
 
-Defined in: [src/errors/AudioStreamError.ts:21](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L21)
+Defined in: [src/errors/AudioStreamError.ts:21](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L21)
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: [src/errors/AudioStreamError.ts:21](https://github.com/deeeed/audiol
 
 > **recoverable**: `boolean`
 
-Defined in: [src/errors/AudioStreamError.ts:19](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L19)
+Defined in: [src/errors/AudioStreamError.ts:19](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L19)

--- a/documentation_site/docs/api-reference/API/interfaces/AudioStreamStatus.md
+++ b/documentation_site/docs/api-reference/API/interfaces/AudioStreamStatus.md
@@ -6,7 +6,7 @@
 
 # Interface: AudioStreamStatus
 
-Defined in: [src/AudioStudio.types.ts:22](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L22)
+Defined in: [src/AudioStudio.types.ts:22](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L22)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:22](https://github.com/deeeed/audiolab/blo
 
 > `optional` **compression?**: [`CompressionInfo`](CompressionInfo.md)
 
-Defined in: [src/AudioStudio.types.ts:38](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L38)
+Defined in: [src/AudioStudio.types.ts:38](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L38)
 
 Information about audio compression if enabled
 
@@ -24,7 +24,7 @@ Information about audio compression if enabled
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:28](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L28)
+Defined in: [src/AudioStudio.types.ts:28](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L28)
 
 Duration of the current recording in milliseconds
 
@@ -34,7 +34,7 @@ Duration of the current recording in milliseconds
 
 > **interval**: `number`
 
-Defined in: [src/AudioStudio.types.ts:32](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L32)
+Defined in: [src/AudioStudio.types.ts:32](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L32)
 
 Interval in milliseconds at which recording data is emitted
 
@@ -44,7 +44,7 @@ Interval in milliseconds at which recording data is emitted
 
 > **intervalAnalysis**: `number`
 
-Defined in: [src/AudioStudio.types.ts:34](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L34)
+Defined in: [src/AudioStudio.types.ts:34](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L34)
 
 Interval in milliseconds at which analysis data is emitted
 
@@ -54,7 +54,7 @@ Interval in milliseconds at which analysis data is emitted
 
 > **isPaused**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:26](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L26)
+Defined in: [src/AudioStudio.types.ts:26](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L26)
 
 Indicates whether recording is in a paused state
 
@@ -64,7 +64,7 @@ Indicates whether recording is in a paused state
 
 > **isRecording**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:24](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L24)
+Defined in: [src/AudioStudio.types.ts:24](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L24)
 
 Indicates whether audio recording is currently active
 
@@ -74,7 +74,7 @@ Indicates whether audio recording is currently active
 
 > `optional` **maxDurationMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:40](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L40)
+Defined in: [src/AudioStudio.types.ts:40](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L40)
 
 Configured maximum active recording duration in milliseconds, if enabled
 
@@ -84,7 +84,7 @@ Configured maximum active recording duration in milliseconds, if enabled
 
 > `optional` **maxDurationReached?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:42](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L42)
+Defined in: [src/AudioStudio.types.ts:42](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L42)
 
 Whether the current recording session has reached the configured maximum duration
 
@@ -94,7 +94,7 @@ Whether the current recording session has reached the configured maximum duratio
 
 > **mimeType**: `string`
 
-Defined in: [src/AudioStudio.types.ts:36](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L36)
+Defined in: [src/AudioStudio.types.ts:36](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L36)
 
 MIME type of the recorded audio (e.g., 'audio/wav')
 
@@ -104,6 +104,6 @@ MIME type of the recorded audio (e.g., 'audio/wav')
 
 > **size**: `number`
 
-Defined in: [src/AudioStudio.types.ts:30](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L30)
+Defined in: [src/AudioStudio.types.ts:30](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L30)
 
 Size of the recorded audio data in bytes

--- a/documentation_site/docs/api-reference/API/interfaces/Chunk.md
+++ b/documentation_site/docs/api-reference/API/interfaces/Chunk.md
@@ -6,7 +6,7 @@
 
 # Interface: Chunk
 
-Defined in: [src/AudioStudio.types.ts:124](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L124)
+Defined in: [src/AudioStudio.types.ts:124](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L124)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:124](https://github.com/deeeed/audiolab/bl
 
 > **text**: `string`
 
-Defined in: [src/AudioStudio.types.ts:126](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L126)
+Defined in: [src/AudioStudio.types.ts:126](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L126)
 
 Transcribed text content
 
@@ -24,6 +24,6 @@ Transcribed text content
 
 > **timestamp**: \[`number`, `number` \| `null`\]
 
-Defined in: [src/AudioStudio.types.ts:128](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L128)
+Defined in: [src/AudioStudio.types.ts:128](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L128)
 
 Start and end timestamp in seconds [start, end] where end can be null if ongoing

--- a/documentation_site/docs/api-reference/API/interfaces/CompressionInfo.md
+++ b/documentation_site/docs/api-reference/API/interfaces/CompressionInfo.md
@@ -6,7 +6,7 @@
 
 # Interface: CompressionInfo
 
-Defined in: [src/AudioStudio.types.ts:9](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L9)
+Defined in: [src/AudioStudio.types.ts:9](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L9)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:9](https://github.com/deeeed/audiolab/blob
 
 > **bitrate**: `number`
 
-Defined in: [src/AudioStudio.types.ts:15](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L15)
+Defined in: [src/AudioStudio.types.ts:15](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L15)
 
 Bitrate of the compressed audio in bits per second
 
@@ -24,7 +24,7 @@ Bitrate of the compressed audio in bits per second
 
 > `optional` **compressedFileUri?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:19](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L19)
+Defined in: [src/AudioStudio.types.ts:19](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L19)
 
 URI to the compressed audio file if available
 
@@ -34,7 +34,7 @@ URI to the compressed audio file if available
 
 > **format**: `string`
 
-Defined in: [src/AudioStudio.types.ts:17](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L17)
+Defined in: [src/AudioStudio.types.ts:17](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L17)
 
 Format of the compression (e.g., 'aac', 'opus')
 
@@ -44,7 +44,7 @@ Format of the compression (e.g., 'aac', 'opus')
 
 > **mimeType**: `string`
 
-Defined in: [src/AudioStudio.types.ts:13](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L13)
+Defined in: [src/AudioStudio.types.ts:13](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L13)
 
 MIME type of the compressed audio (e.g., 'audio/aac', 'audio/opus')
 
@@ -54,6 +54,6 @@ MIME type of the compressed audio (e.g., 'audio/aac', 'audio/opus')
 
 > **size**: `number`
 
-Defined in: [src/AudioStudio.types.ts:11](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L11)
+Defined in: [src/AudioStudio.types.ts:11](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L11)
 
 Size of the compressed audio data in bytes

--- a/documentation_site/docs/api-reference/API/interfaces/DataPoint.md
+++ b/documentation_site/docs/api-reference/API/interfaces/DataPoint.md
@@ -6,7 +6,7 @@
 
 # Interface: DataPoint
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:94](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L94)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:94](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L94)
 
 Represents a single data point in the audio analysis.
 
@@ -16,7 +16,7 @@ Represents a single data point in the audio analysis.
 
 > **amplitude**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:96](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L96)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:96](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L96)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:96](https://github.com/dee
 
 > **dB**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:98](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L98)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:98](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L98)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:98](https://github.com/dee
 
 > `optional` **endPosition?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:106](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L106)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:106](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L106)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:106](https://github.com/de
 
 > `optional` **endTime?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:103](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L103)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:103](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L103)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:103](https://github.com/de
 
 > `optional` **features?**: [`AudioFeatures`](AudioFeatures.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:100](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L100)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:100](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L100)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:100](https://github.com/de
 
 > **id**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:95](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L95)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:95](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L95)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:95](https://github.com/dee
 
 > **rms**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:97](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L97)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:97](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L97)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:97](https://github.com/dee
 
 > `optional` **samples?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:108](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L108)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:108](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L108)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:108](https://github.com/de
 
 > **silent**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:99](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L99)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:99](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L99)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:99](https://github.com/dee
 
 > `optional` **speech?**: [`SpeechFeatures`](SpeechFeatures.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:101](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L101)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:101](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L101)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:101](https://github.com/de
 
 > `optional` **startPosition?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:105](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L105)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:105](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L105)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:105](https://github.com/de
 
 > `optional` **startTime?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:102](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L102)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:102](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L102)

--- a/documentation_site/docs/api-reference/API/interfaces/DecodingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/DecodingConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: DecodingConfig
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:8](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L8)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:8](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L8)
 
 Represents the configuration for decoding audio data.
 
@@ -16,7 +16,7 @@ Represents the configuration for decoding audio data.
 
 > `optional` **normalizeAudio?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:16](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L16)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:16](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L16)
 
 Whether to normalize audio levels (Android and Web)
 
@@ -26,7 +26,7 @@ Whether to normalize audio levels (Android and Web)
 
 > `optional` **silenceRmsThreshold?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:22](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L22)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:22](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L22)
 
 RMS threshold below which a segment is flagged silent.
 Range 0..1. Default 0.01.
@@ -38,7 +38,7 @@ Currently applied as a JS post-process so the same behavior holds across iOS/And
 
 > `optional` **targetBitDepth?**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:14](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L14)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:14](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L14)
 
 Target bit depth (Android and Web)
 
@@ -48,7 +48,7 @@ Target bit depth (Android and Web)
 
 > `optional` **targetChannels?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:12](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L12)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:12](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L12)
 
 Target number of channels (Android and Web)
 
@@ -58,6 +58,6 @@ Target number of channels (Android and Web)
 
 > `optional` **targetSampleRate?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:10](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L10)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:10](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L10)
 
 Target sample rate for decoded audio (Android and Web)

--- a/documentation_site/docs/api-reference/API/interfaces/ExtractAudioDataOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/ExtractAudioDataOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: ExtractAudioDataOptions
 
-Defined in: [src/AudioStudio.types.ts:645](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L645)
+Defined in: [src/AudioStudio.types.ts:661](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L661)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:645](https://github.com/deeeed/audiolab/bl
 
 > `optional` **computeChecksum?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:665](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L665)
+Defined in: [src/AudioStudio.types.ts:681](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L681)
 
 Compute the checksum of the PCM data
 
@@ -24,7 +24,7 @@ Compute the checksum of the PCM data
 
 > `optional` **decodingOptions?**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:667](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L667)
+Defined in: [src/AudioStudio.types.ts:683](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L683)
 
 Target config for the normalized audio (Android and Web)
 
@@ -34,7 +34,7 @@ Target config for the normalized audio (Android and Web)
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:651](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L651)
+Defined in: [src/AudioStudio.types.ts:667](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L667)
 
 End time in milliseconds (for time-based range)
 
@@ -44,7 +44,7 @@ End time in milliseconds (for time-based range)
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:647](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L647)
+Defined in: [src/AudioStudio.types.ts:663](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L663)
 
 URI of the audio file to extract data from
 
@@ -54,7 +54,7 @@ URI of the audio file to extract data from
 
 > `optional` **includeBase64Data?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:659](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L659)
+Defined in: [src/AudioStudio.types.ts:675](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L675)
 
 Include base64 encoded string representation of the audio data
 
@@ -64,7 +64,7 @@ Include base64 encoded string representation of the audio data
 
 > `optional` **includeNormalizedData?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:657](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L657)
+Defined in: [src/AudioStudio.types.ts:673](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L673)
 
 Include normalized audio data in [-1, 1] range
 
@@ -74,7 +74,7 @@ Include normalized audio data in [-1, 1] range
 
 > `optional` **includeWavHeader?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:661](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L661)
+Defined in: [src/AudioStudio.types.ts:677](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L677)
 
 Include WAV header in the PCM data (makes it a valid WAV file)
 
@@ -84,7 +84,7 @@ Include WAV header in the PCM data (makes it a valid WAV file)
 
 > `optional` **length?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:655](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L655)
+Defined in: [src/AudioStudio.types.ts:671](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L671)
 
 Length in bytes to extract (for byte-based range)
 
@@ -94,7 +94,7 @@ Length in bytes to extract (for byte-based range)
 
 > `optional` **logger?**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/AudioStudio.types.ts:663](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L663)
+Defined in: [src/AudioStudio.types.ts:679](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L679)
 
 Logger for debugging - can pass console directly.
 
@@ -104,7 +104,7 @@ Logger for debugging - can pass console directly.
 
 > `optional` **position?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:653](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L653)
+Defined in: [src/AudioStudio.types.ts:669](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L669)
 
 Start position in bytes (for byte-based range)
 
@@ -114,6 +114,6 @@ Start position in bytes (for byte-based range)
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:649](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L649)
+Defined in: [src/AudioStudio.types.ts:665](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L665)
 
 Start time in milliseconds (for time-based range)

--- a/documentation_site/docs/api-reference/API/interfaces/ExtractMelSpectrogramOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/ExtractMelSpectrogramOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: ExtractMelSpectrogramOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:277](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L277)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:277](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L277)
 
 **`Experimental`**
 
@@ -21,7 +21,7 @@ The API may change in future versions.
 
 > `optional` **arrayBuffer?**: `ArrayBuffer`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:279](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L279)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:279](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L279)
 
 **`Experimental`**
 
@@ -31,7 +31,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:279](https://github.com/de
 
 > `optional` **decodingOptions?**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:288](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L288)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:288](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L288)
 
 **`Experimental`**
 
@@ -41,7 +41,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:288](https://github.com/de
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:292](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L292)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:292](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L292)
 
 **`Experimental`**
 
@@ -53,7 +53,7 @@ Optional end time in ms. Clamped so that the range does not exceed MAX_DURATION_
 
 > `optional` **fileUri?**: `string`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:278](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L278)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:278](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L278)
 
 **`Experimental`**
 
@@ -63,7 +63,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:278](https://github.com/de
 
 > `optional` **fMax?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:284](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L284)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:284](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L284)
 
 **`Experimental`**
 
@@ -73,7 +73,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:284](https://github.com/de
 
 > `optional` **fMin?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:283](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L283)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:283](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L283)
 
 **`Experimental`**
 
@@ -83,7 +83,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:283](https://github.com/de
 
 > **hopLengthMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:281](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L281)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:281](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L281)
 
 **`Experimental`**
 
@@ -93,7 +93,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:281](https://github.com/de
 
 > `optional` **logger?**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:293](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L293)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:293](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L293)
 
 **`Experimental`**
 
@@ -103,7 +103,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:293](https://github.com/de
 
 > `optional` **logScale?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:287](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L287)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:287](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L287)
 
 **`Experimental`**
 
@@ -113,7 +113,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:287](https://github.com/de
 
 > **nMels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:282](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L282)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:282](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L282)
 
 **`Experimental`**
 
@@ -123,7 +123,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:282](https://github.com/de
 
 > `optional` **normalize?**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:286](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L286)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:286](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L286)
 
 **`Experimental`**
 
@@ -133,7 +133,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:286](https://github.com/de
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:290](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L290)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:290](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L290)
 
 **`Experimental`**
 
@@ -145,7 +145,7 @@ Optional start time in ms. If neither startTimeMs nor endTimeMs is set, defaults
 
 > **windowSizeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:280](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L280)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:280](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L280)
 
 **`Experimental`**
 
@@ -155,6 +155,6 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:280](https://github.com/de
 
 > `optional` **windowType?**: `"hann"` \| `"hamming"`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:285](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L285)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:285](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L285)
 
 **`Experimental`**

--- a/documentation_site/docs/api-reference/API/interfaces/ExtractedAudioData.md
+++ b/documentation_site/docs/api-reference/API/interfaces/ExtractedAudioData.md
@@ -6,7 +6,7 @@
 
 # Interface: ExtractedAudioData
 
-Defined in: [src/AudioStudio.types.ts:670](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L670)
+Defined in: [src/AudioStudio.types.ts:686](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L686)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:670](https://github.com/deeeed/audiolab/bl
 
 > `optional` **base64Data?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:676](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L676)
+Defined in: [src/AudioStudio.types.ts:692](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L692)
 
 Base64 encoded string representation of the audio data (when includeBase64Data is true)
 
@@ -24,7 +24,7 @@ Base64 encoded string representation of the audio data (when includeBase64Data i
 
 > **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/AudioStudio.types.ts:682](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L682)
+Defined in: [src/AudioStudio.types.ts:698](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L698)
 
 Bits per sample (8, 16, or 32)
 
@@ -34,7 +34,7 @@ Bits per sample (8, 16, or 32)
 
 > **channels**: `number`
 
-Defined in: [src/AudioStudio.types.ts:680](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L680)
+Defined in: [src/AudioStudio.types.ts:696](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L696)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -44,7 +44,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **checksum?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:692](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L692)
+Defined in: [src/AudioStudio.types.ts:708](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L708)
 
 CRC32 Checksum of PCM data
 
@@ -54,7 +54,7 @@ CRC32 Checksum of PCM data
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:684](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L684)
+Defined in: [src/AudioStudio.types.ts:700](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L700)
 
 Duration of the audio in milliseconds
 
@@ -64,7 +64,7 @@ Duration of the audio in milliseconds
 
 > **format**: `"pcm_32bit"` \| `"pcm_16bit"` \| `"pcm_8bit"`
 
-Defined in: [src/AudioStudio.types.ts:686](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L686)
+Defined in: [src/AudioStudio.types.ts:702](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L702)
 
 PCM format identifier (e.g., "pcm_16bit")
 
@@ -74,7 +74,7 @@ PCM format identifier (e.g., "pcm_16bit")
 
 > `optional` **hasWavHeader?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:690](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L690)
+Defined in: [src/AudioStudio.types.ts:706](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L706)
 
 Whether the pcmData includes a WAV header
 
@@ -84,7 +84,7 @@ Whether the pcmData includes a WAV header
 
 > `optional` **normalizedData?**: `Float32Array`\<`ArrayBufferLike`\>
 
-Defined in: [src/AudioStudio.types.ts:674](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L674)
+Defined in: [src/AudioStudio.types.ts:690](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L690)
 
 Normalized audio data in [-1, 1] range (when includeNormalizedData is true)
 
@@ -94,7 +94,7 @@ Normalized audio data in [-1, 1] range (when includeNormalizedData is true)
 
 > **pcmData**: `Uint8Array`
 
-Defined in: [src/AudioStudio.types.ts:672](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L672)
+Defined in: [src/AudioStudio.types.ts:688](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L688)
 
 Raw PCM audio data
 
@@ -104,7 +104,7 @@ Raw PCM audio data
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioStudio.types.ts:678](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L678)
+Defined in: [src/AudioStudio.types.ts:694](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L694)
 
 Sample rate in Hz (e.g., 44100, 48000)
 
@@ -114,6 +114,6 @@ Sample rate in Hz (e.g., 44100, 48000)
 
 > **samples**: `number`
 
-Defined in: [src/AudioStudio.types.ts:688](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L688)
+Defined in: [src/AudioStudio.types.ts:704](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L704)
 
 Total number of audio samples per channel

--- a/documentation_site/docs/api-reference/API/interfaces/IOSConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/IOSConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: IOSConfig
 
-Defined in: [src/AudioStudio.types.ts:268](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L268)
+Defined in: [src/AudioStudio.types.ts:270](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L270)
 
 ## Properties
 
@@ -14,6 +14,6 @@ Defined in: [src/AudioStudio.types.ts:268](https://github.com/deeeed/audiolab/bl
 
 > `optional` **audioSession?**: [`AudioSessionConfig`](AudioSessionConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:270](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L270)
+Defined in: [src/AudioStudio.types.ts:272](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L272)
 
 Configuration for the iOS audio session

--- a/documentation_site/docs/api-reference/API/interfaces/MaxDurationReachedEvent.md
+++ b/documentation_site/docs/api-reference/API/interfaces/MaxDurationReachedEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: MaxDurationReachedEvent
 
-Defined in: [src/AudioStudio.types.ts:197](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L197)
+Defined in: [src/AudioStudio.types.ts:197](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L197)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:197](https://github.com/deeeed/audiolab/bl
 
 > **autoStopped**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:207](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L207)
+Defined in: [src/AudioStudio.types.ts:207](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L207)
 
 Whether the recorder was configured to stop automatically after this event
 
@@ -24,7 +24,7 @@ Whether the recorder was configured to stop automatically after this event
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:199](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L199)
+Defined in: [src/AudioStudio.types.ts:199](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L199)
 
 Active recording duration that triggered the event, in milliseconds
 
@@ -34,7 +34,7 @@ Active recording duration that triggered the event, in milliseconds
 
 > **maxDurationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:201](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L201)
+Defined in: [src/AudioStudio.types.ts:201](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L201)
 
 Configured active recording duration limit, in milliseconds
 
@@ -44,7 +44,7 @@ Configured active recording duration limit, in milliseconds
 
 > **overrunMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:203](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L203)
+Defined in: [src/AudioStudio.types.ts:203](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L203)
 
 Amount by which timer delivery exceeded the limit, in milliseconds
 
@@ -54,6 +54,6 @@ Amount by which timer delivery exceeded the limit, in milliseconds
 
 > `optional` **streamUuid?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:205](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L205)
+Defined in: [src/AudioStudio.types.ts:205](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L205)
 
 Active stream identifier when available

--- a/documentation_site/docs/api-reference/API/interfaces/MelSpectrogram.md
+++ b/documentation_site/docs/api-reference/API/interfaces/MelSpectrogram.md
@@ -6,7 +6,7 @@
 
 # Interface: MelSpectrogram
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:314](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L314)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:314](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L314)
 
 **`Experimental`**
 
@@ -21,7 +21,7 @@ The API may change in future versions.
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:319](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L319)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:319](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L319)
 
 **`Experimental`**
 
@@ -31,7 +31,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:319](https://github.com/de
 
 > **nMels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:317](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L317)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:317](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L317)
 
 **`Experimental`**
 
@@ -41,7 +41,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:317](https://github.com/de
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:316](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L316)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:316](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L316)
 
 **`Experimental`**
 
@@ -51,7 +51,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:316](https://github.com/de
 
 > **spectrogram**: `number`[][]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:315](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L315)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:315](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L315)
 
 **`Experimental`**
 
@@ -61,6 +61,6 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:315](https://github.com/de
 
 > **timeSteps**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:318](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L318)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:318](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L318)
 
 **`Experimental`**

--- a/documentation_site/docs/api-reference/API/interfaces/NotificationAction.md
+++ b/documentation_site/docs/api-reference/API/interfaces/NotificationAction.md
@@ -6,7 +6,7 @@
 
 # Interface: NotificationAction
 
-Defined in: [src/AudioStudio.types.ts:619](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L619)
+Defined in: [src/AudioStudio.types.ts:635](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L635)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:619](https://github.com/deeeed/audiolab/bl
 
 > `optional` **icon?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:627](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L627)
+Defined in: [src/AudioStudio.types.ts:643](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L643)
 
 Icon to be displayed for the action (Android only)
 
@@ -24,7 +24,7 @@ Icon to be displayed for the action (Android only)
 
 > **identifier**: `string`
 
-Defined in: [src/AudioStudio.types.ts:624](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L624)
+Defined in: [src/AudioStudio.types.ts:640](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L640)
 
 Unique identifier for the action
 
@@ -34,6 +34,6 @@ Unique identifier for the action
 
 > **title**: `string`
 
-Defined in: [src/AudioStudio.types.ts:621](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L621)
+Defined in: [src/AudioStudio.types.ts:637](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L637)
 
 Display title for the action

--- a/documentation_site/docs/api-reference/API/interfaces/NotificationConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/NotificationConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: NotificationConfig
 
-Defined in: [src/AudioStudio.types.ts:569](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L569)
+Defined in: [src/AudioStudio.types.ts:585](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L585)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:569](https://github.com/deeeed/audiolab/bl
 
 > `optional` **android?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:580](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L580)
+Defined in: [src/AudioStudio.types.ts:596](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L596)
 
 Android-specific notification configuration
 
@@ -84,7 +84,7 @@ Configuration for the waveform visualization in the notification
 
 > `optional` **icon?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:577](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L577)
+Defined in: [src/AudioStudio.types.ts:593](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L593)
 
 Icon to be displayed in the notification (resource name or URI)
 
@@ -94,7 +94,7 @@ Icon to be displayed in the notification (resource name or URI)
 
 > `optional` **ios?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:613](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L613)
+Defined in: [src/AudioStudio.types.ts:629](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L629)
 
 iOS-specific notification configuration
 
@@ -110,7 +110,7 @@ Identifier for the notification category (used for grouping similar notification
 
 > `optional` **text?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:574](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L574)
+Defined in: [src/AudioStudio.types.ts:590](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L590)
 
 Main text content of the notification
 
@@ -120,6 +120,6 @@ Main text content of the notification
 
 > `optional` **title?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:571](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L571)
+Defined in: [src/AudioStudio.types.ts:587](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L587)
 
 Title of the notification

--- a/documentation_site/docs/api-reference/API/interfaces/OutputConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/OutputConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: OutputConfig
 
-Defined in: [src/AudioStudio.types.ts:367](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L367)
+Defined in: [src/AudioStudio.types.ts:369](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L369)
 
 Configuration for audio output files during recording
 
@@ -16,7 +16,7 @@ Configuration for audio output files during recording
 
 > `optional` **compressed?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:381](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L381)
+Defined in: [src/AudioStudio.types.ts:383](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L383)
 
 Configuration for the compressed output file
 
@@ -55,7 +55,7 @@ Note: iOS always produces M4A containers and ignores this flag
 
 > `optional` **primary?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:371](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L371)
+Defined in: [src/AudioStudio.types.ts:373](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L373)
 
 Configuration for the primary (uncompressed) output file
 

--- a/documentation_site/docs/api-reference/API/interfaces/PlatformCapabilities.md
+++ b/documentation_site/docs/api-reference/API/interfaces/PlatformCapabilities.md
@@ -6,7 +6,7 @@
 
 # Interface: PlatformCapabilities
 
-Defined in: [src/constants/platformLimitations.ts:9](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L9)
+Defined in: [src/constants/platformLimitations.ts:9](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L9)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/constants/platformLimitations.ts:9](https://github.com/deeeed/a
 
 > **notes**: `string`[]
 
-Defined in: [src/constants/platformLimitations.ts:12](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L12)
+Defined in: [src/constants/platformLimitations.ts:12](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L12)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/constants/platformLimitations.ts:12](https://github.com/deeeed/
 
 > **supportedBitDepths**: [`BitDepth`](../type-aliases/BitDepth.md)[]
 
-Defined in: [src/constants/platformLimitations.ts:11](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L11)
+Defined in: [src/constants/platformLimitations.ts:11](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L11)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [src/constants/platformLimitations.ts:11](https://github.com/deeeed/
 
 > **supportedEncodings**: [`EncodingType`](../type-aliases/EncodingType.md)[]
 
-Defined in: [src/constants/platformLimitations.ts:10](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/constants/platformLimitations.ts#L10)
+Defined in: [src/constants/platformLimitations.ts:10](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/constants/platformLimitations.ts#L10)

--- a/documentation_site/docs/api-reference/API/interfaces/PreviewBar.md
+++ b/documentation_site/docs/api-reference/API/interfaces/PreviewBar.md
@@ -6,7 +6,7 @@
 
 # Interface: PreviewBar
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:172](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L172)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:172](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L172)
 
 Options for generating a quick preview of audio waveform.
 This is optimized for UI rendering with a specified number of points.
@@ -17,7 +17,7 @@ This is optimized for UI rendering with a specified number of points.
 
 > **amplitude**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:176](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L176)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:176](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L176)
 
 Peak amplitude for this bar, normalized to 0..1.
 
@@ -27,7 +27,7 @@ Peak amplitude for this bar, normalized to 0..1.
 
 > **endTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:184](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L184)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:184](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L184)
 
 Bar end time in milliseconds from the extracted range start.
 
@@ -37,7 +37,7 @@ Bar end time in milliseconds from the extracted range start.
 
 > **id**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:174](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L174)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:174](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L174)
 
 Stable zero-based bar identifier.
 
@@ -47,7 +47,7 @@ Stable zero-based bar identifier.
 
 > **rms**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:178](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L178)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:178](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L178)
 
 Root mean square amplitude for this bar, normalized to 0..1.
 
@@ -57,7 +57,7 @@ Root mean square amplitude for this bar, normalized to 0..1.
 
 > **silent**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:180](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L180)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:180](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L180)
 
 Whether this bar is below the configured silence RMS threshold.
 
@@ -67,6 +67,6 @@ Whether this bar is below the configured silence RMS threshold.
 
 > **startTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:182](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L182)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:182](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L182)
 
 Bar start time in milliseconds from the extracted range start.

--- a/documentation_site/docs/api-reference/API/interfaces/PreviewBarsOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/PreviewBarsOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: PreviewBarsOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:216](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L216)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:216](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L216)
 
 Options for extracting compact waveform preview bars for UI rendering.
 
@@ -20,7 +20,7 @@ Options for extracting compact waveform preview bars for UI rendering.
 
 > `optional` **decodingOptions?**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:227](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L227)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:227](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L227)
 
 Optional configuration for decoding the audio file.
 
@@ -30,7 +30,7 @@ Optional configuration for decoding the audio file.
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:165](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L165)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:165](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L165)
 
 End time in milliseconds
 
@@ -44,7 +44,7 @@ End time in milliseconds
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:218](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L218)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:218](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L218)
 
 URI of the audio file to analyze
 
@@ -54,7 +54,7 @@ URI of the audio file to analyze
 
 > `optional` **logger?**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:225](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L225)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:225](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L225)
 
 Optional logger for debugging.
 
@@ -64,7 +64,7 @@ Optional logger for debugging.
 
 > `optional` **numberOfBars?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:223](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L223)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:223](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L223)
 
 Total number of bars to generate for the preview.
 
@@ -80,7 +80,7 @@ Total number of bars to generate for the preview.
 
 > `optional` **onBarReady?**: (`bar`, `index`, `total`) => `void`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:232](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L232)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:232](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L232)
 
 Optional callback fired once per compact bar after extraction resolves.
 Native progressive streaming is not implied by this callback.
@@ -109,7 +109,7 @@ Native progressive streaming is not implied by this callback.
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:163](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L163)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:163](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L163)
 
 Start time in milliseconds
 

--- a/documentation_site/docs/api-reference/API/interfaces/PreviewBarsResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/PreviewBarsResult.md
@@ -6,7 +6,7 @@
 
 # Interface: PreviewBarsResult
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:191](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L191)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:191](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L191)
 
 Compact preview-bars result for UI waveform rendering.
 Unlike `AudioAnalysis`, this intentionally omits full `DataPoint` feature data.
@@ -17,7 +17,7 @@ Unlike `AudioAnalysis`, this intentionally omits full `DataPoint` feature data.
 
 > **amplitudeRange**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:202](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L202)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:202](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L202)
 
 #### max
 
@@ -33,7 +33,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:202](https://github.com/de
 
 > **barDurationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:201](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L201)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:201](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L201)
 
 Approximate duration represented by each bar.
 
@@ -43,7 +43,7 @@ Approximate duration represented by each bar.
 
 > **bars**: [`PreviewBar`](PreviewBar.md)[]
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:192](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L192)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:192](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L192)
 
 ***
 
@@ -51,7 +51,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:192](https://github.com/de
 
 > **bitDepth**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:196](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L196)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:196](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L196)
 
 ***
 
@@ -59,7 +59,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:196](https://github.com/de
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:193](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L193)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:193](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L193)
 
 ***
 
@@ -67,7 +67,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:193](https://github.com/de
 
 > **extractionTimeMs**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:210](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L210)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:210](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L210)
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:210](https://github.com/de
 
 > **numberOfChannels**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:195](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L195)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:195](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L195)
 
 ***
 
@@ -83,7 +83,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:195](https://github.com/de
 
 > **requestedNumberOfBars**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:199](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L199)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:199](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L199)
 
 Requested bar count before native/platform clamping.
 
@@ -93,7 +93,7 @@ Requested bar count before native/platform clamping.
 
 > **rmsRange**: `object`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:206](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L206)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:206](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L206)
 
 #### max
 
@@ -109,7 +109,7 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:206](https://github.com/de
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:194](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L194)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:194](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L194)
 
 ***
 
@@ -117,4 +117,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:194](https://github.com/de
 
 > **samples**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:197](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L197)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:197](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L197)

--- a/documentation_site/docs/api-reference/API/interfaces/PreviewOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/PreviewOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: PreviewOptions
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:235](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L235)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:235](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L235)
 
 Options for specifying a time range within an audio file.
 
@@ -20,7 +20,7 @@ Options for specifying a time range within an audio file.
 
 > `optional` **decodingOptions?**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:255](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L255)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:255](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L255)
 
 Optional configuration for decoding the audio file.
 Defaults to:
@@ -35,7 +35,7 @@ Defaults to:
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:165](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L165)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:165](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L165)
 
 End time in milliseconds
 
@@ -49,7 +49,7 @@ End time in milliseconds
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:237](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L237)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:237](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L237)
 
 URI of the audio file to analyze
 
@@ -59,7 +59,7 @@ URI of the audio file to analyze
 
 > `optional` **logger?**: [`ConsoleLike`](../type-aliases/ConsoleLike.md)
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:246](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L246)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:246](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L246)
 
 Optional logger for debugging.
 
@@ -69,7 +69,7 @@ Optional logger for debugging.
 
 > `optional` **numberOfPoints?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:242](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L242)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:242](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L242)
 
 Total number of points to generate for the preview.
 
@@ -85,7 +85,7 @@ Total number of points to generate for the preview.
 
 > `optional` **onPointReady?**: (`point`, `index`, `total`) => `void`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:262](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L262)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:262](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L262)
 
 Optional callback fired once per data point as the preview becomes available.
 Today the native module returns the full analysis in one shot; the points are then
@@ -116,7 +116,7 @@ Native progressive streaming is a future enhancement.
 
 > `optional` **signal?**: `AbortSignal`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:268](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L268)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:268](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L268)
 
 Optional cancellation signal for JS-side progressive point emission.
 Aborting does not cancel native extraction after it has started, but it
@@ -128,7 +128,7 @@ stops any queued `onPointReady` callbacks from an older request.
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:163](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L163)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:163](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L163)
 
 Start time in milliseconds
 

--- a/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: RecordingConfig
 
-Defined in: [src/AudioStudio.types.ts:410](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L410)
+Defined in: [src/AudioStudio.types.ts:412](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L412)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:410](https://github.com/deeeed/audiolab/bl
 
 > `optional` **android?**: [`AndroidConfig`](AndroidConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:470](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L470)
+Defined in: [src/AudioStudio.types.ts:472](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L472)
 
 Android-specific configuration
 
@@ -24,7 +24,7 @@ Android-specific configuration
 
 > `optional` **autoResumeAfterInterruption?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:499](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L499)
+Defined in: [src/AudioStudio.types.ts:501](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L501)
 
 Whether to automatically resume recording after an interruption (default is false)
 
@@ -34,13 +34,13 @@ Whether to automatically resume recording after an interruption (default is fals
 
 > `optional` **autoStopOnMaxDuration?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:518](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L518)
+Defined in: [src/AudioStudio.types.ts:521](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L521)
 
 Stop recording automatically when maxDurationMs is reached.
 
-Defaults to false. The MaxDurationReached event is emitted before the stop request.
-The automatic stop result is not returned to onMaxDurationReached; use the
-event and stream callbacks for immediate UI updates.
+Defaults to false. When used with `useAudioRecorder`, the
+MaxDurationReached event is emitted immediately, then the hook stops the
+recorder and exposes the final result through `onRecordingStopped`.
 
 ***
 
@@ -48,7 +48,7 @@ event and stream callbacks for immediate UI updates.
 
 > `optional` **bufferDurationSeconds?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:553](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L553)
+Defined in: [src/AudioStudio.types.ts:569](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L569)
 
 Buffer duration in seconds. Controls the size of audio buffers
 used during recording. Smaller values reduce latency but increase
@@ -69,7 +69,7 @@ Optimal iOS: >= 0.1 seconds
 
 > `optional` **channels?**: `1` \| `2`
 
-Defined in: [src/AudioStudio.types.ts:415](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L415)
+Defined in: [src/AudioStudio.types.ts:417](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L417)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -79,7 +79,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **deviceDisconnectionBehavior?**: [`DeviceDisconnectionBehaviorType`](../type-aliases/DeviceDisconnectionBehaviorType.md)
 
-Defined in: [src/AudioStudio.types.ts:537](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L537)
+Defined in: [src/AudioStudio.types.ts:553](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L553)
 
 How to handle device disconnection during recording
 
@@ -89,7 +89,7 @@ How to handle device disconnection during recording
 
 > `optional` **deviceId?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:534](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L534)
+Defined in: [src/AudioStudio.types.ts:550](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L550)
 
 ID of the device to use for recording (if not specified, uses default)
 
@@ -99,7 +99,7 @@ ID of the device to use for recording (if not specified, uses default)
 
 > `optional` **enableProcessing?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:453](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L453)
+Defined in: [src/AudioStudio.types.ts:455](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L455)
 
 Enable audio processing (default is false)
 
@@ -109,7 +109,7 @@ Enable audio processing (default is false)
 
 > `optional` **encoding?**: [`EncodingType`](../type-aliases/EncodingType.md)
 
-Defined in: [src/AudioStudio.types.ts:432](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L432)
+Defined in: [src/AudioStudio.types.ts:434](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L434)
 
 Encoding type for the recording.
 
@@ -138,7 +138,7 @@ platform capabilities. A warning will be logged if fallback is required.
 
 > `optional` **features?**: [`AudioFeaturesOptions`](AudioFeaturesOptions.md)
 
-Defined in: [src/AudioStudio.types.ts:479](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L479)
+Defined in: [src/AudioStudio.types.ts:481](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L481)
 
 Feature options to extract during audio processing
 
@@ -148,7 +148,7 @@ Feature options to extract during audio processing
 
 > `optional` **filename?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:531](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L531)
+Defined in: [src/AudioStudio.types.ts:547](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L547)
 
 Optional filename for the recording (uses UUID if not provided)
 
@@ -158,7 +158,7 @@ Optional filename for the recording (uses UUID if not provided)
 
 > `optional` **interval?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:435](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L435)
+Defined in: [src/AudioStudio.types.ts:437](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L437)
 
 Interval in milliseconds at which to emit recording data (minimum: 10ms)
 
@@ -168,7 +168,7 @@ Interval in milliseconds at which to emit recording data (minimum: 10ms)
 
 > `optional` **intervalAnalysis?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:438](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L438)
+Defined in: [src/AudioStudio.types.ts:440](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L440)
 
 Interval in milliseconds at which to emit analysis data (minimum: 10ms)
 
@@ -178,7 +178,7 @@ Interval in milliseconds at which to emit analysis data (minimum: 10ms)
 
 > `optional` **ios?**: [`IOSConfig`](IOSConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:467](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L467)
+Defined in: [src/AudioStudio.types.ts:469](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L469)
 
 iOS-specific configuration
 
@@ -188,7 +188,7 @@ iOS-specific configuration
 
 > `optional` **keepAwake?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:441](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L441)
+Defined in: [src/AudioStudio.types.ts:443](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L443)
 
 Keep the device awake while recording (default is false)
 
@@ -198,7 +198,7 @@ Keep the device awake while recording (default is false)
 
 > `optional` **keepFullAnalysis?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:464](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L464)
+Defined in: [src/AudioStudio.types.ts:466](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L466)
 
 Whether `useAudioRecorder` should retain every audio-analysis data point
 and attach the full history to `stopRecording().analysisData`.
@@ -214,7 +214,7 @@ growth in the hook without disabling native analysis processing.
 
 > `optional` **maxDurationMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:509](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L509)
+Defined in: [src/AudioStudio.types.ts:511](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L511)
 
 Maximum cumulative active recording duration, in milliseconds.
 
@@ -226,7 +226,7 @@ Paused time does not count. Set to undefined, 0, or a negative value to disable.
 
 > `optional` **notification?**: [`NotificationConfig`](NotificationConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:450](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L450)
+Defined in: [src/AudioStudio.types.ts:452](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L452)
 
 Configuration for the notification
 
@@ -236,7 +236,7 @@ Configuration for the notification
 
 > `optional` **onAudioAnalysis?**: (`_`) => `Promise`\<`void`\>
 
-Defined in: [src/AudioStudio.types.ts:485](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L485)
+Defined in: [src/AudioStudio.types.ts:487](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L487)
 
 Callback function to handle audio features extraction results
 
@@ -256,7 +256,7 @@ Callback function to handle audio features extraction results
 
 > `optional` **onAudioStream?**: (`_`) => `Promise`\<`void`\>
 
-Defined in: [src/AudioStudio.types.ts:482](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L482)
+Defined in: [src/AudioStudio.types.ts:484](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L484)
 
 Callback function to handle audio stream data
 
@@ -276,12 +276,13 @@ Callback function to handle audio stream data
 
 > `optional` **onMaxDurationReached?**: (`_`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:526](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L526)
+Defined in: [src/AudioStudio.types.ts:530](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L530)
 
 Optional callback invoked when maxDurationMs is reached.
 
-If autoStopOnMaxDuration is true, this callback is invoked before the
-recorder finishes stopping. The final stop result is not passed here.
+This remains an immediate threshold callback. If
+autoStopOnMaxDuration is true, use `onRecordingStopped` for the full
+recording result after stop completes.
 
 #### Parameters
 
@@ -299,7 +300,7 @@ recorder finishes stopping. The final stop result is not passed here.
 
 > `optional` **onRecordingInterrupted?**: (`_`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:502](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L502)
+Defined in: [src/AudioStudio.types.ts:504](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L504)
 
 Optional callback to handle recording interruptions
 
@@ -315,11 +316,39 @@ Optional callback to handle recording interruptions
 
 ***
 
+### onRecordingStopped?
+
+> `optional` **onRecordingStopped?**: (`recording`, `reason`) => `void` \| `Promise`\<`void`\>
+
+Defined in: [src/AudioStudio.types.ts:539](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L539)
+
+Optional callback invoked after a recording has fully stopped and the
+final `AudioRecording` result is available.
+
+The reason is `manual` when stopped through `stopRecording()` and
+`maxDuration` when stopped by `autoStopOnMaxDuration`.
+
+#### Parameters
+
+##### recording
+
+[`AudioRecording`](AudioRecording.md)
+
+##### reason
+
+[`RecordingStopReason`](../type-aliases/RecordingStopReason.md)
+
+#### Returns
+
+`void` \| `Promise`\<`void`\>
+
+***
+
 ### output?
 
 > `optional` **output?**: [`OutputConfig`](OutputConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:496](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L496)
+Defined in: [src/AudioStudio.types.ts:498](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L498)
 
 Configuration for audio output files
 
@@ -335,7 +364,7 @@ Examples:
 
 > `optional` **outputDirectory?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:529](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L529)
+Defined in: [src/AudioStudio.types.ts:545](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L545)
 
 Optional directory path where output files will be saved
 
@@ -345,7 +374,7 @@ Optional directory path where output files will be saved
 
 > `optional` **sampleRate?**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/AudioStudio.types.ts:412](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L412)
+Defined in: [src/AudioStudio.types.ts:414](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L414)
 
 Sample rate for recording in Hz (16000, 44100, or 48000)
 
@@ -355,7 +384,7 @@ Sample rate for recording in Hz (16000, 44100, or 48000)
 
 > `optional` **segmentDurationMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:476](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L476)
+Defined in: [src/AudioStudio.types.ts:478](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L478)
 
 Duration of each segment in milliseconds for analysis (default: 100)
 
@@ -365,7 +394,7 @@ Duration of each segment in milliseconds for analysis (default: 100)
 
 > `optional` **showNotification?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:444](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L444)
+Defined in: [src/AudioStudio.types.ts:446](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L446)
 
 Show a notification during recording (default is false)
 
@@ -375,7 +404,7 @@ Show a notification during recording (default is false)
 
 > `optional` **showWaveformInNotification?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:447](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L447)
+Defined in: [src/AudioStudio.types.ts:449](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L449)
 
 Show waveform in the notification (Android only, when showNotification is true)
 
@@ -385,7 +414,7 @@ Show waveform in the notification (Android only, when showNotification is true)
 
 > `optional` **streamFormat?**: `"float32"` \| `"raw"`
 
-Defined in: [src/AudioStudio.types.ts:566](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L566)
+Defined in: [src/AudioStudio.types.ts:582](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L582)
 
 Format for the audio stream data delivered to `onAudioStream`.
 
@@ -407,6 +436,6 @@ Format for the audio stream data delivered to `onAudioStream`.
 
 > `optional` **web?**: [`WebConfig`](WebConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:473](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L473)
+Defined in: [src/AudioStudio.types.ts:475](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L475)
 
 Web-specific configuration options

--- a/documentation_site/docs/api-reference/API/interfaces/RecordingInterruptionEvent.md
+++ b/documentation_site/docs/api-reference/API/interfaces/RecordingInterruptionEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: RecordingInterruptionEvent
 
-Defined in: [src/AudioStudio.types.ts:315](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L315)
+Defined in: [src/AudioStudio.types.ts:317](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L317)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:315](https://github.com/deeeed/audiolab/bl
 
 > **isPaused**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:319](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L319)
+Defined in: [src/AudioStudio.types.ts:321](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L321)
 
 Indicates whether the recording is paused due to the interruption
 
@@ -24,6 +24,6 @@ Indicates whether the recording is paused due to the interruption
 
 > **reason**: [`RecordingInterruptionReason`](../type-aliases/RecordingInterruptionReason.md)
 
-Defined in: [src/AudioStudio.types.ts:317](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L317)
+Defined in: [src/AudioStudio.types.ts:319](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L319)
 
 The reason for the recording interruption

--- a/documentation_site/docs/api-reference/API/interfaces/SpeechFeatures.md
+++ b/documentation_site/docs/api-reference/API/interfaces/SpeechFeatures.md
@@ -6,7 +6,7 @@
 
 # Interface: SpeechFeatures
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:28](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L28)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:28](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L28)
 
 Represents speech-related features extracted from audio.
 
@@ -16,7 +16,7 @@ Represents speech-related features extracted from audio.
 
 > **isActive**: `boolean`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:29](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L29)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:29](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L29)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:29](https://github.com/dee
 
 > `optional` **speakerId?**: `number`
 
-Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:30](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L30)
+Defined in: [src/AudioAnalysis/AudioAnalysis.types.ts:30](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/AudioAnalysis.types.ts#L30)

--- a/documentation_site/docs/api-reference/API/interfaces/StartRecordingResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StartRecordingResult.md
@@ -6,7 +6,7 @@
 
 # Interface: StartRecordingResult
 
-Defined in: [src/AudioStudio.types.ts:179](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L179)
+Defined in: [src/AudioStudio.types.ts:179](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L179)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:179](https://github.com/deeeed/audiolab/bl
 
 > `optional` **bitDepth?**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/AudioStudio.types.ts:187](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L187)
+Defined in: [src/AudioStudio.types.ts:187](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L187)
 
 Bit depth of the audio (8, 16, or 32 bits)
 
@@ -24,7 +24,7 @@ Bit depth of the audio (8, 16, or 32 bits)
 
 > `optional` **channels?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:185](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L185)
+Defined in: [src/AudioStudio.types.ts:185](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L185)
 
 Number of audio channels (1 for mono, 2 for stereo)
 
@@ -34,7 +34,7 @@ Number of audio channels (1 for mono, 2 for stereo)
 
 > `optional` **compression?**: [`CompressionInfo`](CompressionInfo.md) & `object`
 
-Defined in: [src/AudioStudio.types.ts:191](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L191)
+Defined in: [src/AudioStudio.types.ts:191](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L191)
 
 Information about compression if enabled, including the URI to the compressed file
 
@@ -52,7 +52,7 @@ URI to the compressed audio file
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:181](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L181)
+Defined in: [src/AudioStudio.types.ts:181](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L181)
 
 URI to the file being recorded
 
@@ -62,7 +62,7 @@ URI to the file being recorded
 
 > **mimeType**: `string`
 
-Defined in: [src/AudioStudio.types.ts:183](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L183)
+Defined in: [src/AudioStudio.types.ts:183](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L183)
 
 MIME type of the recording
 
@@ -72,6 +72,6 @@ MIME type of the recording
 
 > `optional` **sampleRate?**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/AudioStudio.types.ts:189](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L189)
+Defined in: [src/AudioStudio.types.ts:189](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L189)
 
 Sample rate of the audio in Hz

--- a/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataCallbacks.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataCallbacks.md
@@ -6,7 +6,7 @@
 
 # Interface: StreamAudioDataCallbacks
 
-Defined in: [src/streamAudioData.ts:97](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L97)
+Defined in: [src/streamAudioData.ts:97](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L97)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/streamAudioData.ts:97](https://github.com/deeeed/audiolab/blob/
 
 > **onChunk**: (`chunk`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [src/streamAudioData.ts:103](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L103)
+Defined in: [src/streamAudioData.ts:103](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L103)
 
 Called with each decoded chunk. If this returns a Promise, native decode
 pauses until it resolves (backpressure). Throwing aborts the stream with
@@ -36,7 +36,7 @@ pauses until it resolves (backpressure). Throwing aborts the stream with
 
 > `optional` **onProgress?**: (`progress`) => `void`
 
-Defined in: [src/streamAudioData.ts:105](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L105)
+Defined in: [src/streamAudioData.ts:105](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L105)
 
 Called whenever native reports progress.
 

--- a/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataChunk.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataChunk.md
@@ -6,7 +6,7 @@
 
 # Interface: StreamAudioDataChunk
 
-Defined in: [src/streamAudioData.ts:53](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L53)
+Defined in: [src/streamAudioData.ts:53](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L53)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/streamAudioData.ts:53](https://github.com/deeeed/audiolab/blob/
 
 > **channels**: `number`
 
-Defined in: [src/streamAudioData.ts:71](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L71)
+Defined in: [src/streamAudioData.ts:71](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L71)
 
 Output channel count.
 
@@ -24,7 +24,7 @@ Output channel count.
 
 > **chunkIndex**: `number`
 
-Defined in: [src/streamAudioData.ts:57](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L57)
+Defined in: [src/streamAudioData.ts:57](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L57)
 
 Zero-based monotonic chunk index.
 
@@ -34,7 +34,7 @@ Zero-based monotonic chunk index.
 
 > **durationMs**: `number`
 
-Defined in: [src/streamAudioData.ts:63](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L63)
+Defined in: [src/streamAudioData.ts:63](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L63)
 
 Duration in ms (`endTimeMs - startTimeMs`).
 
@@ -44,7 +44,7 @@ Duration in ms (`endTimeMs - startTimeMs`).
 
 > **endTimeMs**: `number`
 
-Defined in: [src/streamAudioData.ts:61](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L61)
+Defined in: [src/streamAudioData.ts:61](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L61)
 
 End time in output-rate ms.
 
@@ -54,7 +54,7 @@ End time in output-rate ms.
 
 > **isFinal**: `boolean`
 
-Defined in: [src/streamAudioData.ts:75](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L75)
+Defined in: [src/streamAudioData.ts:75](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L75)
 
 True for the last chunk of a non-cancelled run.
 
@@ -64,7 +64,7 @@ True for the last chunk of a non-cancelled run.
 
 > **requestId**: `string`
 
-Defined in: [src/streamAudioData.ts:55](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L55)
+Defined in: [src/streamAudioData.ts:55](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L55)
 
 Native request id; constant across all chunks of one call.
 
@@ -74,7 +74,7 @@ Native request id; constant across all chunks of one call.
 
 > **sampleCount**: `number`
 
-Defined in: [src/streamAudioData.ts:67](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L67)
+Defined in: [src/streamAudioData.ts:67](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L67)
 
 Sample count in `samples` (interleaved if channels > 1).
 
@@ -84,7 +84,7 @@ Sample count in `samples` (interleaved if channels > 1).
 
 > **sampleRate**: `number`
 
-Defined in: [src/streamAudioData.ts:69](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L69)
+Defined in: [src/streamAudioData.ts:69](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L69)
 
 Output sample rate.
 
@@ -94,7 +94,7 @@ Output sample rate.
 
 > **samples**: `Float32Array`
 
-Defined in: [src/streamAudioData.ts:73](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L73)
+Defined in: [src/streamAudioData.ts:73](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L73)
 
 Interleaved Float32 samples in [-1, 1].
 
@@ -104,7 +104,7 @@ Interleaved Float32 samples in [-1, 1].
 
 > **startSample**: `number`
 
-Defined in: [src/streamAudioData.ts:65](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L65)
+Defined in: [src/streamAudioData.ts:65](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L65)
 
 First sample index in the output timeline.
 
@@ -114,6 +114,6 @@ First sample index in the output timeline.
 
 > **startTimeMs**: `number`
 
-Defined in: [src/streamAudioData.ts:59](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L59)
+Defined in: [src/streamAudioData.ts:59](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L59)
 
 Start time in output-rate ms (rounded to nearest sample).

--- a/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: StreamAudioDataOptions
 
-Defined in: [src/streamAudioData.ts:18](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L18)
+Defined in: [src/streamAudioData.ts:18](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L18)
 
 High-level API: stream decoded audio from a stored file as bounded Float32
 chunks without materializing the full PCM range in memory.
@@ -19,7 +19,7 @@ See `docs/STREAM_AUDIO_DATA.md` for the full contract and rollout notes.
 
 > `optional` **backpressureTimeoutMs?**: `number`
 
-Defined in: [src/streamAudioData.ts:46](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L46)
+Defined in: [src/streamAudioData.ts:46](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L46)
 
 Optional timeout for a chunk acknowledgement while backpressure is active.
 Undefined/0 disables timeout so long transcription callbacks can run.
@@ -30,7 +30,7 @@ Undefined/0 disables timeout so long transcription callbacks can run.
 
 > `optional` **channels?**: `number`
 
-Defined in: [src/streamAudioData.ts:33](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L33)
+Defined in: [src/streamAudioData.ts:33](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L33)
 
 Output channel count (1 = mono downmix, 2 = stereo passthrough).
 
@@ -40,7 +40,7 @@ Output channel count (1 = mono downmix, 2 = stereo passthrough).
 
 > `optional` **chunkDurationMs?**: `number`
 
-Defined in: [src/streamAudioData.ts:37](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L37)
+Defined in: [src/streamAudioData.ts:37](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L37)
 
 Target chunk duration in ms (default: 1000, min: 10, max: 60000).
 
@@ -50,7 +50,7 @@ Target chunk duration in ms (default: 1000, min: 10, max: 60000).
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/streamAudioData.ts:24](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L24)
+Defined in: [src/streamAudioData.ts:24](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L24)
 
 End time in milliseconds (default: end-of-file).
 
@@ -60,7 +60,7 @@ End time in milliseconds (default: end-of-file).
 
 > **fileUri**: `string`
 
-Defined in: [src/streamAudioData.ts:20](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L20)
+Defined in: [src/streamAudioData.ts:20](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L20)
 
 URI of the audio file to decode.
 
@@ -70,7 +70,7 @@ URI of the audio file to decode.
 
 > `optional` **maxBufferedChunks?**: `number`
 
-Defined in: [src/streamAudioData.ts:41](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L41)
+Defined in: [src/streamAudioData.ts:41](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L41)
 
 Max chunks queued in native before JS ack pauses decode (default: 4).
 
@@ -80,7 +80,7 @@ Max chunks queued in native before JS ack pauses decode (default: 4).
 
 > `optional` **maxChunkBytes?**: `number`
 
-Defined in: [src/streamAudioData.ts:39](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L39)
+Defined in: [src/streamAudioData.ts:39](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L39)
 
 Soft cap on chunk size in bytes (Float32 = 4 bytes/sample).
 
@@ -90,7 +90,7 @@ Soft cap on chunk size in bytes (Float32 = 4 bytes/sample).
 
 > `optional` **normalizeAudio?**: `boolean`
 
-Defined in: [src/streamAudioData.ts:35](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L35)
+Defined in: [src/streamAudioData.ts:35](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L35)
 
 Clamp samples to [-1, 1] and replace non-finite values with 0.
 
@@ -100,7 +100,7 @@ Clamp samples to [-1, 1] and replace non-finite values with 0.
 
 > `optional` **sampleRate?**: `number`
 
-Defined in: [src/streamAudioData.ts:29](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L29)
+Defined in: [src/streamAudioData.ts:29](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L29)
 
 Source sample rate hint. Ignored if `targetSampleRate` is set; native
 decoders read the actual rate from the file.
@@ -111,7 +111,7 @@ decoders read the actual rate from the file.
 
 > `optional` **signal?**: `AbortSignal`
 
-Defined in: [src/streamAudioData.ts:50](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L50)
+Defined in: [src/streamAudioData.ts:50](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L50)
 
 Abort the in-flight request. Resolves promise with `cancelled: true`.
 
@@ -121,7 +121,7 @@ Abort the in-flight request. Resolves promise with `cancelled: true`.
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/streamAudioData.ts:22](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L22)
+Defined in: [src/streamAudioData.ts:22](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L22)
 
 Start time in milliseconds (default: 0).
 
@@ -131,7 +131,7 @@ Start time in milliseconds (default: 0).
 
 > `optional` **streamFormat?**: `"float32"`
 
-Defined in: [src/streamAudioData.ts:48](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L48)
+Defined in: [src/streamAudioData.ts:48](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L48)
 
 Output PCM format; only `'float32'` supported today.
 
@@ -141,6 +141,6 @@ Output PCM format; only `'float32'` supported today.
 
 > `optional` **targetSampleRate?**: `number`
 
-Defined in: [src/streamAudioData.ts:31](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L31)
+Defined in: [src/streamAudioData.ts:31](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L31)
 
 Output sample rate. Native resamples when this differs from the file.

--- a/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataProgress.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataProgress.md
@@ -6,7 +6,7 @@
 
 # Interface: StreamAudioDataProgress
 
-Defined in: [src/streamAudioData.ts:78](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L78)
+Defined in: [src/streamAudioData.ts:78](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L78)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/streamAudioData.ts:78](https://github.com/deeeed/audiolab/blob/
 
 > `optional` **bufferedChunks?**: `number`
 
-Defined in: [src/streamAudioData.ts:84](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L84)
+Defined in: [src/streamAudioData.ts:84](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L84)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/streamAudioData.ts:84](https://github.com/deeeed/audiolab/blob/
 
 > **durationMs**: `number`
 
-Defined in: [src/streamAudioData.ts:81](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L81)
+Defined in: [src/streamAudioData.ts:81](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L81)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [src/streamAudioData.ts:81](https://github.com/deeeed/audiolab/blob/
 
 > **emittedChunks**: `number`
 
-Defined in: [src/streamAudioData.ts:83](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L83)
+Defined in: [src/streamAudioData.ts:83](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L83)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/streamAudioData.ts:83](https://github.com/deeeed/audiolab/blob/
 
 > **processedMs**: `number`
 
-Defined in: [src/streamAudioData.ts:80](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L80)
+Defined in: [src/streamAudioData.ts:80](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L80)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [src/streamAudioData.ts:80](https://github.com/deeeed/audiolab/blob/
 
 > **progress**: `number`
 
-Defined in: [src/streamAudioData.ts:82](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L82)
+Defined in: [src/streamAudioData.ts:82](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L82)
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: [src/streamAudioData.ts:82](https://github.com/deeeed/audiolab/blob/
 
 > **requestId**: `string`
 
-Defined in: [src/streamAudioData.ts:79](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L79)
+Defined in: [src/streamAudioData.ts:79](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L79)

--- a/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/StreamAudioDataResult.md
@@ -6,7 +6,7 @@
 
 # Interface: StreamAudioDataResult
 
-Defined in: [src/streamAudioData.ts:87](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L87)
+Defined in: [src/streamAudioData.ts:87](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L87)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/streamAudioData.ts:87](https://github.com/deeeed/audiolab/blob/
 
 > **cancelled**: `boolean`
 
-Defined in: [src/streamAudioData.ts:94](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L94)
+Defined in: [src/streamAudioData.ts:94](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L94)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/streamAudioData.ts:94](https://github.com/deeeed/audiolab/blob/
 
 > **channels**: `number`
 
-Defined in: [src/streamAudioData.ts:91](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L91)
+Defined in: [src/streamAudioData.ts:91](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L91)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [src/streamAudioData.ts:91](https://github.com/deeeed/audiolab/blob/
 
 > **chunks**: `number`
 
-Defined in: [src/streamAudioData.ts:92](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L92)
+Defined in: [src/streamAudioData.ts:92](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L92)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/streamAudioData.ts:92](https://github.com/deeeed/audiolab/blob/
 
 > **durationMs**: `number`
 
-Defined in: [src/streamAudioData.ts:89](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L89)
+Defined in: [src/streamAudioData.ts:89](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L89)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [src/streamAudioData.ts:89](https://github.com/deeeed/audiolab/blob/
 
 > **requestId**: `string`
 
-Defined in: [src/streamAudioData.ts:88](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L88)
+Defined in: [src/streamAudioData.ts:88](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L88)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/streamAudioData.ts:88](https://github.com/deeeed/audiolab/blob/
 
 > **sampleRate**: `number`
 
-Defined in: [src/streamAudioData.ts:90](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L90)
+Defined in: [src/streamAudioData.ts:90](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L90)
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: [src/streamAudioData.ts:90](https://github.com/deeeed/audiolab/blob/
 
 > **samples**: `number`
 
-Defined in: [src/streamAudioData.ts:93](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/streamAudioData.ts#L93)
+Defined in: [src/streamAudioData.ts:93](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/streamAudioData.ts#L93)

--- a/documentation_site/docs/api-reference/API/interfaces/TimeRange.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TimeRange.md
@@ -6,7 +6,7 @@
 
 # Interface: TimeRange
 
-Defined in: [src/AudioStudio.types.ts:789](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L789)
+Defined in: [src/AudioStudio.types.ts:814](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L814)
 
 Defines a time range in milliseconds for trimming operations.
 
@@ -16,7 +16,7 @@ Defines a time range in milliseconds for trimming operations.
 
 > **endTimeMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:798](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L798)
+Defined in: [src/AudioStudio.types.ts:823](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L823)
 
 The end time of the range in milliseconds.
 
@@ -26,6 +26,6 @@ The end time of the range in milliseconds.
 
 > **startTimeMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:793](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L793)
+Defined in: [src/AudioStudio.types.ts:818](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L818)
 
 The start time of the range in milliseconds.

--- a/documentation_site/docs/api-reference/API/interfaces/TranscriberData.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TranscriberData.md
@@ -6,7 +6,7 @@
 
 # Interface: TranscriberData
 
-Defined in: [src/AudioStudio.types.ts:131](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L131)
+Defined in: [src/AudioStudio.types.ts:131](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L131)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:131](https://github.com/deeeed/audiolab/bl
 
 > **chunks**: [`Chunk`](Chunk.md)[]
 
-Defined in: [src/AudioStudio.types.ts:143](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L143)
+Defined in: [src/AudioStudio.types.ts:143](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L143)
 
 Array of transcribed text chunks with timestamps
 
@@ -24,7 +24,7 @@ Array of transcribed text chunks with timestamps
 
 > **endTime**: `number`
 
-Defined in: [src/AudioStudio.types.ts:141](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L141)
+Defined in: [src/AudioStudio.types.ts:141](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L141)
 
 End time of the transcription in milliseconds
 
@@ -34,7 +34,7 @@ End time of the transcription in milliseconds
 
 > **id**: `string`
 
-Defined in: [src/AudioStudio.types.ts:133](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L133)
+Defined in: [src/AudioStudio.types.ts:133](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L133)
 
 Unique identifier for the transcription
 
@@ -44,7 +44,7 @@ Unique identifier for the transcription
 
 > **isBusy**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:135](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L135)
+Defined in: [src/AudioStudio.types.ts:135](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L135)
 
 Indicates if the transcriber is currently processing
 
@@ -54,7 +54,7 @@ Indicates if the transcriber is currently processing
 
 > **startTime**: `number`
 
-Defined in: [src/AudioStudio.types.ts:139](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L139)
+Defined in: [src/AudioStudio.types.ts:139](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L139)
 
 Start time of the transcription in milliseconds
 
@@ -64,6 +64,6 @@ Start time of the transcription in milliseconds
 
 > **text**: `string`
 
-Defined in: [src/AudioStudio.types.ts:137](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L137)
+Defined in: [src/AudioStudio.types.ts:137](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L137)
 
 Complete transcribed text

--- a/documentation_site/docs/api-reference/API/interfaces/TrimAudioOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TrimAudioOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: TrimAudioOptions
 
-Defined in: [src/AudioStudio.types.ts:804](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L804)
+Defined in: [src/AudioStudio.types.ts:829](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L829)
 
 Options for configuring the audio trimming operation.
 
@@ -16,7 +16,7 @@ Options for configuring the audio trimming operation.
 
 > `optional` **decodingOptions?**: [`DecodingConfig`](DecodingConfig.md)
 
-Defined in: [src/AudioStudio.types.ts:884](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L884)
+Defined in: [src/AudioStudio.types.ts:909](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L909)
 
 Options for decoding the input audio file.
 - See `DecodingConfig` for details.
@@ -27,7 +27,7 @@ Options for decoding the input audio file.
 
 > `optional` **endTimeMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:836](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L836)
+Defined in: [src/AudioStudio.types.ts:861](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L861)
 
 The end time in milliseconds for the `'single'` mode.
 - If not provided, trimming extends to the end of the audio.
@@ -38,7 +38,7 @@ The end time in milliseconds for the `'single'` mode.
 
 > **fileUri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:808](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L808)
+Defined in: [src/AudioStudio.types.ts:833](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L833)
 
 The URI of the audio file to trim.
 
@@ -48,7 +48,7 @@ The URI of the audio file to trim.
 
 > `optional` **mode?**: `"single"` \| `"keep"` \| `"remove"`
 
-Defined in: [src/AudioStudio.types.ts:817](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L817)
+Defined in: [src/AudioStudio.types.ts:842](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L842)
 
 The mode of trimming to apply.
 - `'single'`: Trims the audio to a single range defined by `startTimeMs` and `endTimeMs`.
@@ -67,7 +67,7 @@ The mode of trimming to apply.
 
 > `optional` **outputFileName?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:841](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L841)
+Defined in: [src/AudioStudio.types.ts:866](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L866)
 
 The name of the output file. If not provided, a default name will be generated.
 
@@ -77,7 +77,7 @@ The name of the output file. If not provided, a default name will be generated.
 
 > `optional` **outputFormat?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:846](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L846)
+Defined in: [src/AudioStudio.types.ts:871](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L871)
 
 Configuration for the output audio format.
 
@@ -124,7 +124,7 @@ The sample rate of the output audio in Hertz (Hz).
 
 > `optional` **ranges?**: [`TimeRange`](TimeRange.md)[]
 
-Defined in: [src/AudioStudio.types.ts:824](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L824)
+Defined in: [src/AudioStudio.types.ts:849](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L849)
 
 An array of time ranges to keep or remove, depending on the `mode`.
 - Required for `'keep'` and `'remove'` modes.
@@ -136,7 +136,7 @@ An array of time ranges to keep or remove, depending on the `mode`.
 
 > `optional` **startTimeMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:830](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L830)
+Defined in: [src/AudioStudio.types.ts:855](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L855)
 
 The start time in milliseconds for the `'single'` mode.
 - If not provided, trimming starts from the beginning of the audio (0 ms).

--- a/documentation_site/docs/api-reference/API/interfaces/TrimAudioResult.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TrimAudioResult.md
@@ -6,7 +6,7 @@
 
 # Interface: TrimAudioResult
 
-Defined in: [src/AudioStudio.types.ts:890](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L890)
+Defined in: [src/AudioStudio.types.ts:915](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L915)
 
 Result of the audio trimming operation.
 
@@ -16,7 +16,7 @@ Result of the audio trimming operation.
 
 > **bitDepth**: `number`
 
-Defined in: [src/AudioStudio.types.ts:924](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L924)
+Defined in: [src/AudioStudio.types.ts:949](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L949)
 
 The bit depth of the trimmed audio, applicable to PCM formats like `'wav'`.
 
@@ -26,7 +26,7 @@ The bit depth of the trimmed audio, applicable to PCM formats like `'wav'`.
 
 > **channels**: `number`
 
-Defined in: [src/AudioStudio.types.ts:919](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L919)
+Defined in: [src/AudioStudio.types.ts:944](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L944)
 
 The number of channels in the trimmed audio (e.g., 1 for mono, 2 for stereo).
 
@@ -36,7 +36,7 @@ The number of channels in the trimmed audio (e.g., 1 for mono, 2 for stereo).
 
 > `optional` **compression?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:934](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L934)
+Defined in: [src/AudioStudio.types.ts:959](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L959)
 
 Information about compression if the output format is compressed.
 
@@ -64,7 +64,7 @@ The size of the compressed audio file in bytes.
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:904](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L904)
+Defined in: [src/AudioStudio.types.ts:929](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L929)
 
 The duration of the trimmed audio in milliseconds.
 
@@ -74,7 +74,7 @@ The duration of the trimmed audio in milliseconds.
 
 > **filename**: `string`
 
-Defined in: [src/AudioStudio.types.ts:899](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L899)
+Defined in: [src/AudioStudio.types.ts:924](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L924)
 
 The filename of the trimmed audio file.
 
@@ -84,7 +84,7 @@ The filename of the trimmed audio file.
 
 > **mimeType**: `string`
 
-Defined in: [src/AudioStudio.types.ts:929](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L929)
+Defined in: [src/AudioStudio.types.ts:954](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L954)
 
 The MIME type of the trimmed audio file (e.g., `'audio/wav'`, `'audio/mpeg'`).
 
@@ -94,7 +94,7 @@ The MIME type of the trimmed audio file (e.g., `'audio/wav'`, `'audio/mpeg'`).
 
 > `optional` **processingInfo?**: `object`
 
-Defined in: [src/AudioStudio.types.ts:954](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L954)
+Defined in: [src/AudioStudio.types.ts:979](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L979)
 
 Information about the processing time.
 
@@ -110,7 +110,7 @@ The time it took to process the audio in milliseconds.
 
 > **sampleRate**: `number`
 
-Defined in: [src/AudioStudio.types.ts:914](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L914)
+Defined in: [src/AudioStudio.types.ts:939](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L939)
 
 The sample rate of the trimmed audio in Hertz (Hz).
 
@@ -120,7 +120,7 @@ The sample rate of the trimmed audio in Hertz (Hz).
 
 > **size**: `number`
 
-Defined in: [src/AudioStudio.types.ts:909](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L909)
+Defined in: [src/AudioStudio.types.ts:934](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L934)
 
 The size of the trimmed audio file in bytes.
 
@@ -130,6 +130,6 @@ The size of the trimmed audio file in bytes.
 
 > **uri**: `string`
 
-Defined in: [src/AudioStudio.types.ts:894](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L894)
+Defined in: [src/AudioStudio.types.ts:919](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L919)
 
 The URI of the trimmed audio file.

--- a/documentation_site/docs/api-reference/API/interfaces/TrimProgressEvent.md
+++ b/documentation_site/docs/api-reference/API/interfaces/TrimProgressEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: TrimProgressEvent
 
-Defined in: [src/AudioStudio.types.ts:769](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L769)
+Defined in: [src/AudioStudio.types.ts:794](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L794)
 
 Represents an event emitted during the trimming process to report progress.
 
@@ -16,7 +16,7 @@ Represents an event emitted during the trimming process to report progress.
 
 > `optional` **bytesProcessed?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:778](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L778)
+Defined in: [src/AudioStudio.types.ts:803](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L803)
 
 The number of bytes that have been processed so far. This is optional and may not be provided in all implementations.
 
@@ -26,7 +26,7 @@ The number of bytes that have been processed so far. This is optional and may no
 
 > **progress**: `number`
 
-Defined in: [src/AudioStudio.types.ts:773](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L773)
+Defined in: [src/AudioStudio.types.ts:798](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L798)
 
 The percentage of the trimming process that has been completed, ranging from 0 to 100.
 
@@ -36,6 +36,6 @@ The percentage of the trimming process that has been completed, ranging from 0 t
 
 > `optional` **totalBytes?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:783](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L783)
+Defined in: [src/AudioStudio.types.ts:808](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L808)
 
 The total number of bytes to process. This is optional and may not be provided in all implementations.

--- a/documentation_site/docs/api-reference/API/interfaces/UseAudioRecorderState.md
+++ b/documentation_site/docs/api-reference/API/interfaces/UseAudioRecorderState.md
@@ -6,7 +6,7 @@
 
 # Interface: UseAudioRecorderState
 
-Defined in: [src/AudioStudio.types.ts:695](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L695)
+Defined in: [src/AudioStudio.types.ts:711](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L711)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:695](https://github.com/deeeed/audiolab/bl
 
 > `optional` **analysisData?**: [`AudioAnalysis`](AudioAnalysis.md)
 
-Defined in: [src/AudioStudio.types.ts:759](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L759)
+Defined in: [src/AudioStudio.types.ts:775](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L775)
 
 Analysis data for the recording if processing was enabled
 
@@ -24,7 +24,7 @@ Analysis data for the recording if processing was enabled
 
 > `optional` **compression?**: [`CompressionInfo`](CompressionInfo.md)
 
-Defined in: [src/AudioStudio.types.ts:753](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L753)
+Defined in: [src/AudioStudio.types.ts:769](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L769)
 
 Information about compression if enabled
 
@@ -34,7 +34,7 @@ Information about compression if enabled
 
 > **durationMs**: `number`
 
-Defined in: [src/AudioStudio.types.ts:749](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L749)
+Defined in: [src/AudioStudio.types.ts:765](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L765)
 
 Duration of the current recording in milliseconds
 
@@ -44,7 +44,7 @@ Duration of the current recording in milliseconds
 
 > **isPaused**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:747](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L747)
+Defined in: [src/AudioStudio.types.ts:763](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L763)
 
 Indicates whether recording is in a paused state
 
@@ -54,9 +54,19 @@ Indicates whether recording is in a paused state
 
 > **isRecording**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:745](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L745)
+Defined in: [src/AudioStudio.types.ts:761](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L761)
 
 Indicates whether recording is currently active
+
+***
+
+### lastRecordingReason?
+
+> `optional` **lastRecordingReason?**: [`RecordingStopReason`](../type-aliases/RecordingStopReason.md)
+
+Defined in: [src/AudioStudio.types.ts:779](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L779)
+
+Reason associated with the last completed recording
 
 ***
 
@@ -64,7 +74,7 @@ Indicates whether recording is currently active
 
 > `optional` **maxDurationMs?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:755](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L755)
+Defined in: [src/AudioStudio.types.ts:771](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L771)
 
 Configured maximum active recording duration in milliseconds, if enabled
 
@@ -74,7 +84,7 @@ Configured maximum active recording duration in milliseconds, if enabled
 
 > `optional` **maxDurationReached?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:757](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L757)
+Defined in: [src/AudioStudio.types.ts:773](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L773)
 
 Whether the current recording session has reached the configured maximum duration
 
@@ -84,7 +94,7 @@ Whether the current recording session has reached the configured maximum duratio
 
 > `optional` **onMaxDurationReached?**: (`_`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:763](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L763)
+Defined in: [src/AudioStudio.types.ts:783](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L783)
 
 Optional callback invoked when maxDurationMs is reached
 
@@ -104,7 +114,7 @@ Optional callback invoked when maxDurationMs is reached
 
 > `optional` **onRecordingInterrupted?**: (`_`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:761](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L761)
+Defined in: [src/AudioStudio.types.ts:781](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L781)
 
 Optional callback to handle recording interruptions
 
@@ -120,11 +130,35 @@ Optional callback to handle recording interruptions
 
 ***
 
+### onRecordingStopped?
+
+> `optional` **onRecordingStopped?**: (`recording`, `reason`) => `void` \| `Promise`\<`void`\>
+
+Defined in: [src/AudioStudio.types.ts:785](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L785)
+
+Optional callback invoked when a recording fully stops
+
+#### Parameters
+
+##### recording
+
+[`AudioRecording`](AudioRecording.md)
+
+##### reason
+
+[`RecordingStopReason`](../type-aliases/RecordingStopReason.md)
+
+#### Returns
+
+`void` \| `Promise`\<`void`\>
+
+***
+
 ### pauseRecording
 
 > **pauseRecording**: () => `Promise`\<`void`\>
 
-Defined in: [src/AudioStudio.types.ts:741](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L741)
+Defined in: [src/AudioStudio.types.ts:757](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L757)
 
 Pauses the current recording
 
@@ -138,7 +172,7 @@ Pauses the current recording
 
 > **prepareRecording**: (`_`) => `Promise`\<`void`\>
 
-Defined in: [src/AudioStudio.types.ts:735](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L735)
+Defined in: [src/AudioStudio.types.ts:751](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L751)
 
 Prepares recording with the specified configuration without starting it.
 
@@ -196,7 +230,7 @@ const handleRecordPress = () => startRecording({
 
 > **resumeRecording**: () => `Promise`\<`void`\>
 
-Defined in: [src/AudioStudio.types.ts:743](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L743)
+Defined in: [src/AudioStudio.types.ts:759](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L759)
 
 Resumes a paused recording
 
@@ -210,7 +244,7 @@ Resumes a paused recording
 
 > **size**: `number`
 
-Defined in: [src/AudioStudio.types.ts:751](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L751)
+Defined in: [src/AudioStudio.types.ts:767](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L767)
 
 Size of the recorded audio in bytes
 
@@ -220,7 +254,7 @@ Size of the recorded audio in bytes
 
 > **startRecording**: (`_`) => `Promise`\<[`StartRecordingResult`](StartRecordingResult.md)\>
 
-Defined in: [src/AudioStudio.types.ts:737](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L737)
+Defined in: [src/AudioStudio.types.ts:753](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L753)
 
 Starts recording with the specified configuration
 
@@ -240,7 +274,7 @@ Starts recording with the specified configuration
 
 > **stopRecording**: () => `Promise`\<[`AudioRecording`](AudioRecording.md) \| `null`\>
 
-Defined in: [src/AudioStudio.types.ts:739](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L739)
+Defined in: [src/AudioStudio.types.ts:755](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L755)
 
 Stops the current recording and returns the recording data
 

--- a/documentation_site/docs/api-reference/API/interfaces/WavFileInfo.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WavFileInfo.md
@@ -6,7 +6,7 @@
 
 # Interface: WavFileInfo
 
-Defined in: [src/utils/getWavFileInfo.ts:26](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L26)
+Defined in: [src/utils/getWavFileInfo.ts:26](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L26)
 
 Interface representing the metadata of a WAV file.
 
@@ -16,7 +16,7 @@ Interface representing the metadata of a WAV file.
 
 > **audioFormatDescription**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:32](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L32)
+Defined in: [src/utils/getWavFileInfo.ts:32](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L32)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/utils/getWavFileInfo.ts:32](https://github.com/deeeed/audiolab/
 
 > **bitDepth**: [`BitDepth`](../type-aliases/BitDepth.md)
 
-Defined in: [src/utils/getWavFileInfo.ts:29](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L29)
+Defined in: [src/utils/getWavFileInfo.ts:29](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L29)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/utils/getWavFileInfo.ts:29](https://github.com/deeeed/audiolab/
 
 > **blockAlign**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:34](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L34)
+Defined in: [src/utils/getWavFileInfo.ts:34](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L34)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [src/utils/getWavFileInfo.ts:34](https://github.com/deeeed/audiolab/
 
 > **byteRate**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:33](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L33)
+Defined in: [src/utils/getWavFileInfo.ts:33](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L33)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/utils/getWavFileInfo.ts:33](https://github.com/deeeed/audiolab/
 
 > `optional` **comments?**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:36](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L36)
+Defined in: [src/utils/getWavFileInfo.ts:36](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L36)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [src/utils/getWavFileInfo.ts:36](https://github.com/deeeed/audiolab/
 
 > `optional` **compressionType?**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:37](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L37)
+Defined in: [src/utils/getWavFileInfo.ts:37](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L37)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/utils/getWavFileInfo.ts:37](https://github.com/deeeed/audiolab/
 
 > `optional` **creationDateTime?**: `string`
 
-Defined in: [src/utils/getWavFileInfo.ts:35](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L35)
+Defined in: [src/utils/getWavFileInfo.ts:35](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/utils/getWavFileInfo.ts:35](https://github.com/deeeed/audiolab/
 
 > **dataChunkOffset**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:38](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L38)
+Defined in: [src/utils/getWavFileInfo.ts:38](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L38)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/utils/getWavFileInfo.ts:38](https://github.com/deeeed/audiolab/
 
 > **durationMs**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:31](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L31)
+Defined in: [src/utils/getWavFileInfo.ts:31](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L31)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/utils/getWavFileInfo.ts:31](https://github.com/deeeed/audiolab/
 
 > **numChannels**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:28](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L28)
+Defined in: [src/utils/getWavFileInfo.ts:28](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L28)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/utils/getWavFileInfo.ts:28](https://github.com/deeeed/audiolab/
 
 > **sampleRate**: [`SampleRate`](../type-aliases/SampleRate.md)
 
-Defined in: [src/utils/getWavFileInfo.ts:27](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L27)
+Defined in: [src/utils/getWavFileInfo.ts:27](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L27)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [src/utils/getWavFileInfo.ts:27](https://github.com/deeeed/audiolab/
 
 > **size**: `number`
 
-Defined in: [src/utils/getWavFileInfo.ts:30](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/getWavFileInfo.ts#L30)
+Defined in: [src/utils/getWavFileInfo.ts:30](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/getWavFileInfo.ts#L30)

--- a/documentation_site/docs/api-reference/API/interfaces/WavHeaderOptions.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WavHeaderOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: WavHeaderOptions
 
-Defined in: [src/utils/writeWavHeader.ts:6](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L6)
+Defined in: [src/utils/writeWavHeader.ts:6](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L6)
 
 Options for creating a WAV header.
 
@@ -16,7 +16,7 @@ Options for creating a WAV header.
 
 > **bitDepth**: `number`
 
-Defined in: [src/utils/writeWavHeader.ts:14](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L14)
+Defined in: [src/utils/writeWavHeader.ts:14](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L14)
 
 The bit depth of the audio (e.g., 16, 24, or 32).
 
@@ -26,7 +26,7 @@ The bit depth of the audio (e.g., 16, 24, or 32).
 
 > `optional` **buffer?**: `ArrayBuffer`
 
-Defined in: [src/utils/writeWavHeader.ts:8](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L8)
+Defined in: [src/utils/writeWavHeader.ts:8](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L8)
 
 Optional buffer containing audio data. If provided, it will be combined with the header.
 
@@ -36,7 +36,7 @@ Optional buffer containing audio data. If provided, it will be combined with the
 
 > `optional` **isFloat?**: `boolean`
 
-Defined in: [src/utils/writeWavHeader.ts:16](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L16)
+Defined in: [src/utils/writeWavHeader.ts:16](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L16)
 
 Whether the audio data is in float format (only applies to 32-bit)
 
@@ -46,7 +46,7 @@ Whether the audio data is in float format (only applies to 32-bit)
 
 > **numChannels**: `number`
 
-Defined in: [src/utils/writeWavHeader.ts:12](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L12)
+Defined in: [src/utils/writeWavHeader.ts:12](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L12)
 
 The number of audio channels (e.g., 1 for mono, 2 for stereo).
 
@@ -56,6 +56,6 @@ The number of audio channels (e.g., 1 for mono, 2 for stereo).
 
 > **sampleRate**: `number`
 
-Defined in: [src/utils/writeWavHeader.ts:10](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/writeWavHeader.ts#L10)
+Defined in: [src/utils/writeWavHeader.ts:10](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/writeWavHeader.ts#L10)
 
 The sample rate of the audio in Hz (e.g., 44100).

--- a/documentation_site/docs/api-reference/API/interfaces/WaveformConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WaveformConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: WaveformConfig
 
-Defined in: [src/AudioStudio.types.ts:630](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L630)
+Defined in: [src/AudioStudio.types.ts:646](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L646)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/AudioStudio.types.ts:630](https://github.com/deeeed/audiolab/bl
 
 > `optional` **color?**: `string`
 
-Defined in: [src/AudioStudio.types.ts:632](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L632)
+Defined in: [src/AudioStudio.types.ts:648](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L648)
 
 The color of the waveform (e.g., "#FFFFFF" for white)
 
@@ -24,7 +24,7 @@ The color of the waveform (e.g., "#FFFFFF" for white)
 
 > `optional` **height?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:642](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L642)
+Defined in: [src/AudioStudio.types.ts:658](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L658)
 
 Height of the waveform view in dp (default: 64)
 
@@ -34,7 +34,7 @@ Height of the waveform view in dp (default: 64)
 
 > `optional` **mirror?**: `boolean`
 
-Defined in: [src/AudioStudio.types.ts:640](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L640)
+Defined in: [src/AudioStudio.types.ts:656](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L656)
 
 Whether to mirror the waveform (symmetrical display)
 
@@ -44,7 +44,7 @@ Whether to mirror the waveform (symmetrical display)
 
 > `optional` **opacity?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:634](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L634)
+Defined in: [src/AudioStudio.types.ts:650](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L650)
 
 Opacity of the waveform (0.0 - 1.0)
 
@@ -54,7 +54,7 @@ Opacity of the waveform (0.0 - 1.0)
 
 > `optional` **strokeWidth?**: `number`
 
-Defined in: [src/AudioStudio.types.ts:636](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L636)
+Defined in: [src/AudioStudio.types.ts:652](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L652)
 
 Width of the waveform line (default: 1.5)
 
@@ -64,6 +64,6 @@ Width of the waveform line (default: 1.5)
 
 > `optional` **style?**: `"fill"` \| `"stroke"`
 
-Defined in: [src/AudioStudio.types.ts:638](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L638)
+Defined in: [src/AudioStudio.types.ts:654](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L654)
 
 Drawing style: "stroke" for outline, "fill" for solid

--- a/documentation_site/docs/api-reference/API/interfaces/WebConfig.md
+++ b/documentation_site/docs/api-reference/API/interfaces/WebConfig.md
@@ -6,6 +6,6 @@
 
 # Interface: WebConfig
 
-Defined in: [src/AudioStudio.types.ts:289](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L289)
+Defined in: [src/AudioStudio.types.ts:291](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L291)
 
 Web platform specific configuration options

--- a/documentation_site/docs/api-reference/API/type-aliases/AudioDataEvent.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/AudioDataEvent.md
@@ -8,4 +8,4 @@
 
 > **AudioDataEvent** = [`AudioDataEventRaw`](../interfaces/AudioDataEventRaw.md) \| [`AudioDataEventFloat32`](../interfaces/AudioDataEventFloat32.md)
 
-Defined in: [src/AudioStudio.types.ts:73](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L73)
+Defined in: [src/AudioStudio.types.ts:73](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L73)

--- a/documentation_site/docs/api-reference/API/type-aliases/AudioExtractionErrorCode.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/AudioExtractionErrorCode.md
@@ -8,7 +8,7 @@
 
 > **AudioExtractionErrorCode** = `"unsupported_codec"` \| `"malformed_file"` \| `"decode_failed"` \| `"permission_denied"` \| `"file_not_found"` \| `"unknown"`
 
-Defined in: [src/errors/AudioExtractionError.ts:5](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioExtractionError.ts#L5)
+Defined in: [src/errors/AudioExtractionError.ts:5](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioExtractionError.ts#L5)
 
 Typed error class for audio extraction failures.
 Wraps native module errors with stable codes consumers can switch on.

--- a/documentation_site/docs/api-reference/API/type-aliases/AudioStreamErrorCode.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/AudioStreamErrorCode.md
@@ -8,6 +8,6 @@
 
 > **AudioStreamErrorCode** = `"ERR_AUDIO_STREAM_UNSUPPORTED_FORMAT"` \| `"ERR_AUDIO_STREAM_INVALID_RANGE"` \| `"ERR_AUDIO_STREAM_DECODE_FAILED"` \| `"ERR_AUDIO_STREAM_CANCELLED"` \| `"ERR_AUDIO_STREAM_PERMISSION_DENIED"` \| `"ERR_AUDIO_STREAM_FILE_NOT_FOUND"` \| `"ERR_AUDIO_STREAM_BACKPRESSURE_TIMEOUT"` \| `"ERR_AUDIO_STREAM_NATIVE_UNAVAILABLE"` \| `"ERR_AUDIO_STREAM_BUSY"` \| `"ERR_AUDIO_STREAM_UNKNOWN"`
 
-Defined in: [src/errors/AudioStreamError.ts:4](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/errors/AudioStreamError.ts#L4)
+Defined in: [src/errors/AudioStreamError.ts:4](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/errors/AudioStreamError.ts#L4)
 
 Stable typed errors for `streamAudioData`. Callers can switch on `code`.

--- a/documentation_site/docs/api-reference/API/type-aliases/BitDepth.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/BitDepth.md
@@ -8,7 +8,7 @@
 
 > **BitDepth** = `8` \| `16` \| `32`
 
-Defined in: [src/AudioStudio.types.ts:103](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L103)
+Defined in: [src/AudioStudio.types.ts:103](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L103)
 
 Audio bit depth (bits per sample).
 

--- a/documentation_site/docs/api-reference/API/type-aliases/ConsoleLike.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/ConsoleLike.md
@@ -8,7 +8,7 @@
 
 > **ConsoleLike** = `object`
 
-Defined in: [src/AudioStudio.types.ts:111](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L111)
+Defined in: [src/AudioStudio.types.ts:111](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L111)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [src/AudioStudio.types.ts:111](https://github.com/deeeed/audiolab/bl
 
 > **debug**: (`message`, ...`args`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:115](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L115)
+Defined in: [src/AudioStudio.types.ts:115](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L115)
 
 Logs a debug message with optional arguments
 
@@ -40,7 +40,7 @@ Logs a debug message with optional arguments
 
 > **error**: (`message`, ...`args`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:121](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L121)
+Defined in: [src/AudioStudio.types.ts:121](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L121)
 
 Logs an error message with optional arguments
 
@@ -64,7 +64,7 @@ Logs an error message with optional arguments
 
 > **info**: (`message`, ...`args`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:117](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L117)
+Defined in: [src/AudioStudio.types.ts:117](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L117)
 
 Logs an info message with optional arguments
 
@@ -88,7 +88,7 @@ Logs an info message with optional arguments
 
 > **log**: (`message`, ...`args`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:113](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L113)
+Defined in: [src/AudioStudio.types.ts:113](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L113)
 
 Logs a message with optional arguments
 
@@ -112,7 +112,7 @@ Logs a message with optional arguments
 
 > **warn**: (`message`, ...`args`) => `void`
 
-Defined in: [src/AudioStudio.types.ts:119](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L119)
+Defined in: [src/AudioStudio.types.ts:119](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L119)
 
 Logs a warning message with optional arguments
 

--- a/documentation_site/docs/api-reference/API/type-aliases/DeviceDisconnectionBehaviorType.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/DeviceDisconnectionBehaviorType.md
@@ -8,6 +8,6 @@
 
 > **DeviceDisconnectionBehaviorType** = *typeof* [`DeviceDisconnectionBehavior`](../variables/DeviceDisconnectionBehavior.md)\[keyof *typeof* [`DeviceDisconnectionBehavior`](../variables/DeviceDisconnectionBehavior.md)\]
 
-Defined in: [src/AudioStudio.types.ts:361](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L361)
+Defined in: [src/AudioStudio.types.ts:363](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L363)
 
 Type for DeviceDisconnectionBehavior values

--- a/documentation_site/docs/api-reference/API/type-aliases/EncodingType.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/EncodingType.md
@@ -8,7 +8,7 @@
 
 > **EncodingType** = `"pcm_32bit"` \| `"pcm_16bit"` \| `"pcm_8bit"`
 
-Defined in: [src/AudioStudio.types.ts:85](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L85)
+Defined in: [src/AudioStudio.types.ts:85](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L85)
 
 Audio encoding types supported by the library.
 

--- a/documentation_site/docs/api-reference/API/type-aliases/PCMFormat.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/PCMFormat.md
@@ -8,7 +8,7 @@
 
 > **PCMFormat** = `` `pcm_${BitDepth}bit` ``
 
-Defined in: [src/AudioStudio.types.ts:109](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L109)
+Defined in: [src/AudioStudio.types.ts:109](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L109)
 
 PCM format string representation.
 

--- a/documentation_site/docs/api-reference/API/type-aliases/RecordingInterruptionReason.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/RecordingInterruptionReason.md
@@ -8,4 +8,4 @@
 
 > **RecordingInterruptionReason** = `"audioFocusLoss"` \| `"audioFocusGain"` \| `"phoneCall"` \| `"phoneCallEnded"` \| `"recordingStopped"` \| `"deviceDisconnected"` \| `"deviceFallback"` \| `"deviceConnected"` \| `"deviceSwitchFailed"`
 
-Defined in: [src/AudioStudio.types.ts:294](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L294)
+Defined in: [src/AudioStudio.types.ts:296](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L296)

--- a/documentation_site/docs/api-reference/API/type-aliases/RecordingStopReason.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/RecordingStopReason.md
@@ -1,0 +1,11 @@
+[**@siteed/audio-studio**](../README.md)
+
+***
+
+[@siteed/audio-studio](../README.md) / RecordingStopReason
+
+# Type Alias: RecordingStopReason
+
+> **RecordingStopReason** = `"manual"` \| `"maxDuration"`
+
+Defined in: [src/AudioStudio.types.ts:210](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L210)

--- a/documentation_site/docs/api-reference/API/type-aliases/SampleRate.md
+++ b/documentation_site/docs/api-reference/API/type-aliases/SampleRate.md
@@ -8,7 +8,7 @@
 
 > **SampleRate** = `16000` \| `44100` \| `48000`
 
-Defined in: [src/AudioStudio.types.ts:91](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L91)
+Defined in: [src/AudioStudio.types.ts:91](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L91)
 
 Supported audio sample rates in Hz.
 All platforms support these standard rates.

--- a/documentation_site/docs/api-reference/API/variables/AudioRecorderProvider.md
+++ b/documentation_site/docs/api-reference/API/variables/AudioRecorderProvider.md
@@ -8,4 +8,4 @@
 
 > `const` **AudioRecorderProvider**: `React.FC`\<`AudioRecorderProviderProps`\>
 
-Defined in: [src/AudioRecorder.provider.tsx:37](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioRecorder.provider.tsx#L37)
+Defined in: [src/AudioRecorder.provider.tsx:37](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioRecorder.provider.tsx#L37)

--- a/documentation_site/docs/api-reference/API/variables/AudioStudioModule.md
+++ b/documentation_site/docs/api-reference/API/variables/AudioStudioModule.md
@@ -8,4 +8,4 @@
 
 > **AudioStudioModule**: `any`
 
-Defined in: [src/AudioStudioModule.ts:7](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudioModule.ts#L7)
+Defined in: [src/AudioStudioModule.ts:7](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudioModule.ts#L7)

--- a/documentation_site/docs/api-reference/API/variables/DeviceDisconnectionBehavior.md
+++ b/documentation_site/docs/api-reference/API/variables/DeviceDisconnectionBehavior.md
@@ -8,7 +8,7 @@
 
 > `const` **DeviceDisconnectionBehavior**: `object`
 
-Defined in: [src/AudioStudio.types.ts:353](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioStudio.types.ts#L353)
+Defined in: [src/AudioStudio.types.ts:355](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioStudio.types.ts#L355)
 
 Defines how recording should behave when a device becomes unavailable
 

--- a/documentation_site/docs/api-reference/API/variables/ExpoAudioStreamModule.md
+++ b/documentation_site/docs/api-reference/API/variables/ExpoAudioStreamModule.md
@@ -8,7 +8,7 @@
 
 > `const` **ExpoAudioStreamModule**: `any` = `AudioStudioModule`
 
-Defined in: [src/index.ts:104](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/index.ts#L104)
+Defined in: [src/index.ts:104](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/index.ts#L104)
 
 ## Deprecated
 

--- a/documentation_site/docs/api-reference/API/variables/MAX_DURATION_MS.md
+++ b/documentation_site/docs/api-reference/API/variables/MAX_DURATION_MS.md
@@ -8,7 +8,7 @@
 
 > `const` **MAX\_DURATION\_MS**: `30000` = `30_000`
 
-Defined in: [src/AudioAnalysis/extractMelSpectrogram.ts:25](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioAnalysis/extractMelSpectrogram.ts#L25)
+Defined in: [src/AudioAnalysis/extractMelSpectrogram.ts:25](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioAnalysis/extractMelSpectrogram.ts#L25)
 
 Maximum duration in milliseconds that extractMelSpectrogram will process in a single call.
 The C++ core requires the entire trimmed range as a contiguous float array in memory,

--- a/documentation_site/docs/api-reference/API/variables/WAV_HEADER_SIZE.md
+++ b/documentation_site/docs/api-reference/API/variables/WAV_HEADER_SIZE.md
@@ -8,4 +8,4 @@
 
 > `const` **WAV\_HEADER\_SIZE**: `44` = `44`
 
-Defined in: [src/utils/convertPCMToFloat32.ts:6](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/utils/convertPCMToFloat32.ts#L6)
+Defined in: [src/utils/convertPCMToFloat32.ts:6](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/utils/convertPCMToFloat32.ts#L6)

--- a/documentation_site/docs/api-reference/API/variables/audioDeviceManager.md
+++ b/documentation_site/docs/api-reference/API/variables/audioDeviceManager.md
@@ -8,4 +8,4 @@
 
 > `const` **audioDeviceManager**: [`AudioDeviceManager`](../classes/AudioDeviceManager.md)
 
-Defined in: [src/AudioDeviceManager.ts:798](https://github.com/deeeed/audiolab/blob/aa94a5362218b70425a166d847bf058456071a52/packages/audio-studio/src/AudioDeviceManager.ts#L798)
+Defined in: [src/AudioDeviceManager.ts:798](https://github.com/deeeed/audiolab/blob/c729585a5bba4d56b2e225795b3b4e8fe3e3cdfe/packages/audio-studio/src/AudioDeviceManager.ts#L798)

--- a/documentation_site/docs/api-reference/recording-config.md
+++ b/documentation_site/docs/api-reference/recording-config.md
@@ -57,6 +57,7 @@ export interface RecordingConfig {
     maxDurationMs?: number // Maximum cumulative active recording duration in milliseconds. Paused time does not count.
     autoStopOnMaxDuration?: boolean // Whether to stop automatically when maxDurationMs is reached (default is false)
     onMaxDurationReached?: (_: MaxDurationReachedEvent) => void // Callback for max-duration events
+    onRecordingStopped?: (recording: AudioRecording, reason: 'manual' | 'maxDuration') => void | Promise<void> // Callback after final stop result is available
 
     // Callback functions
     onAudioStream?: (_: AudioDataEvent) => Promise<void> // Callback function to handle audio stream
@@ -145,6 +146,12 @@ await startRecording({
       autoStopped: event.autoStopped,
     })
   },
+  onRecordingStopped: (recording, reason) => {
+    if (reason === 'maxDuration') {
+      console.log('Final auto-stopped recording', recording.fileUri)
+      console.log('Analysis points', recording.analysisData?.dataPoints.length ?? 0)
+    }
+  },
 })
 ```
 
@@ -154,10 +161,11 @@ Behavior:
 2. `autoStopOnMaxDuration: false` emits `onMaxDurationReached` and keeps recording.
 3. `autoStopOnMaxDuration: true` emits `onMaxDurationReached` and then stops recording automatically.
 4. `maxDurationMs` and `maxDurationReached` remain available in hook/status state after stop so UI can explain why recording ended.
+5. `onRecordingStopped(recording, 'maxDuration')` exposes the final `AudioRecording` result after auto-stop completes, while `lastRecordingReason` records why the session ended.
 
 When auto-stop is enabled, the automatic stop result is not passed to
-`onMaxDurationReached`. Use the event for immediate UI updates and the normal
-recording state/results flow to observe the stopped state.
+`onMaxDurationReached`. Use the event for immediate UI updates, then use
+`onRecordingStopped` for the final file/compression/analysis result.
 
 ## Live Analysis Retention {#live-analysis-retention}
 

--- a/documentation_site/docs/hooks/use-audio-recorder.md
+++ b/documentation_site/docs/hooks/use-audio-recorder.md
@@ -82,6 +82,11 @@ export default function App() {
                 onMaxDurationReached: (event) => {
                     console.log(`Reached ${event.maxDurationMs}ms limit`)
                 },
+                onRecordingStopped: (recording, reason) => {
+                    if (reason === 'maxDuration') {
+                        console.log(`Saved auto-stopped recording: ${recording.fileUri}`)
+                    }
+                },
             }
             
             await startRecording(config)
@@ -180,6 +185,7 @@ The `startRecording` function accepts a configuration object with the following 
 | `maxDurationMs` | `number` | Maximum cumulative active recording duration in milliseconds. Paused time does not count. `undefined`, `0`, or a negative value disables the limit. |
 | `autoStopOnMaxDuration` | `boolean` | Whether to stop automatically when `maxDurationMs` is reached. Defaults to `false`. |
 | `onMaxDurationReached` | `(event: MaxDurationReachedEvent) => void` | Callback invoked when the active recording duration reaches `maxDurationMs`. |
+| `onRecordingStopped` | `(recording: AudioRecording, reason: 'manual' \| 'maxDuration') => void \| Promise<void>` | Callback invoked after stop completes and the final recording result is available. |
 
 ### Max Active Recording Duration
 
@@ -201,14 +207,22 @@ await startRecording({
             autoStopped: event.autoStopped,
         })
     },
+    onRecordingStopped: (recording, reason) => {
+        if (reason === 'maxDuration') {
+            console.log('Final recording result', recording.fileUri)
+            console.log('Full analysis points', recording.analysisData?.dataPoints.length ?? 0)
+        }
+    },
 })
 ```
 
 With `autoStopOnMaxDuration: false`, the event is a notification and recording
 continues until you call `stopRecording()`. With `autoStopOnMaxDuration: true`,
 the event is emitted before the automatic stop completes. The automatic stop
-result is not passed to `onMaxDurationReached`; use hook state and stream
-callbacks for immediate UI updates.
+result is not passed to `onMaxDurationReached`; use that callback for immediate
+UI updates, then use `onRecordingStopped` for the final `AudioRecording`
+result. The hook's `lastRecordingReason` state remains available so UI can
+explain why recording ended.
 
 ### Long-Running Analysis Retention
 

--- a/documentation_site/docs/usage/standalone-recording.md
+++ b/documentation_site/docs/usage/standalone-recording.md
@@ -107,6 +107,11 @@ export default function App() {
         onMaxDurationReached: (event) => {
             console.log(`Recording reached ${event.maxDurationMs}ms limit`)
         },
+        onRecordingStopped: (recording, reason) => {
+            if (reason === 'maxDuration') {
+                console.log(`Auto-stopped recording saved at ${recording.fileUri}`)
+            }
+        },
         
         // Optional: Audio focus strategy (Android only)
         audioFocusStrategy: 'background', // 'background', 'interactive', 'communication', or 'none'
@@ -226,3 +231,4 @@ const recorder = useAudioRecorder(options?: UseAudioRecorderProps)
 | `maxDurationMs` | `number \| undefined` | Configured maximum active recording duration in milliseconds, if enabled |
 | `maxDurationReached` | `boolean \| undefined` | Whether the recording reached the configured maximum duration |
 | `analysisData` | `AudioAnalysis \| undefined` | Recent live analysis data for the recording if processing was enabled |
+| `lastRecordingReason` | `'manual' \| 'maxDuration' \| undefined` | Why the last completed recording stopped |

--- a/packages/audio-studio/README.md
+++ b/packages/audio-studio/README.md
@@ -128,6 +128,7 @@ const {
     startRecording,
     maxDurationMs,
     maxDurationReached,
+    lastRecordingReason,
 } = useAudioRecorder()
 
 await startRecording({
@@ -138,12 +139,22 @@ await startRecording({
     onMaxDurationReached: (event) => {
         console.log('Reached recording limit:', event.maxDurationMs)
     },
+    onRecordingStopped: (recording, reason) => {
+        if (reason === 'maxDuration') {
+            console.log('Auto-stopped recording:', recording.fileUri)
+        }
+    },
 })
 ```
 
 When auto-stop is enabled, the max-duration event is emitted before the stop
 finishes. Use the event and stream callbacks for immediate UI updates, then use
-normal recording state to observe that the recorder has stopped.
+`onRecordingStopped` for the final `AudioRecording`, including `analysisData`
+when full-analysis retention is enabled. `lastRecordingReason` remains in React
+state so UI can explain why recording ended. Because hook auto-stop finalization
+runs after the native max-duration event is delivered to JS, keep the app/runtime
+active for background recording scenarios where the final stop result must be
+observed immediately.
 
 ## Audio Analysis
 

--- a/packages/audio-studio/src/AudioStudio.types.ts
+++ b/packages/audio-studio/src/AudioStudio.types.ts
@@ -207,6 +207,8 @@ export interface MaxDurationReachedEvent {
     autoStopped: boolean
 }
 
+export type RecordingStopReason = 'manual' | 'maxDuration'
+
 export interface AudioSessionConfig {
     /**
      * Audio session category that defines the audio behavior
@@ -511,19 +513,32 @@ export interface RecordingConfig {
     /**
      * Stop recording automatically when maxDurationMs is reached.
      *
-     * Defaults to false. The MaxDurationReached event is emitted before the stop request.
-     * The automatic stop result is not returned to onMaxDurationReached; use the
-     * event and stream callbacks for immediate UI updates.
+     * Defaults to false. When used with `useAudioRecorder`, the
+     * MaxDurationReached event is emitted immediately, then the hook stops the
+     * recorder and exposes the final result through `onRecordingStopped`.
      */
     autoStopOnMaxDuration?: boolean
 
     /**
      * Optional callback invoked when maxDurationMs is reached.
      *
-     * If autoStopOnMaxDuration is true, this callback is invoked before the
-     * recorder finishes stopping. The final stop result is not passed here.
+     * This remains an immediate threshold callback. If
+     * autoStopOnMaxDuration is true, use `onRecordingStopped` for the full
+     * recording result after stop completes.
      */
     onMaxDurationReached?: (_: MaxDurationReachedEvent) => void
+
+    /**
+     * Optional callback invoked after a recording has fully stopped and the
+     * final `AudioRecording` result is available.
+     *
+     * The reason is `manual` when stopped through `stopRecording()` and
+     * `maxDuration` when stopped by `autoStopOnMaxDuration`.
+     */
+    onRecordingStopped?: (
+        recording: AudioRecording,
+        reason: RecordingStopReason
+    ) => void | Promise<void>
 
     /** Optional directory path where output files will be saved */
     outputDirectory?: string // If not provided, uses default app directory
@@ -757,10 +772,17 @@ export interface UseAudioRecorderState {
     maxDurationReached?: boolean
     /** Analysis data for the recording if processing was enabled */
     analysisData?: AudioAnalysis // Analysis data for the recording depending on enableProcessing flag
+    /** Reason associated with the last completed recording */
+    lastRecordingReason?: RecordingStopReason
     /** Optional callback to handle recording interruptions */
     onRecordingInterrupted?: (_: RecordingInterruptionEvent) => void
     /** Optional callback invoked when maxDurationMs is reached */
     onMaxDurationReached?: (_: MaxDurationReachedEvent) => void
+    /** Optional callback invoked when a recording fully stops */
+    onRecordingStopped?: (
+        recording: AudioRecording,
+        reason: RecordingStopReason
+    ) => void | Promise<void>
 }
 
 /**

--- a/packages/audio-studio/src/useAudioRecorder.tsx
+++ b/packages/audio-studio/src/useAudioRecorder.tsx
@@ -12,6 +12,7 @@ import {
     ConsoleLike,
     MaxDurationReachedEvent,
     RecordingConfig,
+    RecordingStopReason,
     StartRecordingResult,
 } from './AudioStudio.types'
 import AudioStudioModule from './AudioStudioModule'
@@ -23,7 +24,7 @@ import {
     addMaxDurationReachedListener,
     addRecordingInterruptionListener,
 } from './events'
-import { cleanNativeOptions } from './utils/cleanNativeOptions'
+import { createNativeRecordingOptions } from './utils/nativeRecordingOptions'
 
 export interface UseAudioRecorderProps {
     logger?: ConsoleLike
@@ -45,6 +46,7 @@ export interface UseAudioRecorderState {
     analysisData?: AudioAnalysis
     maxDurationMs?: number
     maxDurationReached?: boolean
+    lastRecordingReason?: RecordingStopReason
 }
 
 interface RecorderReducerState {
@@ -56,10 +58,17 @@ interface RecorderReducerState {
     analysisData?: AudioAnalysis
     maxDurationMs?: number
     maxDurationReached?: boolean
+    lastRecordingReason?: RecordingStopReason
 }
 
 type RecorderAction =
-    | { type: 'START' | 'STOP' | 'PAUSE' | 'RESUME' }
+    | { type: 'START' | 'PAUSE' | 'RESUME' }
+    | {
+          type: 'STOP'
+          payload: {
+              reason: RecordingStopReason
+          }
+      }
     | {
           type: 'UPDATE_RECORDING_STATE'
           payload: {
@@ -102,6 +111,42 @@ const defaultAnalysis: AudioAnalysis = {
     extractionTimeMs: 0,
 }
 
+function finiteOrZero(value: number): number {
+    return Number.isFinite(value) ? value : 0
+}
+
+function sanitizeSerializableValue<T>(value: T): T {
+    if (typeof value === 'number') {
+        return finiteOrZero(value) as T
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item) => sanitizeSerializableValue(item)) as T
+    }
+
+    if (value && typeof value === 'object') {
+        const sanitized: Record<string, unknown> = {}
+
+        for (const [key, nestedValue] of Object.entries(
+            value as Record<string, unknown>
+        )) {
+            sanitized[key] = sanitizeSerializableValue(nestedValue)
+        }
+
+        return sanitized as T
+    }
+
+    return value
+}
+
+function createSerializableAnalysis(analysis: AudioAnalysis): AudioAnalysis {
+    return sanitizeSerializableValue(analysis)
+}
+
+function createRecordingSnapshot(recording: AudioRecording): AudioRecording {
+    return sanitizeSerializableValue(recording)
+}
+
 function audioRecorderReducer(
     state: RecorderReducerState,
     action: RecorderAction
@@ -118,6 +163,7 @@ function audioRecorderReducer(
                 analysisData: defaultAnalysis,
                 maxDurationMs: undefined,
                 maxDurationReached: false,
+                lastRecordingReason: undefined,
             }
         case 'STOP':
             return {
@@ -128,6 +174,7 @@ function audioRecorderReducer(
                 size: 0,
                 compression: undefined,
                 analysisData: undefined,
+                lastRecordingReason: action.payload.reason,
                 // Preserve max-duration state after stop so UI and agentic
                 // validation can explain why recording ended. START resets it.
             }
@@ -202,6 +249,7 @@ export function useAudioRecorder({
         analysisData: undefined,
         maxDurationMs: undefined,
         maxDurationReached: false,
+        lastRecordingReason: undefined,
     })
 
     const startResultRef = useRef<StartRecordingResult | null>(null)
@@ -240,6 +288,7 @@ export function useAudioRecorder({
 
     const recordingConfigRef = useRef<RecordingConfig | null>(null)
     const maxDurationHandledRef = useRef(false)
+    const stopFinalizationRef = useRef<Promise<AudioRecording> | null>(null)
 
     // Generate unique instance ID for debugging
     const instanceId = useId().replace(/:/g, '').slice(0, 5)
@@ -471,6 +520,83 @@ export function useAudioRecorder({
         []
     )
 
+    const finalizeRecordingStop = useCallback(
+        async (reason: RecordingStopReason) => {
+            if (stopFinalizationRef.current) {
+                return stopFinalizationRef.current
+            }
+
+            const finalizePromise = (async () => {
+                const nativeStopResult: AudioRecording | null =
+                    await audioStudio.stopRecording()
+
+                if (!nativeStopResult) {
+                    throw new Error('Failed to stop recording')
+                }
+
+                const stopResult = createRecordingSnapshot(nativeStopResult)
+
+                if (shouldKeepFullAnalysis(recordingConfigRef.current)) {
+                    stopResult.analysisData = createSerializableAnalysis(
+                        fullAnalysisRef.current
+                    )
+                } else {
+                    // `keepFullAnalysis` is a hook-level retention policy. If a platform
+                    // starts returning native analysisData in the future, keep opt-out
+                    // semantics explicit and avoid leaking a full history here.
+                    delete stopResult.analysisData
+                }
+
+                if (analysisListenerRef.current) {
+                    analysisListenerRef.current.remove()
+                    analysisListenerRef.current = null
+                }
+                onAudioStreamRef.current = null
+
+                stateRef.current.isRecording = false
+                stateRef.current.isPaused = false
+
+                // Note: We deliberately DON'T clear recordingConfigRef here to preserve callbacks.
+                logger?.debug(`recording stopped`, stopResult)
+                maxDurationHandledRef.current = false
+                dispatch({
+                    type: 'STOP',
+                    payload: { reason },
+                })
+
+                const stoppedCallback =
+                    recordingConfigRef.current?.onRecordingStopped
+                if (stoppedCallback) {
+                    try {
+                        void Promise.resolve(
+                            stoppedCallback(stopResult, reason)
+                        ).catch((error) => {
+                            logger?.error(
+                                `Error in recording stopped callback:`,
+                                error
+                            )
+                        })
+                    } catch (error) {
+                        logger?.error(
+                            `Error in recording stopped callback:`,
+                            error
+                        )
+                    }
+                }
+
+                return stopResult
+            })()
+
+            stopFinalizationRef.current = finalizePromise
+            try {
+                return await finalizePromise
+            } finally {
+                stopFinalizationRef.current = null
+            }
+        },
+        [audioStudio, dispatch, logger]
+    )
+
     const handleMaxDurationReached = useCallback(
         async (event: MaxDurationReachedEvent) => {
             if (maxDurationHandledRef.current) {
@@ -498,84 +624,15 @@ export function useAudioRecorder({
                 logger?.error(`Error in max duration callback:`, error)
             }
 
-            const finishStoppedState = () => {
-                if (analysisListenerRef.current) {
-                    analysisListenerRef.current.remove()
-                    analysisListenerRef.current = null
-                }
-                onAudioStreamRef.current = null
-                stateRef.current.isRecording = false
-                stateRef.current.isPaused = false
-                dispatch({ type: 'STOP' })
-            }
-
-            const waitForPlatformAutoStop = async () => {
-                const timeoutMs = 3000
-                const startedAt = Date.now()
-                let lastStatus: AudioStreamStatus | undefined
-
-                while (Date.now() - startedAt < timeoutMs) {
-                    await new Promise((resolve) => setTimeout(resolve, 50))
-                    try {
-                        const currentStatus: AudioStreamStatus =
-                            audioStudio.status()
-                        lastStatus = currentStatus
-                        if (
-                            !currentStatus.isRecording &&
-                            !currentStatus.isPaused
-                        ) {
-                            finishStoppedState()
-                            return
-                        }
-                    } catch (error) {
-                        logger?.warn(
-                            `Error checking status after max duration auto-stop:`,
-                            error
-                        )
-                        break
-                    }
-                }
-
-                if (
-                    lastStatus &&
-                    (lastStatus.isRecording || lastStatus.isPaused)
-                ) {
-                    try {
-                        await audioStudio.stopRecording()
-                    } catch (error) {
-                        logger?.warn(
-                            `Error completing max duration auto-stop fallback:`,
-                            error
-                        )
-                    }
-                }
-                // At this point platform-owned auto-stop did not settle cleanly.
-                // Clear hook state so the UI does not stay stuck as recording.
-                finishStoppedState()
-            }
-
-            // Only the original event tells us whether the platform already
-            // owns auto-stop. Keep stream callbacks alive until status confirms
-            // stop completion so native final audio flushes can still reach JS.
-            if (event.autoStopped && stateRef.current.isRecording) {
-                await waitForPlatformAutoStop()
-                return
-            }
-
-            if (
-                config?.autoStopOnMaxDuration &&
-                !event.autoStopped &&
-                stateRef.current.isRecording
-            ) {
+            if (config?.autoStopOnMaxDuration && stateRef.current.isRecording) {
                 try {
-                    await audioStudio.stopRecording()
-                    finishStoppedState()
+                    await finalizeRecordingStop('maxDuration')
                 } catch (error) {
                     logger?.error(`Error auto-stopping on max duration:`, error)
                 }
             }
         },
-        [audioStudio, dispatch, logger]
+        [dispatch, finalizeRecordingStop, logger]
     )
 
     const checkStatus = useCallback(async () => {
@@ -618,27 +675,38 @@ export function useAudioRecorder({
                 })
             }
 
+            const statusMaxDurationReached = status.maxDurationReached ?? false
+            const preserveStoppedMaxDuration =
+                !status.isRecording &&
+                !status.isPaused &&
+                stateRef.current.maxDurationReached &&
+                !statusMaxDurationReached
+            const nextMaxDurationMs = preserveStoppedMaxDuration
+                ? stateRef.current.maxDurationMs
+                : status.maxDurationMs
+            const nextMaxDurationReached = preserveStoppedMaxDuration
+                ? true
+                : statusMaxDurationReached
+
             if (
                 status.durationMs !== stateRef.current.durationMs ||
                 status.size !== stateRef.current.size ||
-                status.maxDurationMs !== stateRef.current.maxDurationMs ||
-                status.maxDurationReached !==
-                    stateRef.current.maxDurationReached
+                nextMaxDurationMs !== stateRef.current.maxDurationMs ||
+                nextMaxDurationReached !== stateRef.current.maxDurationReached
             ) {
                 stateRef.current.durationMs = status.durationMs
                 stateRef.current.size = status.size
                 stateRef.current.compression = status.compression
-                stateRef.current.maxDurationMs = status.maxDurationMs
-                stateRef.current.maxDurationReached =
-                    status.maxDurationReached ?? false
+                stateRef.current.maxDurationMs = nextMaxDurationMs
+                stateRef.current.maxDurationReached = nextMaxDurationReached
                 dispatch({
                     type: 'UPDATE_STATUS',
                     payload: {
                         durationMs: status.durationMs,
                         size: status.size,
                         compression: status.compression,
-                        maxDurationMs: status.maxDurationMs,
-                        maxDurationReached: status.maxDurationReached,
+                        maxDurationMs: nextMaxDurationMs,
+                        maxDurationReached: nextMaxDurationReached,
                     },
                 })
             }
@@ -697,15 +765,7 @@ export function useAudioRecorder({
 
             analysisRef.current = { ...defaultAnalysis } // Reset analysis data
             fullAnalysisRef.current = { ...defaultAnalysis }
-            const {
-                onAudioStream,
-                onRecordingInterrupted,
-                onMaxDurationReached,
-                onAudioAnalysis,
-                keepFullAnalysis: _keepFullAnalysis,
-                ...options
-            } = validatedOptions
-            const { enableProcessing } = options
+            const { onAudioStream, enableProcessing } = validatedOptions
 
             const maxRecentDataDuration = 10000 // TODO compute maxRecentDataDuration based on screen dimensions
             if (typeof onAudioStream === 'function') {
@@ -714,8 +774,10 @@ export function useAudioRecorder({
                 logger?.warn(`onAudioStream is not a function`, onAudioStream)
                 onAudioStreamRef.current = null
             }
-            // Strip undefined values and functions that can't cross the native bridge
-            const cleanOptions = cleanNativeOptions(options)
+            // Strip hook-only values and undefineds that can't cross the native bridge.
+            // autoStopOnMaxDuration stays hook-owned so finalization can expose
+            // the same AudioRecording result as a manual stop.
+            const cleanOptions = createNativeRecordingOptions(validatedOptions)
             const startResult: StartRecordingResult =
                 await audioStudio.startRecording(cleanOptions)
             dispatch({ type: 'START' })
@@ -755,14 +817,7 @@ export function useAudioRecorder({
 
             analysisRef.current = { ...defaultAnalysis } // Reset analysis data
             fullAnalysisRef.current = { ...defaultAnalysis }
-            const {
-                onAudioStream,
-                onRecordingInterrupted,
-                onMaxDurationReached,
-                onAudioAnalysis,
-                keepFullAnalysis: _keepFullAnalysis,
-                ...options
-            } = recordingOptions
+            const { onAudioStream } = recordingOptions
 
             // Store onAudioStream for later use when recording starts
             if (typeof onAudioStream === 'function') {
@@ -772,8 +827,8 @@ export function useAudioRecorder({
                 onAudioStreamRef.current = null
             }
 
-            // Strip undefined values and functions that can't cross the native bridge
-            const cleanOptions = cleanNativeOptions(options)
+            // Strip hook-only values and undefineds that can't cross the native bridge.
+            const cleanOptions = createNativeRecordingOptions(recordingOptions)
             // Call the native prepareRecording method
             await audioStudio.prepareRecording(cleanOptions)
             logger?.debug(`recording prepared successfully`)
@@ -783,29 +838,8 @@ export function useAudioRecorder({
 
     const stopRecording = useCallback(async () => {
         logger?.debug(`stoping recording`)
-
-        const stopResult: AudioRecording = await audioStudio.stopRecording()
-        if (shouldKeepFullAnalysis(recordingConfigRef.current)) {
-            stopResult.analysisData = fullAnalysisRef.current
-        } else {
-            // `keepFullAnalysis` is a hook-level retention policy. If a platform
-            // starts returning native analysisData in the future, keep opt-out
-            // semantics explicit and avoid leaking a full history here.
-            delete stopResult.analysisData
-        }
-
-        if (analysisListenerRef.current) {
-            analysisListenerRef.current.remove()
-            analysisListenerRef.current = null
-        }
-        onAudioStreamRef.current = null
-
-        // Note: We deliberately DON'T clear recordingConfigRef here to preserve interruption callback
-        logger?.debug(`recording stopped`, stopResult)
-        maxDurationHandledRef.current = false
-        dispatch({ type: 'STOP' })
-        return stopResult
-    }, [dispatch])
+        return finalizeRecordingStop('manual')
+    }, [finalizeRecordingStop, logger])
 
     const pauseRecording = useCallback(async () => {
         logger?.debug(`pause recording`)
@@ -982,5 +1016,6 @@ export function useAudioRecorder({
         analysisData: state.analysisData,
         maxDurationMs: state.maxDurationMs,
         maxDurationReached: state.maxDurationReached,
+        lastRecordingReason: state.lastRecordingReason,
     }
 }

--- a/packages/audio-studio/src/utils/nativeRecordingOptions.test.ts
+++ b/packages/audio-studio/src/utils/nativeRecordingOptions.test.ts
@@ -1,0 +1,29 @@
+import { createNativeRecordingOptions } from './nativeRecordingOptions'
+
+describe('createNativeRecordingOptions', () => {
+    it('keeps maxDurationMs native but leaves auto-stop finalization hook-owned', () => {
+        const nativeOptions = createNativeRecordingOptions({
+            maxDurationMs: 1500,
+            autoStopOnMaxDuration: true,
+            onMaxDurationReached: jest.fn(),
+            onRecordingStopped: jest.fn(),
+            onRecordingInterrupted: jest.fn(),
+            onAudioAnalysis: jest.fn(),
+            onAudioStream: jest.fn(),
+            keepFullAnalysis: true,
+            sampleRate: 16000,
+        })
+
+        expect(nativeOptions).toMatchObject({
+            maxDurationMs: 1500,
+            sampleRate: 16000,
+        })
+        expect(nativeOptions).not.toHaveProperty('autoStopOnMaxDuration')
+        expect(nativeOptions).not.toHaveProperty('onMaxDurationReached')
+        expect(nativeOptions).not.toHaveProperty('onRecordingStopped')
+        expect(nativeOptions).not.toHaveProperty('onRecordingInterrupted')
+        expect(nativeOptions).not.toHaveProperty('onAudioAnalysis')
+        expect(nativeOptions).not.toHaveProperty('onAudioStream')
+        expect(nativeOptions).not.toHaveProperty('keepFullAnalysis')
+    })
+})

--- a/packages/audio-studio/src/utils/nativeRecordingOptions.ts
+++ b/packages/audio-studio/src/utils/nativeRecordingOptions.ts
@@ -1,0 +1,20 @@
+import { RecordingConfig } from '../AudioStudio.types'
+import { cleanNativeOptions } from './cleanNativeOptions'
+
+export function createNativeRecordingOptions(recordingOptions: RecordingConfig) {
+    const {
+        onAudioStream,
+        onRecordingInterrupted,
+        onMaxDurationReached,
+        onRecordingStopped,
+        onAudioAnalysis,
+        keepFullAnalysis: _keepFullAnalysis,
+        // Keep hook-owned auto-stop out of the native bridge so the hook can
+        // reuse the same finalization path as manual stop and expose the
+        // resulting AudioRecording consistently.
+        autoStopOnMaxDuration: _autoStopOnMaxDuration,
+        ...options
+    } = recordingOptions
+
+    return cleanNativeOptions(options)
+}


### PR DESCRIPTION
## Summary

Fixes #403 by preserving the immediate `onMaxDurationReached` callback while adding a post-stop result surface for auto-stop flows.

Changes:
- add `onRecordingStopped(recording, reason)` and `lastRecording` / `lastRecordingReason`
- make `useAudioRecorder` own `autoStopOnMaxDuration` finalization so auto-stop reuses the same result path as manual `stopRecording()`
- keep native/web responsible for max-duration timing/event emission, but strip hook-only auto-stop options from the native bridge
- attach retained full `analysisData` consistently to the final `AudioRecording`
- expose `lastRecording` through the playground agentic bridge and extend the max-duration recipe assertions
- update README/docs/generated API docs

## Validation

- `yarn workspace @siteed/audio-studio typecheck`
- `yarn workspace @siteed/audio-studio jest --runInBand src/utils/nativeRecordingOptions.test.ts src/errors/AudioStreamError.test.ts`
- `yarn workspace @siteed/audio-studio build:types && yarn workspace audio-playground typecheck`
- `git diff --check`

## Runtime validation note

A connected-device CDP recipe run was started, but the app target had not reloaded the new JS bridge state, so the new `lastRecording` recipe assertion could not be completed before this PR. The recipe has been updated to assert the #403 behavior once the app is relaunched against this branch.

Fixes #403
