### PR TITLE
fix(sherpa-onnx.rn): add missing dpdfnet field to OfflineSpeechDenoiserModelConfig (Android SIGABRT)

### DIFF
--- a/packages/sherpa-onnx.rn/android/src/main/kotlin/com/k2fsa/sherpa/onnx/OfflineSpeechDenoiser.kt
+++ b/packages/sherpa-onnx.rn/android/src/main/kotlin/com/k2fsa/sherpa/onnx/OfflineSpeechDenoiser.kt
@@ -6,8 +6,13 @@ data class OfflineSpeechDenoiserGtcrnModelConfig(
     var model: String = "",
 )
 
+data class OfflineSpeechDenoiserDpdfNetModelConfig(
+    var model: String = "",
+)
+
 data class OfflineSpeechDenoiserModelConfig(
     var gtcrn: OfflineSpeechDenoiserGtcrnModelConfig = OfflineSpeechDenoiserGtcrnModelConfig(),
+    var dpdfnet: OfflineSpeechDenoiserDpdfNetModelConfig = OfflineSpeechDenoiserDpdfNetModelConfig(),
     var numThreads: Int = 1,
     var debug: Boolean = false,
     var provider: String = "cpu",


### PR DESCRIPTION
## Summary

Fixes #411. On Android, `OfflineSpeechDenoiser.newFromFile` aborts the process with SIGABRT under CheckJNI because the native JNI calls `GetFieldID("dpdfnet", "Lcom/k2fsa/sherpa/onnx/OfflineSpeechDenoiserDpdfNetModelConfig;")` on `OfflineSpeechDenoiserModelConfig`, but the Kotlin data class doesn't declare that field.

This PR adds the missing `OfflineSpeechDenoiserDpdfNetModelConfig` data class and the `dpdfnet` field on `OfflineSpeechDenoiserModelConfig`, matching upstream sherpa-onnx Java bindings.

## Crash (before)

```
F DEBUG: #08 CheckJNI::GetField
F DEBUG: #11 libsherpa-onnx-jni.so Java_..._OfflineSpeechDenoiser_newFromFile+56
F DEBUG: #17 com.k2fsa.sherpa.onnx.OfflineSpeechDenoiser.<init>
```

## Test plan

- [x] Verified upstream `sherpa-onnx/jni/speech-denoiser.cc` queries the `dpdfnet` field unconditionally
- [x] Verified the prebuilt `libsherpa-onnx-jni.so` shipped in 1.3.1-beta.1 references `dpdfnet` (binary grep)
- [x] Applied the equivalent patch locally via `pnpm patch` — denoiser init no longer aborts
- [ ] Maintainer to verify on iOS (Swift handlers should be unaffected)

## Notes

- Only Android is affected; iOS uses Swift handlers under `ios/handlers/` and doesn't reflect on Kotlin classes.
- Default value of the new field is an empty `OfflineSpeechDenoiserDpdfNetModelConfig()`, so existing GTCRN-only callers are not affected at runtime.