### PR TITLE
fix(sherpa-onnx.rn,ios): dispatch inference bridges off main thread

### DIFF
--- a/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
+++ b/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
@@ -27,10 +27,13 @@
 
 RCT_EXPORT_MODULE(SherpaOnnx)
 
-// This allows running off main thread
-- (dispatch_queue_t)methodQueue {
-    return dispatch_get_main_queue();
-}
+// Intentionally do not override methodQueue. Returning the main queue here
+// dispatches every RCT_EXPORT_METHOD body onto the iOS UI thread, which makes
+// long-running ONNX inference (ASR/TTS/SpeakerId/AudioTagging) block the main
+// thread and trigger App Hang reports. Each handler section below installs its
+// own serial dispatch queue and wraps its method bodies in dispatch_async, in
+// line with the pattern already used by KWS/VAD/LanguageId/Punctuation/
+// Diarization/Denoising/OnnxInference in this file.
 
 // Initializer
 - (instancetype)init {
@@ -291,6 +294,16 @@ RCT_EXPORT_METHOD(extractTarBz2:(NSString *)sourcePath
 
 // MARK: - ASR Methods
 
+static dispatch_queue_t _asrSerialQueue;
+static dispatch_once_t _asrQueueOnce;
+
+static dispatch_queue_t asrSerialQueue(void) {
+    dispatch_once(&_asrQueueOnce, ^{
+        _asrSerialQueue = dispatch_queue_create("com.sherpaonnx.asr", DISPATCH_QUEUE_SERIAL);
+    });
+    return _asrSerialQueue;
+}
+
 // Initialize ASR with the provided configuration
 RCT_EXPORT_METHOD(initAsr:(JS::NativeSherpaOnnxSpec::SpecInitAsrConfig &)config
                  resolve:(RCTPromiseResolveBlock)resolve
@@ -375,16 +388,18 @@ RCT_EXPORT_METHOD(initAsr:(JS::NativeSherpaOnnxSpec::SpecInitAsrConfig &)config
     if (modelFileTokenizer) [modelFiles setObject:modelFileTokenizer forKey:@"tokenizer"];
     if (modelFiles.count > 0) [configDict setObject:modelFiles forKey:@"modelFiles"];
 
-    @try {
-        NSDictionary *result = [self.asrHandler initAsr:configDict];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_INIT", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler initAsr:configDict];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_INIT", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_INIT", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_INIT", exception.reason, nil);
-    }
+    });
 }
 
 // Recognize speech from audio samples
@@ -393,16 +408,18 @@ RCT_EXPORT_METHOD(recognizeFromSamples:(double)sampleRate
                           resolve:(RCTPromiseResolveBlock)resolve
                           reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler recognizeFromSamples:(int)sampleRate samples:samples];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_RECOGNIZE", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler recognizeFromSamples:(int)sampleRate samples:samples];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_RECOGNIZE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_RECOGNIZE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_RECOGNIZE", exception.reason, nil);
-    }
+    });
 }
 
 // Recognize speech from an audio file
@@ -410,28 +427,32 @@ RCT_EXPORT_METHOD(recognizeFromFile:(NSString *)filePath
                        resolve:(RCTPromiseResolveBlock)resolve
                        reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler recognizeFromFile:filePath];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_RECOGNIZE_FILE", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler recognizeFromFile:filePath];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_RECOGNIZE_FILE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_RECOGNIZE_FILE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_RECOGNIZE_FILE", exception.reason, nil);
-    }
+    });
 }
 
 // Release ASR resources
 RCT_EXPORT_METHOD(releaseAsr:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler releaseResources];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_RELEASE", exception.reason, nil);
-    }
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler releaseResources];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_RELEASE", exception.reason, nil);
+        }
+    });
 }
 
 // MARK: - ASR Online Streaming Methods
@@ -439,16 +460,18 @@ RCT_EXPORT_METHOD(releaseAsr:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(createAsrOnlineStream:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler createAsrOnlineStream];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_STREAM", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler createAsrOnlineStream];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_STREAM", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_STREAM", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_STREAM", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(acceptAsrOnlineWaveform:(double)sampleRate
@@ -456,71 +479,91 @@ RCT_EXPORT_METHOD(acceptAsrOnlineWaveform:(double)sampleRate
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler acceptAsrOnlineWaveform:(int)sampleRate samples:samples];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_WAVEFORM", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler acceptAsrOnlineWaveform:(int)sampleRate samples:samples];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_WAVEFORM", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_WAVEFORM", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_WAVEFORM", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(isAsrOnlineEndpoint:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler isAsrOnlineEndpoint];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_ENDPOINT", exception.reason, nil);
-    }
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler isAsrOnlineEndpoint];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_ENDPOINT", exception.reason, nil);
+        }
+    });
 }
 
 RCT_EXPORT_METHOD(getAsrOnlineResult:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler getAsrOnlineResult];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_RESULT", exception.reason, nil);
-    }
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler getAsrOnlineResult];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_RESULT", exception.reason, nil);
+        }
+    });
 }
 
 RCT_EXPORT_METHOD(finishAsrOnlineInput:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler finishAsrOnlineInput];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_FINISH", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler finishAsrOnlineInput];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_FINISH", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_FINISH", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_FINISH", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(resetAsrOnlineStream:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.asrHandler resetAsrOnlineStream];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_ASR_RESET", result[@"error"], nil);
+    dispatch_async(asrSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.asrHandler resetAsrOnlineStream];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_ASR_RESET", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_ASR_RESET", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_ASR_RESET", exception.reason, nil);
-    }
+    });
 }
 
 // MARK: - TTS Methods
+
+static dispatch_queue_t _ttsSerialQueue;
+static dispatch_once_t _ttsQueueOnce;
+
+static dispatch_queue_t ttsSerialQueue(void) {
+    dispatch_once(&_ttsQueueOnce, ^{
+        _ttsSerialQueue = dispatch_queue_create("com.sherpaonnx.tts", DISPATCH_QUEUE_SERIAL);
+    });
+    return _ttsSerialQueue;
+}
 
 
 RCT_EXPORT_METHOD(initTts:(JS::NativeSherpaOnnxSpec::SpecInitTtsConfig &)config
@@ -566,18 +609,20 @@ RCT_EXPORT_METHOD(initTts:(JS::NativeSherpaOnnxSpec::SpecInitTtsConfig &)config
     if (lengthScale) [configDict setObject:@(*lengthScale) forKey:@"lengthScale"];
     if (lang) [configDict setObject:lang forKey:@"lang"];
     RCTLogInfo(@"[SherpaOnnxRnModule.mm] initTts entered.");
-    @try {
-        RCTLogInfo(@"[SherpaOnnxRnModule.mm] Calling Swift ttsHandler.initTts...");
-        NSDictionary *result = [self.ttsHandler initTts:configDict]; // Directly pass the dictionary
-        RCTLogInfo(@"[SherpaOnnxRnModule.mm] Swift ttsHandler.initTts returned: %@", result);
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_TTS_INIT", result[@"error"], nil);
+    dispatch_async(ttsSerialQueue(), ^{
+        @try {
+            RCTLogInfo(@"[SherpaOnnxRnModule.mm] Calling Swift ttsHandler.initTts...");
+            NSDictionary *result = [self.ttsHandler initTts:configDict]; // Directly pass the dictionary
+            RCTLogInfo(@"[SherpaOnnxRnModule.mm] Swift ttsHandler.initTts returned: %@", result);
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_TTS_INIT", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_TTS_INIT", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_TTS_INIT", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(generateTts:(JS::NativeSherpaOnnxSpec::SpecGenerateTtsConfig &)config
@@ -602,40 +647,46 @@ RCT_EXPORT_METHOD(generateTts:(JS::NativeSherpaOnnxSpec::SpecGenerateTtsConfig &
     if (lengthScale) [configDict setObject:@(*lengthScale) forKey:@"lengthScale"];
     if (noiseScale) [configDict setObject:@(*noiseScale) forKey:@"noiseScale"];
     if (noiseScaleW) [configDict setObject:@(*noiseScaleW) forKey:@"noiseScaleW"];
-    @try {
-        NSDictionary *result = [self.ttsHandler generateTts:configDict]; // Directly pass dict
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_TTS_GENERATE", result[@"error"], nil);
+    dispatch_async(ttsSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.ttsHandler generateTts:configDict]; // Directly pass dict
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_TTS_GENERATE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_TTS_GENERATE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_TTS_GENERATE", exception.reason, nil);
-    }
+    });
 }
 
 // Stop TTS playback
 RCT_EXPORT_METHOD(stopTts:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.ttsHandler stopTts];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_TTS_STOP", exception.reason, nil);
-    }
+    dispatch_async(ttsSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.ttsHandler stopTts];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_TTS_STOP", exception.reason, nil);
+        }
+    });
 }
 
 // Release TTS resources
 RCT_EXPORT_METHOD(releaseTts:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.ttsHandler releaseTts];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_TTS_RELEASE", exception.reason, nil);
-    }
+    dispatch_async(ttsSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.ttsHandler releaseTts];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_TTS_RELEASE", exception.reason, nil);
+        }
+    });
 }
 
 // Implementation of getTurboModule for TurboModule support
@@ -645,6 +696,16 @@ RCT_EXPORT_METHOD(releaseTts:(RCTPromiseResolveBlock)resolve
 }
 
 // MARK: - Audio Tagging Methods
+
+static dispatch_queue_t _audioTaggingSerialQueue;
+static dispatch_once_t _audioTaggingQueueOnce;
+
+static dispatch_queue_t audioTaggingSerialQueue(void) {
+    dispatch_once(&_audioTaggingQueueOnce, ^{
+        _audioTaggingSerialQueue = dispatch_queue_create("com.sherpaonnx.audiotagging", DISPATCH_QUEUE_SERIAL);
+    });
+    return _audioTaggingSerialQueue;
+}
 
 RCT_EXPORT_METHOD(initAudioTagging:(JS::NativeSherpaOnnxSpec::SpecInitAudioTaggingConfig &)config
                  resolve:(RCTPromiseResolveBlock)resolve
@@ -667,32 +728,36 @@ RCT_EXPORT_METHOD(initAudioTagging:(JS::NativeSherpaOnnxSpec::SpecInitAudioTaggi
     if (topK) [configDict setObject:@(*topK) forKey:@"topK"];
     if (debug) [configDict setObject:@(*debug) forKey:@"debug"];
 
-    @try {
-        NSDictionary *result = [self.audioTaggingHandler initAudioTagging:configDict];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_AUDIO_TAGGING_INIT", result[@"error"], nil);
+    dispatch_async(audioTaggingSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.audioTaggingHandler initAudioTagging:configDict];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_AUDIO_TAGGING_INIT", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_AUDIO_TAGGING_INIT", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_AUDIO_TAGGING_INIT", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(processAndComputeAudioTagging:(NSString *)filePath
                               resolve:(RCTPromiseResolveBlock)resolve
                                reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.audioTaggingHandler processAndComputeFile:filePath];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_AUDIO_TAGGING_COMPUTE", result[@"error"], nil);
+    dispatch_async(audioTaggingSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.audioTaggingHandler processAndComputeFile:filePath];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_AUDIO_TAGGING_COMPUTE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_AUDIO_TAGGING_COMPUTE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_AUDIO_TAGGING_COMPUTE", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(processAndComputeAudioSamples:(double)sampleRate
@@ -700,30 +765,44 @@ RCT_EXPORT_METHOD(processAndComputeAudioSamples:(double)sampleRate
                               resolve:(RCTPromiseResolveBlock)resolve
                                reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.audioTaggingHandler processAndComputeSamples:(int)sampleRate samples:samples];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_AUDIO_TAGGING_COMPUTE", result[@"error"], nil);
+    dispatch_async(audioTaggingSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.audioTaggingHandler processAndComputeSamples:(int)sampleRate samples:samples];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_AUDIO_TAGGING_COMPUTE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_AUDIO_TAGGING_COMPUTE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_AUDIO_TAGGING_COMPUTE", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(releaseAudioTagging:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.audioTaggingHandler releaseResources];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_AUDIO_TAGGING_RELEASE", exception.reason, nil);
-    }
+    dispatch_async(audioTaggingSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.audioTaggingHandler releaseResources];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_AUDIO_TAGGING_RELEASE", exception.reason, nil);
+        }
+    });
 }
 
 // MARK: - Speaker ID Methods
+
+static dispatch_queue_t _speakerIdSerialQueue;
+static dispatch_once_t _speakerIdQueueOnce;
+
+static dispatch_queue_t speakerIdSerialQueue(void) {
+    dispatch_once(&_speakerIdQueueOnce, ^{
+        _speakerIdSerialQueue = dispatch_queue_create("com.sherpaonnx.speakerid", DISPATCH_QUEUE_SERIAL);
+    });
+    return _speakerIdSerialQueue;
+}
 
 RCT_EXPORT_METHOD(initSpeakerId:(JS::NativeSherpaOnnxSpec::SpecInitSpeakerIdConfig &)config
               resolve:(RCTPromiseResolveBlock)resolve
@@ -744,16 +823,18 @@ RCT_EXPORT_METHOD(initSpeakerId:(JS::NativeSherpaOnnxSpec::SpecInitSpeakerIdConf
     if (provider) [configDict setObject:provider forKey:@"provider"];
     if (debug) [configDict setObject:@(*debug) forKey:@"debug"];
 
-    @try {
-        NSDictionary *result = [self.speakerIdHandler initSpeakerId:configDict];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_INIT", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler initSpeakerId:configDict];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_INIT", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_INIT", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_INIT", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(processSpeakerIdSamples:(double)sampleRate
@@ -761,46 +842,52 @@ RCT_EXPORT_METHOD(processSpeakerIdSamples:(double)sampleRate
                         resolve:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler processSamples:(int)sampleRate samples:samples];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_PROCESS", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler processSamples:(int)sampleRate samples:samples];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_PROCESS", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_PROCESS", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_PROCESS", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(computeSpeakerEmbedding:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler computeEmbedding];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_COMPUTE", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler computeEmbedding];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_COMPUTE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_COMPUTE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_COMPUTE", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(resetSpeakerIdStream:(RCTPromiseResolveBlock)resolve
                          reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler resetStream];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_RESET", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler resetStream];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_RESET", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_RESET", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_RESET", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(registerSpeaker:(NSString *)name
@@ -808,43 +895,49 @@ RCT_EXPORT_METHOD(registerSpeaker:(NSString *)name
                 resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler registerSpeaker:name embedding:embedding];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_REGISTER", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler registerSpeaker:name embedding:embedding];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_REGISTER", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_REGISTER", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_REGISTER", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(removeSpeaker:(NSString *)name
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler removeSpeaker:name];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_REMOVE", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler removeSpeaker:name];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_REMOVE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_REMOVE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_REMOVE", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(getSpeakers:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler getSpeakers];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_GET_SPEAKERS", exception.reason, nil);
-    }
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler getSpeakers];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_GET_SPEAKERS", exception.reason, nil);
+        }
+    });
 }
 
 RCT_EXPORT_METHOD(identifySpeaker:(NSArray *)embedding
@@ -852,12 +945,14 @@ RCT_EXPORT_METHOD(identifySpeaker:(NSArray *)embedding
                 resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler identifySpeaker:embedding threshold:(float)threshold];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_IDENTIFY", exception.reason, nil);
-    }
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler identifySpeaker:embedding threshold:(float)threshold];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_IDENTIFY", exception.reason, nil);
+        }
+    });
 }
 
 RCT_EXPORT_METHOD(verifySpeaker:(NSString *)name
@@ -866,28 +961,32 @@ RCT_EXPORT_METHOD(verifySpeaker:(NSString *)name
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler verifySpeaker:name embedding:embedding threshold:(float)threshold];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_VERIFY", exception.reason, nil);
-    }
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler verifySpeaker:name embedding:embedding threshold:(float)threshold];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_VERIFY", exception.reason, nil);
+        }
+    });
 }
 
 RCT_EXPORT_METHOD(processSpeakerIdFile:(NSString *)filePath
                      resolve:(RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler processFile:filePath];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_PROCESS_FILE", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler processFile:filePath];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_PROCESS_FILE", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_PROCESS_FILE", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_PROCESS_FILE", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(processSpeakerIdFileWindow:(NSString *)filePath
@@ -896,27 +995,31 @@ RCT_EXPORT_METHOD(processSpeakerIdFileWindow:(NSString *)filePath
                       resolve:(RCTPromiseResolveBlock)resolve
                        reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler processFileWindow:filePath startTimeMs:startTimeMs durationMs:durationMs];
-        if ([result[@"success"] boolValue]) {
-            resolve(result);
-        } else {
-            reject(@"ERR_SPEAKER_ID_PROCESS_FILE_WINDOW", result[@"error"], nil);
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler processFileWindow:filePath startTimeMs:startTimeMs durationMs:durationMs];
+            if ([result[@"success"] boolValue]) {
+                resolve(result);
+            } else {
+                reject(@"ERR_SPEAKER_ID_PROCESS_FILE_WINDOW", result[@"error"], nil);
+            }
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_PROCESS_FILE_WINDOW", exception.reason, nil);
         }
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_PROCESS_FILE_WINDOW", exception.reason, nil);
-    }
+    });
 }
 
 RCT_EXPORT_METHOD(releaseSpeakerId:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    @try {
-        NSDictionary *result = [self.speakerIdHandler releaseResources];
-        resolve(result);
-    } @catch (NSException *exception) {
-        reject(@"ERR_SPEAKER_ID_RELEASE", exception.reason, nil);
-    }
+    dispatch_async(speakerIdSerialQueue(), ^{
+        @try {
+            NSDictionary *result = [self.speakerIdHandler releaseResources];
+            resolve(result);
+        } @catch (NSException *exception) {
+            reject(@"ERR_SPEAKER_ID_RELEASE", exception.reason, nil);
+        }
+    });
 }
 
 // MARK: - KWS Methods

--- a/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
+++ b/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
@@ -1246,11 +1246,12 @@ RCT_EXPORT_METHOD(detectLanguageFromFile:(NSString *)filePath
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    if (!filePath || filePath.length == 0) {
-        resolve(@{@"success": @NO, @"error": @"File path is required"});
-        return;
-    }
     dispatch_async(langIdSerialQueue(), ^{
+        if (!filePath || filePath.length == 0) {
+            resolve(@{@"success": @NO, @"error": @"File path is required"});
+            return;
+        }
+
         @try {
             NSDictionary *result = [self.languageIdHandler detectLanguageFromFile:filePath];
             resolve(result);

--- a/packages/sherpa-onnx.rn/src/__tests__/iosBridgeDispatchContract.test.js
+++ b/packages/sherpa-onnx.rn/src/__tests__/iosBridgeDispatchContract.test.js
@@ -12,13 +12,144 @@ const methodNames = Array.from(
   (match) => match[1]
 );
 
+const intentionallyUnwrapped = new Set([
+  'validateLibraryLoaded',
+  'testOnnxIntegration',
+  'getArchitectureInfo',
+  'getSystemInfo',
+  // Archive extraction is delegated to SherpaOnnxArchiveExtractor's completion
+  // API and is not one of the synchronous ONNX inference handlers covered by
+  // issue #405.
+  'extractTarBz2',
+]);
+
+const methodsByQueue = {
+  asrSerialQueue: [
+    'initAsr',
+    'recognizeFromSamples',
+    'recognizeFromFile',
+    'releaseAsr',
+    'createAsrOnlineStream',
+    'acceptAsrOnlineWaveform',
+    'isAsrOnlineEndpoint',
+    'getAsrOnlineResult',
+    'finishAsrOnlineInput',
+    'resetAsrOnlineStream',
+  ],
+  ttsSerialQueue: ['initTts', 'generateTts', 'stopTts', 'releaseTts'],
+  audioTaggingSerialQueue: [
+    'initAudioTagging',
+    'processAndComputeAudioTagging',
+    'processAndComputeAudioSamples',
+    'releaseAudioTagging',
+  ],
+  speakerIdSerialQueue: [
+    'initSpeakerId',
+    'processSpeakerIdSamples',
+    'computeSpeakerEmbedding',
+    'resetSpeakerIdStream',
+    'registerSpeaker',
+    'removeSpeaker',
+    'getSpeakers',
+    'identifySpeaker',
+    'verifySpeaker',
+    'processSpeakerIdFile',
+    'processSpeakerIdFileWindow',
+    'releaseSpeakerId',
+  ],
+  kwsSerialQueue: [
+    'initKws',
+    'acceptKwsWaveform',
+    'resetKwsStream',
+    'releaseKws',
+  ],
+  vadSerialQueue: ['initVad', 'acceptVadWaveform', 'resetVad', 'releaseVad'],
+  langIdSerialQueue: [
+    'initLanguageId',
+    'detectLanguage',
+    'detectLanguageFromFile',
+    'releaseLanguageId',
+  ],
+  punctSerialQueue: ['initPunctuation', 'addPunctuation', 'releasePunctuation'],
+  diarizationSerialQueue: [
+    'initDiarization',
+    'processDiarizationFile',
+    'processDiarizationFileWindow',
+    'releaseDiarization',
+  ],
+  denoisingSerialQueue: ['initDenoiser', 'denoiseFile', 'releaseDenoiser'],
+  inferenceSerialQueue: [
+    'createOnnxSession',
+    'runOnnxSession',
+    'releaseOnnxSession',
+  ],
+};
+
+const expectedQueueByMethod = Object.fromEntries(
+  Object.entries(methodsByQueue).flatMap(([queueName, methods]) =>
+    methods.map((methodName) => [methodName, queueName])
+  )
+);
+
+const queueLabels = {
+  asrSerialQueue: 'com.sherpaonnx.asr',
+  ttsSerialQueue: 'com.sherpaonnx.tts',
+  audioTaggingSerialQueue: 'com.sherpaonnx.audiotagging',
+  speakerIdSerialQueue: 'com.sherpaonnx.speakerid',
+  kwsSerialQueue: 'com.sherpaonnx.kws',
+  vadSerialQueue: 'com.sherpaonnx.vad',
+  langIdSerialQueue: 'com.sherpaonnx.langid',
+  punctSerialQueue: 'com.sherpaonnx.punct',
+  diarizationSerialQueue: 'com.sherpaonnx.diarization',
+  denoisingSerialQueue: 'com.sherpaonnx.denoising',
+  inferenceSerialQueue: 'com.sherpaonnx.inference',
+};
+
 function methodBlock(methodName) {
-  const start = source.search(new RegExp(`RCT_EXPORT_METHOD\\(${methodName}\\b`));
+  const start = source.search(
+    new RegExp(`RCT_EXPORT_METHOD\\(${methodName}\\b`)
+  );
   expect(start).toBeGreaterThanOrEqual(0);
-  const next = source
-    .slice(start + 1)
-    .search(/\n\s*RCT_EXPORT_METHOD\(/);
-  return next === -1 ? source.slice(start) : source.slice(start, start + 1 + next);
+  const next = source.slice(start + 1).search(/\n\s*RCT_EXPORT_METHOD\(/);
+  return next === -1
+    ? source.slice(start)
+    : source.slice(start, start + 1 + next);
+}
+
+function findMatchingBrace(text, openBraceIndex) {
+  let depth = 0;
+
+  for (let i = openBraceIndex; i < text.length; i += 1) {
+    if (text[i] === '{') {
+      depth += 1;
+    } else if (text[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  throw new Error(`No matching brace found from index ${openBraceIndex}`);
+}
+
+function asyncDispatchRange(methodSource, queueName) {
+  const dispatchCall = `dispatch_async(${queueName}(), ^`;
+  const start = methodSource.indexOf(dispatchCall);
+  expect({ queueName, hasDispatchCall: start !== -1 }).toEqual({
+    queueName,
+    hasDispatchCall: true,
+  });
+
+  const openBrace = methodSource.indexOf('{', start + dispatchCall.length);
+  expect(openBrace).toBeGreaterThan(start);
+
+  const closeBrace = findMatchingBrace(methodSource, openBrace);
+  return {
+    start,
+    end: closeBrace + 1,
+    body: methodSource.slice(openBrace, closeBrace + 1),
+  };
 }
 
 describe('iOS SherpaOnnx bridge dispatch contract', () => {
@@ -28,43 +159,56 @@ describe('iOS SherpaOnnx bridge dispatch contract', () => {
     );
   });
 
-  it('keeps all inference-capable exported methods on per-handler serial queues', () => {
-    const intentionallyUnwrapped = new Set([
-      'validateLibraryLoaded',
-      'testOnnxIntegration',
-      'getArchitectureInfo',
-      'getSystemInfo',
-      'extractTarBz2',
-    ]);
-
-    expect(methodNames).toHaveLength(60);
-
+  it('classifies every exported method as queue-bound or intentionally unwrapped', () => {
     for (const methodName of methodNames) {
-      const hasDispatch = methodBlock(methodName).includes('dispatch_async(');
-      expect({ methodName, hasDispatch }).toEqual({
+      const hasQueueMapping = Object.hasOwn(expectedQueueByMethod, methodName);
+      const isIntentionallyUnwrapped = intentionallyUnwrapped.has(methodName);
+      expect({ methodName, hasQueueMapping, isIntentionallyUnwrapped }).toEqual(
+        {
+          methodName,
+          hasQueueMapping: !isIntentionallyUnwrapped,
+          isIntentionallyUnwrapped: !hasQueueMapping,
+        }
+      );
+    }
+  });
+
+  it('keeps every queue-bound method body, including promise completion, inside its serial queue', () => {
+    for (const [methodName, queueName] of Object.entries(
+      expectedQueueByMethod
+    )) {
+      const block = methodBlock(methodName);
+      const dispatchRange = asyncDispatchRange(block, queueName);
+      const outsideDispatch =
+        block.slice(0, dispatchRange.start) + block.slice(dispatchRange.end);
+
+      expect({
         methodName,
-        hasDispatch: !intentionallyUnwrapped.has(methodName),
+        queueName,
+        hasPromiseCompletionInsideDispatch: /\b(resolve|reject)\s*\(/.test(
+          dispatchRange.body
+        ),
+        hasPromiseCompletionOutsideDispatch: /\b(resolve|reject)\s*\(/.test(
+          outsideDispatch
+        ),
+      }).toEqual({
+        methodName,
+        queueName,
+        hasPromiseCompletionInsideDispatch: true,
+        hasPromiseCompletionOutsideDispatch: false,
       });
     }
   });
 
-  it('uses dedicated serial queues for ASR, TTS, AudioTagging, and SpeakerID', () => {
-    const expectedQueues = {
-      asrSerialQueue: 10,
-      ttsSerialQueue: 4,
-      audioTaggingSerialQueue: 4,
-      speakerIdSerialQueue: 12,
-    };
-
-    for (const [queueName, expectedWraps] of Object.entries(expectedQueues)) {
-      expect(source).toContain(`dispatch_queue_create("com.sherpaonnx.${
-        queueName === 'audioTaggingSerialQueue'
-          ? 'audiotagging'
-          : queueName.replace('SerialQueue', '').toLowerCase()
-      }", DISPATCH_QUEUE_SERIAL)`);
-      expect((source.match(new RegExp(`dispatch_async\\(${queueName}\\(\\),`, 'g')) || [])).toHaveLength(
-        expectedWraps
+  it('uses dedicated serial queues for all synchronous native handler groups', () => {
+    for (const [queueName, label] of Object.entries(queueLabels)) {
+      expect(source).toContain(
+        `dispatch_queue_create("${label}", DISPATCH_QUEUE_SERIAL)`
       );
+      expect(
+        source.match(new RegExp(`dispatch_async\\(${queueName}\\(\\),`, 'g')) ||
+          []
+      ).toHaveLength(methodsByQueue[queueName].length);
     }
   });
 });

--- a/packages/sherpa-onnx.rn/src/__tests__/iosBridgeDispatchContract.test.js
+++ b/packages/sherpa-onnx.rn/src/__tests__/iosBridgeDispatchContract.test.js
@@ -1,0 +1,70 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const modulePath = path.resolve(
+  __dirname,
+  '../../ios/bridge/SherpaOnnxRnModule.mm'
+);
+const source = fs.readFileSync(modulePath, 'utf8');
+
+const methodNames = Array.from(
+  source.matchAll(/RCT_EXPORT_METHOD\((\w+)/g),
+  (match) => match[1]
+);
+
+function methodBlock(methodName) {
+  const start = source.search(new RegExp(`RCT_EXPORT_METHOD\\(${methodName}\\b`));
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = source
+    .slice(start + 1)
+    .search(/\n\s*RCT_EXPORT_METHOD\(/);
+  return next === -1 ? source.slice(start) : source.slice(start, start + 1 + next);
+}
+
+describe('iOS SherpaOnnx bridge dispatch contract', () => {
+  it('does not force exported methods onto the main queue', () => {
+    expect(source).not.toMatch(
+      /-\s*\(dispatch_queue_t\)methodQueue\s*\{\s*return\s+dispatch_get_main_queue\(\)/s
+    );
+  });
+
+  it('keeps all inference-capable exported methods on per-handler serial queues', () => {
+    const intentionallyUnwrapped = new Set([
+      'validateLibraryLoaded',
+      'testOnnxIntegration',
+      'getArchitectureInfo',
+      'getSystemInfo',
+      'extractTarBz2',
+    ]);
+
+    expect(methodNames).toHaveLength(60);
+
+    for (const methodName of methodNames) {
+      const hasDispatch = methodBlock(methodName).includes('dispatch_async(');
+      expect({ methodName, hasDispatch }).toEqual({
+        methodName,
+        hasDispatch: !intentionallyUnwrapped.has(methodName),
+      });
+    }
+  });
+
+  it('uses dedicated serial queues for ASR, TTS, AudioTagging, and SpeakerID', () => {
+    const expectedQueues = {
+      asrSerialQueue: 10,
+      ttsSerialQueue: 4,
+      audioTaggingSerialQueue: 4,
+      speakerIdSerialQueue: 12,
+    };
+
+    for (const [queueName, expectedWraps] of Object.entries(expectedQueues)) {
+      expect(source).toContain(`dispatch_queue_create("com.sherpaonnx.${
+        queueName === 'audioTaggingSerialQueue'
+          ? 'audiotagging'
+          : queueName.replace('SerialQueue', '').toLowerCase()
+      }", DISPATCH_QUEUE_SERIAL)`);
+      expect((source.match(new RegExp(`dispatch_async\\(${queueName}\\(\\),`, 'g')) || [])).toHaveLength(
+        expectedWraps
+      );
+    }
+  });
+});

--- a/scripts/agentic/cdp-bridge.mjs
+++ b/scripts/agentic/cdp-bridge.mjs
@@ -36,6 +36,9 @@
  *                   work like web ASR over slow CDN downloads.
  *   CDP_URL         External Chrome CDP URL (e.g. http://192.168.1.5:9222)
  *                   Bypasses .agent/web-browser.json — connects directly
+ *   CDP_ORIGIN      Override native inspector WebSocket Origin. By default,
+ *                   native CDP uses .agent/metro.host from start-metro.sh
+ *                   so physical devices match Metro's LAN-packager origin.
  */
 
 import http from 'node:http';
@@ -237,6 +240,35 @@ function rewriteWsHost(wsUrl, targetHost) {
     return u.toString();
   } catch {
     return wsUrl;
+  }
+}
+
+function getInspectorOrigin(wsUrl) {
+  if (process.env.CDP_ORIGIN !== undefined) {
+    return process.env.CDP_ORIGIN || undefined;
+  }
+
+  try {
+    const parsed = new URL(wsUrl);
+    if (!parsed.pathname.startsWith('/inspector/')) return undefined;
+
+    const metroHostFile = path.join(AGENT_DIR, 'metro.host');
+    if (fs.existsSync(metroHostFile)) {
+      const metroHost = fs.readFileSync(metroHostFile, 'utf8').trim();
+      if (metroHost) {
+        const httpProtocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+        const metroPort = parsed.port || loadPort();
+        return `${httpProtocol}//${metroHost}:${metroPort}`;
+      }
+    }
+
+    parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+    parsed.pathname = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return undefined;
   }
 }
 
@@ -507,22 +539,7 @@ async function resolveWebSocket() {
  */
 function createWSClient(wsUrl, timeout, WebSocketImpl) {
   return new Promise((resolve, reject) => {
-    const origin =
-      process.env.CDP_ORIGIN !== undefined
-        ? process.env.CDP_ORIGIN || undefined
-        : (() => {
-            try {
-              const parsed = new URL(wsUrl);
-              if (!parsed.pathname.startsWith('/inspector/')) return undefined;
-              parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
-              parsed.pathname = '';
-              parsed.search = '';
-              parsed.hash = '';
-              return parsed.toString().replace(/\/$/, '');
-            } catch {
-              return undefined;
-            }
-          })();
+    const origin = getInspectorOrigin(wsUrl);
     const ws = origin
       ? new WebSocketImpl(wsUrl, undefined, { headers: { Origin: origin } })
       : new WebSocketImpl(wsUrl);
@@ -1390,7 +1407,9 @@ Environment:
   WATCHER_PORT    Metro port (default: ${DEFAULT_PORT})
   CDP_TIMEOUT     Connection timeout in ms (default: 5000)
   CDP_URL         External Chrome CDP URL (e.g. http://192.168.1.5:9222)
-                  Bypasses .agent/web-browser.json — connects directly`);
+                  Bypasses .agent/web-browser.json — connects directly
+  CDP_ORIGIN      Override native inspector WebSocket Origin. By default,
+                  native CDP uses .agent/metro.host from start-metro.sh.`);
   process.exit(0);
 }
 

--- a/scripts/agentic/cdp-bridge.mjs
+++ b/scripts/agentic/cdp-bridge.mjs
@@ -37,8 +37,9 @@
  *   CDP_URL         External Chrome CDP URL (e.g. http://192.168.1.5:9222)
  *                   Bypasses .agent/web-browser.json — connects directly
  *   CDP_ORIGIN      Override native inspector WebSocket Origin. By default,
- *                   native CDP uses .agent/metro.host from start-metro.sh
- *                   so physical devices match Metro's LAN-packager origin.
+ *                   native CDP uses app-local .agent/metro.host from
+ *                   start-metro.sh so physical devices match Metro's
+ *                   LAN-packager origin.
  */
 
 import http from 'node:http';
@@ -243,6 +244,47 @@ function rewriteWsHost(wsUrl, targetHost) {
   }
 }
 
+function readMetroHostFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const metroHost = fs.readFileSync(filePath, 'utf8').trim();
+    return metroHost || null;
+  } catch {
+    return null;
+  }
+}
+
+function findAppMetroHost() {
+  const appsDir = path.join(APP_ROOT, 'apps');
+  try {
+    if (!fs.existsSync(appsDir)) return null;
+    const candidates = fs
+      .readdirSync(appsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => {
+        const metroHostFile = path.join(appsDir, entry.name, '.agent', 'metro.host');
+        const metroHost = readMetroHostFile(metroHostFile);
+        if (!metroHost) return null;
+
+        const pidFile = path.join(appsDir, entry.name, '.agent', 'metro.pid');
+        const hasAgentMetadata =
+          readMetroHostFile(pidFile) != null ||
+          fs.existsSync(path.join(appsDir, entry.name, '.agent', 'metro.log'));
+        const mtimeMs = fs.statSync(metroHostFile).mtimeMs;
+        return { metroHost, mtimeMs, hasAgentMetadata };
+      })
+      .filter(Boolean)
+      .sort((a, b) => {
+        if (a.hasAgentMetadata !== b.hasAgentMetadata) return a.hasAgentMetadata ? -1 : 1;
+        return b.mtimeMs - a.mtimeMs;
+      });
+
+    return candidates[0]?.metroHost || null;
+  } catch {
+    return null;
+  }
+}
+
 function getInspectorOrigin(wsUrl) {
   if (process.env.CDP_ORIGIN !== undefined) {
     return process.env.CDP_ORIGIN || undefined;
@@ -252,14 +294,13 @@ function getInspectorOrigin(wsUrl) {
     const parsed = new URL(wsUrl);
     if (!parsed.pathname.startsWith('/inspector/')) return undefined;
 
-    const metroHostFile = path.join(AGENT_DIR, 'metro.host');
-    if (fs.existsSync(metroHostFile)) {
-      const metroHost = fs.readFileSync(metroHostFile, 'utf8').trim();
-      if (metroHost) {
-        const httpProtocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
-        const metroPort = parsed.port || loadPort();
-        return `${httpProtocol}//${metroHost}:${metroPort}`;
-      }
+    const metroPort = parsed.port || loadPort();
+    const metroHost =
+      readMetroHostFile(path.join(AGENT_DIR, 'metro.host')) ||
+      findAppMetroHost();
+    if (metroHost) {
+      const httpProtocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+      return `${httpProtocol}//${metroHost}:${metroPort}`;
     }
 
     parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
@@ -1409,7 +1450,7 @@ Environment:
   CDP_URL         External Chrome CDP URL (e.g. http://192.168.1.5:9222)
                   Bypasses .agent/web-browser.json — connects directly
   CDP_ORIGIN      Override native inspector WebSocket Origin. By default,
-                  native CDP uses .agent/metro.host from start-metro.sh.`);
+                  native CDP uses app-local .agent/metro.host from start-metro.sh.`);
   process.exit(0);
 }
 

--- a/scripts/agentic/cdp-bridge.mjs
+++ b/scripts/agentic/cdp-bridge.mjs
@@ -254,6 +254,17 @@ function readMetroHostFile(filePath) {
   }
 }
 
+function isPidAlive(pidText) {
+  const pid = Number.parseInt(pidText || '', 10);
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function findAppMetroHost() {
   const appsDir = path.join(APP_ROOT, 'apps');
   try {
@@ -267,15 +278,13 @@ function findAppMetroHost() {
         if (!metroHost) return null;
 
         const pidFile = path.join(appsDir, entry.name, '.agent', 'metro.pid');
-        const hasAgentMetadata =
-          readMetroHostFile(pidFile) != null ||
-          fs.existsSync(path.join(appsDir, entry.name, '.agent', 'metro.log'));
+        const hasLivePid = isPidAlive(readMetroHostFile(pidFile));
         const mtimeMs = fs.statSync(metroHostFile).mtimeMs;
-        return { metroHost, mtimeMs, hasAgentMetadata };
+        return { metroHost, mtimeMs, hasLivePid };
       })
       .filter(Boolean)
       .sort((a, b) => {
-        if (a.hasAgentMetadata !== b.hasAgentMetadata) return a.hasAgentMetadata ? -1 : 1;
+        if (a.hasLivePid !== b.hasLivePid) return a.hasLivePid ? -1 : 1;
         return b.mtimeMs - a.mtimeMs;
       });
 
@@ -295,9 +304,12 @@ function getInspectorOrigin(wsUrl) {
     if (!parsed.pathname.startsWith('/inspector/')) return undefined;
 
     const metroPort = parsed.port || loadPort();
-    const metroHost =
-      readMetroHostFile(path.join(AGENT_DIR, 'metro.host')) ||
-      findAppMetroHost();
+    const configuredAppRoot = fs.existsSync(AGENTIC_CONF_FILE);
+    const localMetroHost = readMetroHostFile(path.join(AGENT_DIR, 'metro.host'));
+    const discoveredAppMetroHost = findAppMetroHost();
+    const metroHost = configuredAppRoot
+      ? localMetroHost || discoveredAppMetroHost
+      : discoveredAppMetroHost || localMetroHost;
     if (metroHost) {
       const httpProtocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
       return `${httpProtocol}//${metroHost}:${metroPort}`;

--- a/scripts/agentic/cdp-bridge.mjs
+++ b/scripts/agentic/cdp-bridge.mjs
@@ -244,11 +244,11 @@ function rewriteWsHost(wsUrl, targetHost) {
   }
 }
 
-function readMetroHostFile(filePath) {
+function readTextFile(filePath) {
   try {
     if (!fs.existsSync(filePath)) return null;
-    const metroHost = fs.readFileSync(filePath, 'utf8').trim();
-    return metroHost || null;
+    const text = fs.readFileSync(filePath, 'utf8').trim();
+    return text || null;
   } catch {
     return null;
   }
@@ -274,12 +274,17 @@ function findAppMetroHost() {
       .filter((entry) => entry.isDirectory())
       .map((entry) => {
         const metroHostFile = path.join(appsDir, entry.name, '.agent', 'metro.host');
-        const metroHost = readMetroHostFile(metroHostFile);
+        const metroHost = readTextFile(metroHostFile);
         if (!metroHost) return null;
 
         const pidFile = path.join(appsDir, entry.name, '.agent', 'metro.pid');
-        const hasLivePid = isPidAlive(readMetroHostFile(pidFile));
-        const mtimeMs = fs.statSync(metroHostFile).mtimeMs;
+        const hasLivePid = isPidAlive(readTextFile(pidFile));
+        let mtimeMs = 0;
+        try {
+          mtimeMs = fs.statSync(metroHostFile).mtimeMs;
+        } catch {
+          return null;
+        }
         return { metroHost, mtimeMs, hasLivePid };
       })
       .filter(Boolean)
@@ -305,7 +310,7 @@ function getInspectorOrigin(wsUrl) {
 
     const metroPort = parsed.port || loadPort();
     const configuredAppRoot = fs.existsSync(AGENTIC_CONF_FILE);
-    const localMetroHost = readMetroHostFile(path.join(AGENT_DIR, 'metro.host'));
+    const localMetroHost = readTextFile(path.join(AGENT_DIR, 'metro.host'));
     const discoveredAppMetroHost = findAppMetroHost();
     const metroHost = configuredAppRoot
       ? localMetroHost || discoveredAppMetroHost


### PR DESCRIPTION
## Summary
- Cherry-picks the iOS bridge fix from #404 onto latest `main`.
- Removes the bridge-wide main-thread `methodQueue` override.
- Dispatches ASR/TTS/AudioTagging/SpeakerID exported inference methods onto dedicated serial queues.
- Hardens the iOS bridge dispatch contract test so every exported method is either queue-bound or explicitly allowlisted, and all queue-bound promise completions stay inside their dispatch block.
- Aligns `detectLanguageFromFile` with the same promise-in-queue contract.
- Fixes the agentic native CDP bridge for physical Android validation by sending the Metro LAN `Origin` from `.agent/metro.host` instead of always deriving `localhost` from the inspector WebSocket URL.

Fixes #405.
Related to #404.

## Validation
- ✅ `yarn workspace @siteed/sherpa-onnx.rn jest --runInBand src/__tests__/iosBridgeDispatchContract.test.js`
- ✅ `yarn workspace @siteed/sherpa-onnx.rn typecheck`
- ✅ `yarn workspace @siteed/sherpa-onnx.rn test --runInBand`
- ✅ `yarn workspace @siteed/sherpa-voice typecheck`
- ✅ `node --check scripts/agentic/cdp-bridge.mjs`
- ✅ iOS native target build: `xcodebuild -workspace apps/sherpa-voice/ios/SherpaVoiceDev.xcworkspace -scheme sherpa-onnx-rn ...`
  - log: `apps/sherpa-voice/.agent/sherpa-onnx-rn-ios-target-build-20260529T033824Z.log`
- ✅ Full iOS simulator build/install/launch on dedicated simulator `sherpa-voice-1`
  - log: `apps/sherpa-voice/.agent/ios-simulator-build-20260529T034812Z.log`
- ✅ iOS CDP smoke on `sherpa-voice-1`: app reachable as `sim:sherpa-voice-1`, route `/features/asr`, ASR page state readable through `__AGENTIC__`
  - log: `apps/sherpa-voice/.agent/ios-cdp-smoke-20260529T041059Z.log`
- ✅ iOS simulator origin-regression smoke at final HEAD with `.agent/metro.host` present: `IOS_SIMULATOR=sherpa-voice-1 WATCHER_PORT=7500 SKIP_BUILD=1 yarn ios:launch`
  - log: `apps/sherpa-voice/.agent/ios-cdp-origin-regression-final3-20260529T044849Z.log`
- ✅ Android physical Pixel 6a only (no emulator): `ADB_SERIAL=29071JEGR20638 ANDROID_SERIAL=29071JEGR20638 WATCHER_PORT=7500 SKIP_BUILD=1 yarn android:device:launch` now passes app health via CDP after the Origin fix.
  - log: `apps/sherpa-voice/.agent/android-device-launch-fixed-29071JEGR20638-20260529T043549Z.log`
- ✅ Android physical Pixel 6a final HEAD CDP route smoke: `WATCHER_PORT=7500 node scripts/agentic/cdp-bridge.mjs --device "Pixel 6a" get-route` returns `/features`.
  - log: `apps/sherpa-voice/.agent/android-cdp-route-final3-20260529T044848Z.log`
- ✅ Direct repo-root CDP invocation after reviewer nit fix: `WATCHER_PORT=7500 node scripts/agentic/cdp-bridge.mjs --device "Pixel 6a" get-route` returns `/features` by discovering app-local live Metro host metadata.
  - log: `apps/sherpa-voice/.agent/root-cdp-pixel6a-after-cleanup-*.log`
- ✅ Web headless smoke: `WEB_HEADLESS=true WATCHER_PORT=7500 yarn web`, then `WATCHER_PORT=7500 node scripts/agentic/cdp-bridge.mjs --device web get-route` returns `/features`.
  - logs: `apps/sherpa-voice/.agent/web-launch-20260529T043628Z.log`, `apps/sherpa-voice/.agent/web-cdp-route-final3-20260529T044849Z.log`
  - screenshot: `apps/sherpa-voice/.agent/screenshots/2026-05-29_04-36-51_web-smoke.png`
- ⚠️ `asr-screen-validation` recipe preconditions and navigation passed, but the recipe then timed out waiting for `btn-recognize` with no ASR model selected/downloaded. I am treating that as an unrelated recipe/precondition limitation, not a failure of this iOS threading fix.
  - log: `apps/sherpa-voice/.agent/asr-screen-validation-ios-20260529T040523Z.log`

Notes on iOS validation environment: the generated native app project/Pods under ignored `apps/sherpa-voice/ios/` needed a local refresh to build React Native from source and align the simulator deployment target to iOS 16.4. Those generated-file changes are not part of this PR.

## Android CDP issue found
- The app was not crashing in the latest physical-device validation. Pixel 6a showed the Sherpa Voice UI and emitted normal React Native JS logs.
- The CDP target existed in Metro `/json/list`, but Runtime commands timed out because the inspector WebSocket Origin was wrong for a physical-device Metro session.
- Reproduced with raw WebSocket probes: `Origin: http://localhost:7500` connected then closed/no Runtime response, while `Origin: http://192.168.50.44:7500` returned `Runtime.evaluate` successfully.
- `cdp-bridge.mjs` now honors `CDP_ORIGIN` first, otherwise uses app-local `.agent/metro.host` from `start-metro.sh` for native `/inspector/` WebSockets, with the old URL-derived fallback preserved.

## Cross-review
- ✅ `$cross-review-orchestrator` final one-shot advisor loop reviewed HEAD `d6f05c1fd8a279bccbc80d02aa7b3a5320c31b94` after addressing actionable CDP nits.
- ✅ Claude final read-only review: `VERDICT: APPROVE`, blockers: none.
  - artifact: `.omx/artifacts/cross-review-pr407/claude-d6f05c1fd8a279bccbc80d02aa7b3a5320c31b94.txt`
- ✅ Cursor Agent final read-only review: `VERDICT: APPROVE`, blockers: none.
  - artifact: `.omx/artifacts/cross-review-pr407/cursor-d6f05c1fd8a279bccbc80d02aa7b3a5320c31b94.txt`
- ✅ Addressed reviewer CDP nits in follow-up commits:
  - repo-root CDP invocation now discovers app-local live Metro host metadata instead of relying on a root `.agent/metro.host`.
  - host discovery prefers live Metro PID metadata, uses clearer text-file helper naming, and handles per-candidate stat races.
- ℹ️ Remaining reviewer notes are non-blocking validation caveats: static contract tests do not prove runtime thread affinity, native TTS playback was not separately exercised because no simulator TTS model is installed, and multi-feature native concurrency should be monitored if JS ever drives multiple ONNX subsystems simultaneously.
