### PR TITLE
fix(audio-studio): honor foreground-only Android config

### DIFF
--- a/packages/audio-studio/CHANGELOG.md
+++ b/packages/audio-studio/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Android Expo plugin foreground-only configuration now removes the recording
+  service and receiver manifest entries when `enableBackgroundAudio` is
+  disabled. Regenerate native projects with Expo prebuild or rebuild Android
+  after changing this option.
+
 ## [3.2.1-beta.2] - 2026-05-29
 
 Beta release for validating max-duration recording controls after auto-stop result handling fixes.

--- a/packages/audio-studio/package.json
+++ b/packages/audio-studio/package.json
@@ -93,6 +93,7 @@
         "lint": "expo-module lint",
         "lint:fix": "expo-module lint --fix",
         "test": "expo-module test",
+        "test:plugin": "jest --runInBand plugin/src/index.test.ts",
         "test:android": "yarn test:android:unit && yarn test:android:instrumented",
         "test:android:unit": "cd ../../apps/playground/android && ./gradlew :siteed-audio-studio:test",
         "test:android:instrumented": "cd ../../apps/playground/android && ./gradlew :siteed-audio-studio:connectedAndroidTest",

--- a/packages/audio-studio/plugin/src/index.test.ts
+++ b/packages/audio-studio/plugin/src/index.test.ts
@@ -1,0 +1,76 @@
+import { __testing } from './index'
+
+describe('audio-studio Expo plugin Android background recording components', () => {
+    it('adds fully-qualified foreground service components when background audio is enabled', () => {
+        const application: any = {
+            receiver: [{ $: { 'android:name': '.RecordingActionReceiver' } }],
+            service: [{ $: { 'android:name': '.AudioRecordingService' } }],
+        }
+
+        __testing.configureAndroidBackgroundRecordingComponents(
+            application,
+            true
+        )
+
+        expect(application.receiver).toHaveLength(1)
+        expect(application.receiver[0].$['android:name']).toBe(
+            __testing.RECORDING_ACTION_RECEIVER
+        )
+        expect(application.receiver[0].$['android:exported']).toBe('false')
+        expect(application.receiver[0]['intent-filter'][0].action).toHaveLength(
+            3
+        )
+
+        expect(application.service).toHaveLength(1)
+        expect(application.service[0].$['android:name']).toBe(
+            __testing.AUDIO_RECORDING_SERVICE
+        )
+        expect(application.service[0].$['android:foregroundServiceType']).toBe(
+            'microphone'
+        )
+    })
+
+    it('removes foreground service components when background audio is disabled', () => {
+        const application: any = {
+            receiver: [
+                { $: { 'android:name': '.RecordingActionReceiver' } },
+                {
+                    $: {
+                        'android:name': __testing.RECORDING_ACTION_RECEIVER,
+                    },
+                },
+            ],
+            service: [
+                { $: { 'android:name': '.AudioRecordingService' } },
+                {
+                    $: {
+                        'android:name': __testing.AUDIO_RECORDING_SERVICE,
+                        'android:foregroundServiceType': 'microphone',
+                    },
+                },
+            ],
+        }
+
+        __testing.configureAndroidBackgroundRecordingComponents(
+            application,
+            false
+        )
+
+        expect(application.receiver).toEqual([
+            {
+                $: {
+                    'android:name': __testing.RECORDING_ACTION_RECEIVER,
+                    'tools:node': 'remove',
+                },
+            },
+        ])
+        expect(application.service).toEqual([
+            {
+                $: {
+                    'android:name': __testing.AUDIO_RECORDING_SERVICE,
+                    'tools:node': 'remove',
+                },
+            },
+        ])
+    })
+})

--- a/packages/audio-studio/plugin/src/index.test.ts
+++ b/packages/audio-studio/plugin/src/index.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="jest" />
+
 import { __testing } from './index'
 
 describe('audio-studio Expo plugin Android background recording components', () => {

--- a/packages/audio-studio/plugin/src/index.ts
+++ b/packages/audio-studio/plugin/src/index.ts
@@ -10,6 +10,138 @@ const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone'
 const NOTIFICATION_USAGE = 'Show recording notifications and controls'
 const LOG_PREFIX = '[@siteed/expo-audio-studio]'
 
+const AUDIO_STUDIO_ANDROID_PACKAGE = 'net.siteed.audiostudio'
+const RECORDING_ACTION_RECEIVER = `${AUDIO_STUDIO_ANDROID_PACKAGE}.RecordingActionReceiver`
+const AUDIO_RECORDING_SERVICE = `${AUDIO_STUDIO_ANDROID_PACKAGE}.AudioRecordingService`
+const LEGACY_RELATIVE_RECORDING_ACTION_RECEIVER = '.RecordingActionReceiver'
+const LEGACY_RELATIVE_AUDIO_RECORDING_SERVICE = '.AudioRecordingService'
+
+type AndroidComponent = {
+    $?: Record<string, string | boolean>
+    [key: string]: unknown
+}
+
+type AndroidApplication = {
+    receiver?: AndroidComponent[]
+    service?: AndroidComponent[]
+    [key: string]: unknown
+}
+
+function removeComponentsByName(
+    components: AndroidComponent[] | undefined,
+    names: string[]
+): AndroidComponent[] | undefined {
+    if (!components) {
+        return components
+    }
+
+    const filtered = components.filter(
+        (component) => !names.includes(String(component.$?.['android:name']))
+    )
+
+    return filtered.length > 0 ? filtered : undefined
+}
+
+function upsertComponent(
+    components: AndroidComponent[] | undefined,
+    componentConfig: AndroidComponent
+): AndroidComponent[] {
+    const name = String(componentConfig.$?.['android:name'])
+    const nextComponents = (components || []).filter(
+        (component) => String(component.$?.['android:name']) !== name
+    )
+
+    nextComponents.push(componentConfig)
+    return nextComponents
+}
+
+function addAndroidRemovalMarker(
+    components: AndroidComponent[] | undefined,
+    componentName: string
+): AndroidComponent[] {
+    return upsertComponent(components, {
+        $: {
+            'android:name': componentName,
+            'tools:node': 'remove',
+        },
+    })
+}
+
+function configureAndroidBackgroundRecordingComponents(
+    mainApplication: AndroidApplication,
+    enableBackgroundAudio: boolean | undefined
+): void {
+    const receiverNames = [
+        LEGACY_RELATIVE_RECORDING_ACTION_RECEIVER,
+        RECORDING_ACTION_RECEIVER,
+    ]
+    const serviceNames = [
+        LEGACY_RELATIVE_AUDIO_RECORDING_SERVICE,
+        AUDIO_RECORDING_SERVICE,
+    ]
+
+    mainApplication.receiver = removeComponentsByName(
+        mainApplication.receiver,
+        receiverNames
+    )
+    mainApplication.service = removeComponentsByName(
+        mainApplication.service,
+        serviceNames
+    )
+
+    if (enableBackgroundAudio) {
+        const receiverConfig = {
+            $: {
+                'android:name': RECORDING_ACTION_RECEIVER,
+                'android:exported': 'false' as const,
+            },
+            'intent-filter': [
+                {
+                    action: [
+                        { $: { 'android:name': 'PAUSE_RECORDING' } },
+                        { $: { 'android:name': 'RESUME_RECORDING' } },
+                        { $: { 'android:name': 'STOP_RECORDING' } },
+                    ],
+                },
+            ],
+        }
+
+        const serviceConfig = {
+            $: {
+                'android:name': AUDIO_RECORDING_SERVICE,
+                'android:enabled': 'true' as const,
+                'android:exported': 'false' as const,
+                'android:foregroundServiceType': 'microphone',
+            },
+        }
+
+        mainApplication.receiver = upsertComponent(
+            mainApplication.receiver,
+            receiverConfig
+        )
+        mainApplication.service = upsertComponent(
+            mainApplication.service,
+            serviceConfig
+        )
+        return
+    }
+
+    mainApplication.receiver = addAndroidRemovalMarker(
+        mainApplication.receiver,
+        RECORDING_ACTION_RECEIVER
+    )
+    mainApplication.service = addAndroidRemovalMarker(
+        mainApplication.service,
+        AUDIO_RECORDING_SERVICE
+    )
+}
+
+export const __testing = {
+    AUDIO_RECORDING_SERVICE,
+    RECORDING_ACTION_RECEIVER,
+    configureAndroidBackgroundRecordingComponents,
+}
+
 function debugLog(message: string, ...args: unknown[]): void {
     if (process.env.EXPO_DEBUG) {
         console.log(`${LOG_PREFIX} ${message}`, ...args)
@@ -203,71 +335,21 @@ const withRecordingPermission: ConfigPlugin<AudioStreamPluginOptions> = (
             )
         })
 
+        AndroidConfig.Manifest.ensureToolsAvailable(config.modResults)
+
         // Get the main application node
         const mainApplication = config.modResults.manifest.application?.[0]
         if (mainApplication) {
             debugLog('📱 Configuring Android application components...')
-
-            // Add RecordingActionReceiver
-            if (!mainApplication.receiver) {
-                mainApplication.receiver = []
-            }
-
-            const receiverConfig = {
-                $: {
-                    'android:name': '.RecordingActionReceiver',
-                    'android:exported': 'false' as const,
-                },
-                'intent-filter': [
-                    {
-                        action: [
-                            { $: { 'android:name': 'PAUSE_RECORDING' } },
-                            { $: { 'android:name': 'RESUME_RECORDING' } },
-                            { $: { 'android:name': 'STOP_RECORDING' } },
-                        ],
-                    },
-                ],
-            }
-
-            const receiverIndex = mainApplication.receiver.findIndex(
-                (receiver: any) =>
-                    receiver.$?.['android:name'] === '.RecordingActionReceiver'
+            configureAndroidBackgroundRecordingComponents(
+                mainApplication,
+                enableBackgroundAudio
             )
-
-            if (receiverIndex >= 0) {
-                mainApplication.receiver[receiverIndex] = receiverConfig
-            } else {
-                mainApplication.receiver.push(receiverConfig)
-            }
-
-            debugLog('✅ RecordingActionReceiver configured')
-
-            // Add AudioRecordingService
-            if (!mainApplication.service) {
-                mainApplication.service = []
-            }
-
-            const serviceConfig = {
-                $: {
-                    'android:name': '.AudioRecordingService',
-                    'android:enabled': 'true' as const,
-                    'android:exported': 'false' as const,
-                    'android:foregroundServiceType': 'microphone',
-                },
-            }
-
-            const serviceIndex = mainApplication.service.findIndex(
-                (service: any) =>
-                    service.$?.['android:name'] === '.AudioRecordingService'
+            debugLog(
+                enableBackgroundAudio
+                    ? '✅ Android background recording components configured'
+                    : '✅ Android background recording components disabled'
             )
-
-            if (serviceIndex >= 0) {
-                mainApplication.service[serviceIndex] = serviceConfig
-            } else {
-                mainApplication.service.push(serviceConfig)
-            }
-
-            debugLog('✅ AudioRecordingService configured')
         } else {
             console.error(
                 `${LOG_PREFIX} ❌ Main application node not found in Android Manifest`

--- a/packages/audio-studio/plugin/tsconfig.json
+++ b/packages/audio-studio/plugin/tsconfig.json
@@ -12,5 +12,10 @@
         }
     },
     "include": ["./src"],
-    "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+    "exclude": [
+        "**/__mocks__/*",
+        "**/__tests__/*",
+        "**/*.test.ts",
+        "**/*.spec.ts"
+    ]
 }

--- a/packages/audio-studio/tsconfig.cjs.json
+++ b/packages/audio-studio/tsconfig.cjs.json
@@ -5,6 +5,7 @@
         "moduleResolution": "node",
         "outDir": "./build/cjs",
         "declaration": false,
-        "declarationMap": false
+        "declarationMap": false,
+        "ignoreDeprecations": "6.0"
     }
-} 
+}

--- a/packages/audio-studio/tsconfig.json
+++ b/packages/audio-studio/tsconfig.json
@@ -2,17 +2,14 @@
     "extends": "expo-module-scripts/tsconfig.base",
     "compilerOptions": {
         "rootDir": "./src",
-        "ignoreDeprecations": "6.0",
+        "ignoreDeprecations": "5.0",
         "verbatimModuleSyntax": false,
         "noUncheckedIndexedAccess": false,
         "types": ["jest", "node"],
         "sourceMap": true,
         "declaration": true,
         "declarationMap": true,
-        "typeRoots": [
-            "./node_modules/@types",
-            "../../node_modules/@types",
-        ]
+        "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
     },
     "ts-node": {
         "compilerOptions": {


### PR DESCRIPTION
## Summary
Make the `@siteed/audio-studio` Expo plugin honor foreground-only Android configuration.

When `enableBackgroundAudio` is false, the plugin now removes the recording foreground service and notification receiver instead of declaring microphone foreground-service capability.

## Validation
- `yarn workspace @siteed/audio-studio exec jest --runInBand plugin/src/index.test.ts`
- `yarn workspace @siteed/audio-studio typecheck`
- `yarn workspace @siteed/audio-studio build:plugin`
- `yarn workspace @siteed/audio-studio build`
