### PR TITLE
feat(sherpa-onnx.rn): add offline CT-Transformer punctuation support

### DIFF
--- a/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/PunctuationHandler.kt
+++ b/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/PunctuationHandler.kt
@@ -14,7 +14,8 @@ import java.util.concurrent.Executors
 class PunctuationHandler(private val reactContext: ReactApplicationContext) {
 
     private val executor = Executors.newSingleThreadExecutor()
-    private var punct: OnlinePunctuation? = null
+    private var onlinePunct: com.k2fsa.sherpa.onnx.OnlinePunctuation? = null
+    private var offlinePunct: com.k2fsa.sherpa.onnx.OfflinePunctuation? = null
 
     companion object {
         private const val TAG = "SherpaOnnxPunctuation"
@@ -31,8 +32,6 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
                 Log.i(TAG, "Initializing Punctuation with config: ${config.toHashMap()}")
 
                 val modelDir = AssetUtils.cleanFilePath(config.getString("modelDir") ?: "")
-                val cnnBilstm = config.getString("cnnBilstm") ?: "model.onnx"
-                val bpeVocab = config.getString("bpeVocab") ?: "bpe.vocab"
                 val numThreads = if (config.hasKey("numThreads")) config.getInt("numThreads") else 1
                 val debug = if (config.hasKey("debug")) config.getBoolean("debug") else false
                 val provider = config.getString("provider") ?: "cpu"
@@ -50,36 +49,64 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
                     modelDir
                 }
 
-                val cnnBilstmPath = File(actualModelDir, cnnBilstm).absolutePath
-                val bpeVocabPath = File(actualModelDir, bpeVocab).absolutePath
+                // Release any previous instance (either engine).
+                onlinePunct?.release()
+                onlinePunct = null
+                offlinePunct?.release()
+                offlinePunct = null
 
-                Log.i(TAG, "cnnBilstm: $cnnBilstmPath (exists: ${File(cnnBilstmPath).exists()})")
-                Log.i(TAG, "bpeVocab: $bpeVocabPath (exists: ${File(bpeVocabPath).exists()})")
+                val modelFile = if (config.hasKey("model")) config.getString("model") else null
+                if (!modelFile.isNullOrEmpty()) {
+                    // Offline (CT-Transformer) path.
+                    val modelPath = File(actualModelDir, modelFile).absolutePath
+                    Log.i(TAG, "model: $modelPath (exists: ${File(modelPath).exists()})")
+                    if (!File(modelPath).exists()) {
+                        throw Exception("model file not found: $modelPath")
+                    }
 
-                if (!File(cnnBilstmPath).exists()) {
-                    throw Exception("cnnBilstm file not found: $cnnBilstmPath")
-                }
-                if (!File(bpeVocabPath).exists()) {
-                    throw Exception("bpeVocab file not found: $bpeVocabPath")
-                }
-
-                // Release previous instance
-                punct?.release()
-                punct = null
-
-                val punctConfig = OnlinePunctuationConfig(
-                    model = OnlinePunctuationModelConfig(
-                        cnnBilstm = cnnBilstmPath,
-                        bpeVocab = bpeVocabPath,
+                    val modelCfg = com.k2fsa.sherpa.onnx.OfflinePunctuationModelConfig(
+                        ctTransformer = modelPath,
                         numThreads = numThreads,
                         debug = debug,
                         provider = provider,
-                    ),
-                )
+                    )
+                    offlinePunct = com.k2fsa.sherpa.onnx.OfflinePunctuation(
+                        config = com.k2fsa.sherpa.onnx.OfflinePunctuationConfig(model = modelCfg),
+                    )
 
-                punct = OnlinePunctuation(null, punctConfig)
+                    Log.i(TAG, "OfflinePunctuation initialized successfully")
+                } else {
+                    // Online (CNN-BiLSTM) path — existing behavior.
+                    val cnnBilstm = config.getString("cnnBilstm") ?: "model.onnx"
+                    val bpeVocab = config.getString("bpeVocab") ?: "bpe.vocab"
 
-                Log.i(TAG, "Punctuation initialized successfully")
+                    val cnnBilstmPath = File(actualModelDir, cnnBilstm).absolutePath
+                    val bpeVocabPath = File(actualModelDir, bpeVocab).absolutePath
+
+                    Log.i(TAG, "cnnBilstm: $cnnBilstmPath (exists: ${File(cnnBilstmPath).exists()})")
+                    Log.i(TAG, "bpeVocab: $bpeVocabPath (exists: ${File(bpeVocabPath).exists()})")
+
+                    if (!File(cnnBilstmPath).exists()) {
+                        throw Exception("cnnBilstm file not found: $cnnBilstmPath")
+                    }
+                    if (!File(bpeVocabPath).exists()) {
+                        throw Exception("bpeVocab file not found: $bpeVocabPath")
+                    }
+
+                    val punctConfig = OnlinePunctuationConfig(
+                        model = OnlinePunctuationModelConfig(
+                            cnnBilstm = cnnBilstmPath,
+                            bpeVocab = bpeVocabPath,
+                            numThreads = numThreads,
+                            debug = debug,
+                            provider = provider,
+                        ),
+                    )
+
+                    onlinePunct = OnlinePunctuation(null, punctConfig)
+
+                    Log.i(TAG, "Punctuation initialized successfully")
+                }
 
                 val resultMap = Arguments.createMap()
                 resultMap.putBoolean("success", true)
@@ -87,7 +114,8 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
             } catch (e: Exception) {
                 Log.e(TAG, "Error initializing Punctuation: ${e.message}")
                 e.printStackTrace()
-                punct = null
+                onlinePunct = null
+                offlinePunct = null
                 reactContext.runOnUiQueueThread {
                     promise.reject("ERR_PUNCTUATION_INIT", "Failed to initialize Punctuation: ${e.message}")
                 }
@@ -98,13 +126,14 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
     fun addPunctuation(text: String, promise: Promise) {
         executor.execute {
             try {
-                val currentPunct = punct
-                    ?: throw Exception("Punctuation not initialized")
-
                 Log.d(TAG, "Adding punctuation to: $text")
 
                 val startTime = System.currentTimeMillis()
-                val result = currentPunct.addPunctuation(text)
+                val result = when {
+                    offlinePunct != null -> offlinePunct!!.addPunctuation(text)
+                    onlinePunct != null -> onlinePunct!!.addPunctuation(text)
+                    else -> throw Exception("Punctuation not initialized")
+                }
                 val durationMs = System.currentTimeMillis() - startTime
 
                 Log.i(TAG, "Punctuated text: $result in ${durationMs}ms")
@@ -127,8 +156,10 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
     fun release(promise: Promise) {
         executor.execute {
             try {
-                punct?.release()
-                punct = null
+                onlinePunct?.release()
+                onlinePunct = null
+                offlinePunct?.release()
+                offlinePunct = null
                 Log.i(TAG, "Punctuation released")
 
                 val resultMap = Arguments.createMap()

--- a/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
+++ b/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
@@ -1188,6 +1188,9 @@ RCT_EXPORT_METHOD(initPunctuation:(JS::NativeSherpaOnnxSpec::SpecInitPunctuation
     NSMutableDictionary *configDict = [NSMutableDictionary dictionary];
     if (config.modelDir()) configDict[@"modelDir"] = config.modelDir();
     if (config.cnnBilstm()) configDict[@"cnnBilstm"] = config.cnnBilstm();
+    if (config.model() != nil) {
+        configDict[@"model"] = config.model();
+    }
     if (config.bpeVocab()) configDict[@"bpeVocab"] = config.bpeVocab();
     if (config.numThreads()) configDict[@"numThreads"] = @((int)*config.numThreads());
     if (config.debug()) configDict[@"debug"] = @(*config.debug());

--- a/packages/sherpa-onnx.rn/ios/codegen/SherpaOnnxSpec/SherpaOnnxSpec.h
+++ b/packages/sherpa-onnx.rn/ios/codegen/SherpaOnnxSpec/SherpaOnnxSpec.h
@@ -279,6 +279,7 @@ namespace JS {
     struct SpecInitPunctuationConfig {
       NSString *modelDir() const;
       NSString *cnnBilstm() const;
+      NSString *model() const;
       NSString *bpeVocab() const;
       std::optional<double> numThreads() const;
       std::optional<bool> debug() const;
@@ -1118,6 +1119,11 @@ inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::modelDir()
 inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::cnnBilstm() const
 {
   id const p = _v[@"cnnBilstm"];
+  return RCTBridgingToOptionalString(p);
+}
+inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::model() const
+{
+  id const p = _v[@"model"];
   return RCTBridgingToOptionalString(p);
 }
 inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::bpeVocab() const

--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxPunctuationHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxPunctuationHandler.swift
@@ -2,7 +2,10 @@ import Foundation
 import CSherpaOnnx
 
 @objc public class SherpaOnnxPunctuationHandler: NSObject {
+    private enum Engine { case online, offline }
+
     private var punctPtr: OpaquePointer?
+    private var engine: Engine = .online
 
     private static let TAG = "[SherpaOnnxPunctuation]"
 
@@ -23,8 +26,6 @@ import CSherpaOnnx
             return ["success": false, "error": "modelDir is required"]
         }
 
-        let cnnBilstm = config["cnnBilstm"] as? String ?? "model.onnx"
-        let bpeVocab = config["bpeVocab"] as? String ?? "bpe.vocab"
         let numThreads = config["numThreads"] as? Int ?? 1
         let debug = config["debug"] as? Bool ?? false
         let provider = config["provider"] as? String ?? "cpu"
@@ -42,6 +43,44 @@ import CSherpaOnnx
                 actualModelDir = (modelDir as NSString).appendingPathComponent(subdirs[0])
             }
         }
+
+        // Offline (CT-Transformer) path: triggered when caller supplies a `model` file name.
+        if let modelFile = config["model"] as? String, !modelFile.isEmpty {
+            let modelPath = (actualModelDir as NSString).appendingPathComponent(modelFile)
+            if !fm.fileExists(atPath: modelPath) {
+                return ["success": false, "error": "model file not found: \(modelPath)"]
+            }
+
+            cleanupResources()
+
+            let modelC = strdup(modelPath)!
+            let providerC = strdup(provider)!
+
+            var offlineModelCfg = SherpaOnnxOfflinePunctuationModelConfig(
+                ct_transformer: modelC,
+                num_threads: Int32(numThreads),
+                debug: debug ? 1 : 0,
+                provider: providerC
+            )
+            var offlineCfg = SherpaOnnxOfflinePunctuationConfig(model: offlineModelCfg)
+            let ptr = SherpaOnnxCreateOfflinePunctuation(&offlineCfg)
+
+            free(modelC)
+            free(providerC)
+
+            guard ptr != nil else {
+                return ["success": false, "error": "Failed to create OfflinePunctuation instance"]
+            }
+
+            punctPtr = ptr
+            engine = .offline
+            NSLog("%@ OfflinePunctuation initialized successfully", SherpaOnnxPunctuationHandler.TAG)
+            return ["success": true]
+        }
+
+        // Online (CNN-BiLSTM) path: existing behavior.
+        let cnnBilstm = config["cnnBilstm"] as? String ?? "model.onnx"
+        let bpeVocab = config["bpeVocab"] as? String ?? "bpe.vocab"
 
         let cnnBilstmPath = (actualModelDir as NSString).appendingPathComponent(cnnBilstm)
         let bpeVocabPath = (actualModelDir as NSString).appendingPathComponent(bpeVocab)
@@ -82,6 +121,7 @@ import CSherpaOnnx
         }
 
         punctPtr = ptr
+        engine = .online
 
         NSLog("%@ Punctuation initialized successfully", SherpaOnnxPunctuationHandler.TAG)
         return ["success": true]
@@ -96,14 +136,23 @@ import CSherpaOnnx
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        let resultPtr = SherpaOnnxOnlinePunctuationAddPunct(punct, text)
-        let durationMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000.0
-
         var punctuated = ""
-        if let resultPtr = resultPtr {
-            punctuated = String(cString: resultPtr)
-            SherpaOnnxOnlinePunctuationFreeText(resultPtr)
+        switch engine {
+        case .online:
+            let resultPtr = SherpaOnnxOnlinePunctuationAddPunct(punct, text)
+            if let resultPtr = resultPtr {
+                punctuated = String(cString: resultPtr)
+                SherpaOnnxOnlinePunctuationFreeText(resultPtr)
+            }
+        case .offline:
+            let resultPtr = SherpaOfflinePunctuationAddPunct(punct, text)
+            if let resultPtr = resultPtr {
+                punctuated = String(cString: resultPtr)
+                SherpaOfflinePunctuationFreeText(resultPtr)
+            }
         }
+
+        let durationMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000.0
 
         NSLog("%@ Punctuated text: %@ in %.0fms", SherpaOnnxPunctuationHandler.TAG, punctuated, durationMs)
 
@@ -123,9 +172,15 @@ import CSherpaOnnx
 
     private func cleanupResources() {
         if let ptr = punctPtr {
-            SherpaOnnxDestroyOnlinePunctuation(ptr)
+            switch engine {
+            case .online:
+                SherpaOnnxDestroyOnlinePunctuation(ptr)
+            case .offline:
+                SherpaOnnxDestroyOfflinePunctuation(ptr)
+            }
             punctPtr = nil
         }
+        engine = .online
         NSLog("%@ Punctuation resources released", SherpaOnnxPunctuationHandler.TAG)
     }
 }

--- a/packages/sherpa-onnx.rn/src/NativeSherpaOnnxSpec.ts
+++ b/packages/sherpa-onnx.rn/src/NativeSherpaOnnxSpec.ts
@@ -528,6 +528,7 @@ export interface Spec extends TurboModule {
   initPunctuation(config: {
     modelDir: string;
     cnnBilstm?: string;
+    model?: string;
     bpeVocab?: string;
     numThreads?: number;
     debug?: boolean;

--- a/packages/sherpa-onnx.rn/src/__tests__/PunctuationService.test.ts
+++ b/packages/sherpa-onnx.rn/src/__tests__/PunctuationService.test.ts
@@ -16,14 +16,14 @@ describe('PunctuationService', () => {
     const service = new PunctuationService(api as unknown as ApiInterface);
 
     await service.init({
-      modelDir: '/tmp/punct-models/ct-transformer',
+      modelDir: '/models/punct/ct-transformer',
       model: 'model.int8.onnx',
     });
 
     expect(api.initPunctuation).toHaveBeenCalledTimes(1);
     const forwarded = api.initPunctuation.mock.calls[0]![0] as unknown as Record<string, unknown>;
     expect(forwarded.model).toBe('model.int8.onnx');
-    expect(forwarded.modelDir).toBe('/tmp/punct-models/ct-transformer');
+    expect(forwarded.modelDir).toBe('/models/punct/ct-transformer');
   });
 
   it('omits `model` from the native config when not provided (online CNN-BiLSTM path)', async () => {
@@ -31,7 +31,7 @@ describe('PunctuationService', () => {
     const service = new PunctuationService(api as unknown as ApiInterface);
 
     await service.init({
-      modelDir: '/tmp/punct-models/cnn-bilstm',
+      modelDir: '/models/punct/cnn-bilstm',
       cnnBilstm: 'model.onnx',
       bpeVocab: 'bpe.vocab',
     });

--- a/packages/sherpa-onnx.rn/src/__tests__/PunctuationService.test.ts
+++ b/packages/sherpa-onnx.rn/src/__tests__/PunctuationService.test.ts
@@ -1,0 +1,45 @@
+import { PunctuationService } from '../services/PunctuationService';
+import type { ApiInterface } from '../types/api';
+
+function createMockApi(): jest.Mocked<Pick<ApiInterface, 'validateLibraryLoaded' | 'initPunctuation' | 'addPunctuation' | 'releasePunctuation'>> {
+  return {
+    validateLibraryLoaded: jest.fn().mockResolvedValue({ loaded: true, status: 'ok' }),
+    initPunctuation: jest.fn().mockResolvedValue({ success: true }),
+    addPunctuation: jest.fn().mockResolvedValue({ success: true, text: 'Hello.', durationMs: 1 }),
+    releasePunctuation: jest.fn().mockResolvedValue({ released: true }),
+  };
+}
+
+describe('PunctuationService', () => {
+  it('forwards `model` to the native bridge when set (offline CT-Transformer path)', async () => {
+    const api = createMockApi();
+    const service = new PunctuationService(api as unknown as ApiInterface);
+
+    await service.init({
+      modelDir: '/tmp/punct-models/ct-transformer',
+      model: 'model.int8.onnx',
+    });
+
+    expect(api.initPunctuation).toHaveBeenCalledTimes(1);
+    const forwarded = api.initPunctuation.mock.calls[0]![0] as unknown as Record<string, unknown>;
+    expect(forwarded.model).toBe('model.int8.onnx');
+    expect(forwarded.modelDir).toBe('/tmp/punct-models/ct-transformer');
+  });
+
+  it('omits `model` from the native config when not provided (online CNN-BiLSTM path)', async () => {
+    const api = createMockApi();
+    const service = new PunctuationService(api as unknown as ApiInterface);
+
+    await service.init({
+      modelDir: '/tmp/punct-models/cnn-bilstm',
+      cnnBilstm: 'model.onnx',
+      bpeVocab: 'bpe.vocab',
+    });
+
+    expect(api.initPunctuation).toHaveBeenCalledTimes(1);
+    const forwarded = api.initPunctuation.mock.calls[0]![0] as unknown as Record<string, unknown>;
+    expect('model' in forwarded).toBe(false);
+    expect(forwarded.cnnBilstm).toBe('model.onnx');
+    expect(forwarded.bpeVocab).toBe('bpe.vocab');
+  });
+});

--- a/packages/sherpa-onnx.rn/src/services/PunctuationService.ts
+++ b/packages/sherpa-onnx.rn/src/services/PunctuationService.ts
@@ -36,6 +36,7 @@ export class PunctuationService {
         numThreads: config.numThreads ?? 1,
         debug: config.debug ?? false,
         provider: config.provider ?? 'cpu',
+        ...(config.model !== undefined ? { model: config.model } : {}),
         ...(config.modelBaseUrl && { modelBaseUrl: config.modelBaseUrl }),
         ...(config.onProgress && { onProgress: config.onProgress }),
       };

--- a/packages/sherpa-onnx.rn/src/types/interfaces.ts
+++ b/packages/sherpa-onnx.rn/src/types/interfaces.ts
@@ -1647,6 +1647,13 @@ export interface LanguageIdResult {
 export interface PunctuationModelConfig {
   modelDir: string;
   cnnBilstm?: string;
+  /**
+   * Offline (CT-Transformer) model file name, e.g. `model.onnx` or
+   * `model.int8.onnx`. When set, native code uses the offline engine
+   * (`sherpa-onnx-punct-ct-transformer-*`) instead of the online
+   * (CNN-BiLSTM) engine and `cnnBilstm` / `bpeVocab` are ignored.
+   */
+  model?: string;
   bpeVocab?: string;
   numThreads?: number;
   debug?: boolean;


### PR DESCRIPTION
Fixes #413

## Summary

Wire the existing offline `SherpaOnnxOfflinePunctuation` (iOS C API) and `com.k2fsa.sherpa.onnx.OfflinePunctuation` (Android Kotlin) bindings — both already vendored in this package — through the React Native `PunctuationHandler` / `PunctuationService`. Today only the online CNN-BiLSTM engine is reachable from JS.

Callers opt in by passing `model` (e.g. `"model.int8.onnx"`) in `PunctuationModelConfig`. When set, the native side uses the offline CT-Transformer engine and ignores `cnnBilstm` / `bpeVocab`. Online callers are unchanged — no migration needed.

This unlocks the [`sherpa-onnx-punct-ct-transformer-zh-en-vocab272727`](https://github.com/k2-fsa/sherpa-onnx/releases/tag/punctuation-models) family of models, which produce Chinese + English punctuation in a single ~70 MB int8 model — useful for ASR pipelines targeting both languages.

## What changed

- **iOS Swift handler**: tracks an `Engine` enum (`.online` / `.offline`) and routes `addPunct` / `release` to the matching C entry point (`SherpaOfflinePunctuationAddPunct` / `SherpaOnnxDestroyOfflinePunctuation`).
- **iOS Obj-C++ bridge + codegen**: pass new `model` field through `SpecInitPunctuationConfig`.
- **Android Kotlin handler**: keeps two nullable holders (`onlinePunct`, `offlinePunct`) and branches on the presence of `model`.
- **JS / TS**: `model?: string` plumbed through `PunctuationModelConfig`, `NativeSherpaOnnxSpec`, and `PunctuationService.init()`.

## Tests

- New `src/__tests__/PunctuationService.test.ts` asserts that `model` is forwarded to the native bridge when set, and omitted when not (so existing online callers see no change in the native payload).
- `yarn typecheck` clean.
- `yarn eslint` clean on changed files.

## Notes for the reviewer

- The C / Kotlin offline bindings (`SherpaOnnxCreateOfflinePunctuation`, `OfflinePunctuation`) are already present in this repo — no native build changes needed.
- This was developed and validated end-to-end in a downstream RN 0.85 / New Architecture app (iPhone simulator + physical Android), running the full ASR → CT-Transformer punctuator path.
- Codegen header (`ios/codegen/SherpaOnnxSpec/SherpaOnnxSpec.h`) is checked in upstream, so the `model()` accessor is added inline alongside `cnnBilstm()` / `bpeVocab()` following the same pattern. Happy to regenerate via `yarn regenerate-codegen` if preferred.

## Test plan

- [x] CI typecheck + tests pass
- [x] Smoke test on iOS: init with `model: 'model.int8.onnx'`, call `addPunctuation('你好 hello world how are you')`, expect both Chinese and English punctuation
- [ ] Smoke test on Android: same as above
- [ ] Regression: existing online CNN-BiLSTM callers (no `model` field) behave identically