### PR TITLE
fix: address audio and sherpa release blockers

### DIFF
--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -503,7 +503,14 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             // Now restart the engine if it was paused due to background
             do {
                 // Reinstall tap with hardware format to ensure we have good input
-                _ = installTapWithHardwareFormat()
+                let tapInstall = installTapWithHardwareFormat()
+                guard tapInstall.installed else {
+                    throw NSError(
+                        domain: "AudioStreamManager",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Failed to install audio tap after returning from background"]
+                    )
+                }
                 // Restart the engine
                 try audioEngine.start()
                 Logger.debug("AudioStreamManager", "Successfully restarted audio engine after returning from background")
@@ -1091,6 +1098,8 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             // Use our shared tap installation method
             let tapInstall = installTapWithHardwareFormat()
             guard tapInstall.installed else {
+                isPrepared = true
+                cleanupPreparation()
                 return false
             }
             let tapFormat = tapInstall.format
@@ -1433,7 +1442,12 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         
         do {
             // Check and reinstall tap with hardware format
-            _ = installTapWithHardwareFormat()
+            let tapInstall = installTapWithHardwareFormat()
+            guard tapInstall.installed else {
+                Logger.debug("Failed to install recording tap for resume")
+                currentPauseStart = Date()
+                return
+            }
             Logger.debug("Tap reinstalled for resume")
             
             // Try to restart the engine
@@ -1888,7 +1902,14 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             try AVAudioSession.sharedInstance().setPreferredInput(port)
             Thread.sleep(forTimeInterval: 0.15)
             audioEngine.reset()
-            _ = installTapWithHardwareFormat()
+            let tapInstall = installTapWithHardwareFormat()
+            guard tapInstall.installed else {
+                throw NSError(
+                    domain: "AudioStreamManager",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to install audio tap after device switch"]
+                )
+            }
             if wasRunning {
                 audioEngine.prepare()
                 try audioEngine.start()
@@ -1900,7 +1921,14 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("AudioStreamManager", "Device switch failed: \(error.localizedDescription)")
             if wasRunning {
                 do {
-                    _ = installTapWithHardwareFormat()  // Bug 2 fix: reinstall tap in recovery path
+                    let tapInstall = installTapWithHardwareFormat()  // Bug 2 fix: reinstall tap in recovery path
+                    guard tapInstall.installed else {
+                        throw NSError(
+                            domain: "AudioStreamManager",
+                            code: 1,
+                            userInfo: [NSLocalizedDescriptionKey: "Failed to install audio tap during device-switch recovery"]
+                        )
+                    }
                     audioEngine.prepare()
                     try audioEngine.start()
                     Logger.debug("AudioStreamManager", "Engine recovery after device switch succeeded")
@@ -2339,7 +2367,12 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             }
             
             // Use our shared tap installation method with the custom block
-            _ = installTapWithHardwareFormat(customTapBlock: fallbackTapBlock)
+            let tapInstall = installTapWithHardwareFormat(customTapBlock: fallbackTapBlock)
+            guard tapInstall.installed else {
+                Logger.debug("Fallback failed: Could not install audio tap. Pausing.")
+                performPauseAction(reason: .deviceSwitchFailed)
+                return
+            }
             Logger.debug("Fallback: Re-installed tap with simplified emission handling")
             
             // Force prepare engine again to ensure it's ready

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -275,57 +275,55 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             
         case .ended:
             Logger.debug("AudioStreamManager", "Audio session interruption ended - autoResume: \(autoResumeAfterInterruption), wasSuspended: \(wasSuspended)")
-            if let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt {
-                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-                Logger.debug("AudioStreamManager", "Interruption options - shouldResume: \(options.contains(.shouldResume))")
+            let options = InterruptionOptionsPolicy.options(from: userInfo)
+            Logger.debug("AudioStreamManager", "Interruption options - shouldResume: \(options.contains(.shouldResume))")
 
-                // Auto-resume only if this interruption paused the recording.
-                // If the user had already paused, preserve that intent.
-                // Keep currentPauseStart active until the actual resume so duration accounting
-                // excludes the full paused interval, including any post-interruption delay.
-                if AutoResumePolicy.shouldAutoResume(
-                    autoResumeAfterInterruption: autoResumeAfterInterruption,
-                    isRecording: isRecording,
-                    isPaused: isPaused,
-                    pausedBySystemInterruption: pausedBySystemInterruption
-                ) {
-                    // Add a longer delay for phone calls and ensure proper session setup
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-                        guard let self = self else { return }
-                        Logger.debug("AudioStreamManager", "Attempting to auto-resume recording after phone call")
-                        
-                        // Configure audio session
-                        do {
-                            let session = AVAudioSession.sharedInstance()
-                            let resumeOptions: AVAudioSession.CategoryOptions = self.recordingSettings?.ios?.audioSession?.categoryOptions ?? [.allowBluetooth, .mixWithOthers]
-                            try session.setCategory(.playAndRecord, mode: .default, options: resumeOptions)
-                            try session.setActive(true, options: .notifyOthersOnDeactivation)
-                            
-                            // Resume if we're still recording and paused
-                            if self.isRecording && self.isPaused {
-                                Logger.debug("AudioStreamManager", "Resuming recording after phone call interruption")
-                                self.audioEngine.prepare() 
-                                self.resumeRecording()
-                            } else {
-                                Logger.debug("AudioStreamManager", "Cannot resume - recording state invalid: isRecording=\(self.isRecording), isPaused=\(self.isPaused)")
-                            }
-                        } catch {
-                            Logger.debug("AudioStreamManager", "Failed to reactivate audio session: \(error)")
-                            self.delegate?.audioStreamManager(self, didFailWithError: "Failed to auto-resume: \(error.localizedDescription)")
+            // Auto-resume only if this interruption paused the recording.
+            // If the user had already paused, preserve that intent.
+            // Keep currentPauseStart active until the actual resume so duration accounting
+            // excludes the full paused interval, including any post-interruption delay.
+            if AutoResumePolicy.shouldAutoResume(
+                autoResumeAfterInterruption: autoResumeAfterInterruption,
+                isRecording: isRecording,
+                isPaused: isPaused,
+                pausedBySystemInterruption: pausedBySystemInterruption
+            ) {
+                // Add a longer delay for phone calls and ensure proper session setup
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                    guard let self = self else { return }
+                    Logger.debug("AudioStreamManager", "Attempting to auto-resume recording after phone call")
+
+                    // Configure audio session
+                    do {
+                        let session = AVAudioSession.sharedInstance()
+                        let resumeOptions: AVAudioSession.CategoryOptions = self.recordingSettings?.ios?.audioSession?.categoryOptions ?? [.allowBluetooth, .mixWithOthers]
+                        try session.setCategory(.playAndRecord, mode: .default, options: resumeOptions)
+                        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+                        // Resume if we're still recording and paused
+                        if self.isRecording && self.isPaused {
+                            Logger.debug("AudioStreamManager", "Resuming recording after phone call interruption")
+                            self.audioEngine.prepare()
+                            self.resumeRecording()
+                        } else {
+                            Logger.debug("AudioStreamManager", "Cannot resume - recording state invalid: isRecording=\(self.isRecording), isPaused=\(self.isPaused)")
                         }
+                    } catch {
+                        Logger.debug("AudioStreamManager", "Failed to reactivate audio session: \(error)")
+                        self.delegate?.audioStreamManager(self, didFailWithError: "Failed to auto-resume: \(error.localizedDescription)")
                     }
                 }
-                
-                // Always notify delegate of interruption end
-                delegate?.audioStreamManager(
-                    self,
-                    didReceiveInterruption: [
-                        "type": "ended",
-                        "wasSuspended": wasSuspended,
-                        "shouldResume": options.contains(.shouldResume)
-                    ]
-                )
             }
+
+            // Always notify delegate of interruption end
+            delegate?.audioStreamManager(
+                self,
+                didReceiveInterruption: [
+                    "type": "ended",
+                    "wasSuspended": wasSuspended,
+                    "shouldResume": options.contains(.shouldResume)
+                ]
+            )
         @unknown default:
             break
         }
@@ -942,20 +940,15 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
         }
         
         // Validate hardware format before installing tap (#223)
-        if inputHardwareFormat.channelCount == 0 || inputHardwareFormat.sampleRate == 0 {
-            Logger.debug("AudioStreamManager", "Invalid hardware format: channels=\(inputHardwareFormat.channelCount), sampleRate=\(inputHardwareFormat.sampleRate). Using fallback.")
-            let fallbackSampleRate = Double(recordingSettings?.sampleRate ?? 16000)
-            let fallbackChannels = AVAudioChannelCount(recordingSettings?.numberOfChannels ?? 1)
-            guard let fallbackFormat = AVAudioFormat(standardFormatWithSampleRate: fallbackSampleRate, channels: fallbackChannels) else {
-                Logger.debug("AudioStreamManager", "Failed to create fallback format")
-                return inputHardwareFormat
-            }
-            inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: fallbackFormat, block: tapBlock)
-            Logger.debug("AudioStreamManager", "Tap installed with fallback format")
+        if !AudioTapInstallPolicy.shouldInstallTap(
+            channelCount: inputHardwareFormat.channelCount,
+            sampleRate: inputHardwareFormat.sampleRate
+        ) {
+            Logger.debug("AudioStreamManager", "Invalid hardware format: channels=\(inputHardwareFormat.channelCount), sampleRate=\(inputHardwareFormat.sampleRate). Skipping tap install to avoid format mismatch crash.")
             if prepareEngine {
                 audioEngine.prepare()
             }
-            return fallbackFormat
+            return inputHardwareFormat
         }
 
         // Install the tap with hardware format
@@ -2507,6 +2500,28 @@ internal struct AutoResumePolicy {
             isRecording &&
             isPaused &&
             pausedBySystemInterruption
+    }
+}
+
+internal struct InterruptionOptionsPolicy {
+    static func options(from userInfo: [AnyHashable: Any]) -> AVAudioSession.InterruptionOptions {
+        guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+            // Some background call-decline paths omit this key. Treat it as
+            // "no explicit shouldResume hint" instead of skipping ended
+            // handling entirely.
+            return []
+        }
+
+        return AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+    }
+}
+
+internal struct AudioTapInstallPolicy {
+    static func shouldInstallTap(
+        channelCount: AVAudioChannelCount,
+        sampleRate: Double
+    ) -> Bool {
+        channelCount > 0 && sampleRate > 0
     }
 }
 

--- a/packages/audio-studio/ios/AudioStreamManager.swift
+++ b/packages/audio-studio/ios/AudioStreamManager.swift
@@ -895,7 +895,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
     private func installTapWithHardwareFormat(
         customTapBlock: ((AVAudioPCMBuffer, AVAudioTime) -> Void)? = nil,
         prepareEngine: Bool = true
-    ) -> AVAudioFormat {
+    ) -> (format: AVAudioFormat, installed: Bool) {
         // Get the hardware input format
         let inputNode = audioEngine.inputNode
         let inputHardwareFormat = inputNode.inputFormat(forBus: 0)
@@ -944,11 +944,13 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             channelCount: inputHardwareFormat.channelCount,
             sampleRate: inputHardwareFormat.sampleRate
         ) {
-            Logger.debug("AudioStreamManager", "Invalid hardware format: channels=\(inputHardwareFormat.channelCount), sampleRate=\(inputHardwareFormat.sampleRate). Skipping tap install to avoid format mismatch crash.")
+            let message = "Invalid hardware format: channels=\(inputHardwareFormat.channelCount), sampleRate=\(inputHardwareFormat.sampleRate). Skipping tap install to avoid format mismatch crash."
+            Logger.debug("AudioStreamManager", message)
+            delegate?.audioStreamManager(self, didFailWithError: message)
             if prepareEngine {
                 audioEngine.prepare()
             }
-            return inputHardwareFormat
+            return (inputHardwareFormat, false)
         }
 
         // Install the tap with hardware format
@@ -961,7 +963,7 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("AudioStreamManager", "Engine prepared after tap installation")
         }
         
-        return inputHardwareFormat
+        return (inputHardwareFormat, true)
     }
     
     /// Prepares the audio recording with the specified settings without starting it.
@@ -1087,7 +1089,11 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("AudioStreamManager", "  - compression enabled: \(settings.output.compressed.enabled)")
 
             // Use our shared tap installation method
-            let tapFormat = installTapWithHardwareFormat()
+            let tapInstall = installTapWithHardwareFormat()
+            guard tapInstall.installed else {
+                return false
+            }
+            let tapFormat = tapInstall.format
 
             // Log tap configuration
             Logger.debug("AudioStreamManager", "Final Tap Configuration (Using Hardware Format):")
@@ -1213,7 +1219,12 @@ class AudioStreamManager: NSObject, AudioDeviceManagerDelegate {
             Logger.debug("Using prepared recording state")
             
             // Install tap with hardware format
-            _ = installTapWithHardwareFormat()
+            let tapInstall = installTapWithHardwareFormat()
+            guard tapInstall.installed else {
+                Logger.debug("Failed to install recording tap")
+                cleanupPreparation()
+                return nil
+            }
             Logger.debug("Tap was reinstalled during recording start")
         } else {
             // If not prepared, prepare now

--- a/packages/audio-studio/ios/AudioStudioTests/AudioInterruptionPolicyTests.swift
+++ b/packages/audio-studio/ios/AudioStudioTests/AudioInterruptionPolicyTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import AVFoundation
+@testable import AudioStudio
+
+final class AudioInterruptionPolicyTests: XCTestCase {
+    func testInterruptionOptionsDefaultsToEmptyWhenSystemOmitsKey() {
+        let options = InterruptionOptionsPolicy.options(from: [:])
+
+        XCTAssertFalse(options.contains(.shouldResume))
+    }
+
+    func testAutoResumeDoesNotRequireShouldResumeOptionWhenSystemPausedRecording() {
+        XCTAssertTrue(
+            AutoResumePolicy.shouldAutoResume(
+                autoResumeAfterInterruption: true,
+                isRecording: true,
+                isPaused: true,
+                pausedBySystemInterruption: true
+            )
+        )
+    }
+
+    func testAutoResumePreservesUserPausedRecording() {
+        XCTAssertFalse(
+            AutoResumePolicy.shouldAutoResume(
+                autoResumeAfterInterruption: true,
+                isRecording: true,
+                isPaused: true,
+                pausedBySystemInterruption: false
+            )
+        )
+    }
+
+    func testInvalidHardwareFormatSkipsTapInstall() {
+        XCTAssertFalse(
+            AudioTapInstallPolicy.shouldInstallTap(channelCount: 0, sampleRate: 16_000)
+        )
+        XCTAssertFalse(
+            AudioTapInstallPolicy.shouldInstallTap(channelCount: 1, sampleRate: 0)
+        )
+        XCTAssertTrue(
+            AudioTapInstallPolicy.shouldInstallTap(channelCount: 1, sampleRate: 44_100)
+        )
+    }
+}

--- a/packages/sherpa-onnx.rn/android/src/main/kotlin/com/k2fsa/sherpa/onnx/OfflineSpeechDenoiser.kt
+++ b/packages/sherpa-onnx.rn/android/src/main/kotlin/com/k2fsa/sherpa/onnx/OfflineSpeechDenoiser.kt
@@ -6,8 +6,13 @@ data class OfflineSpeechDenoiserGtcrnModelConfig(
     var model: String = "",
 )
 
+data class OfflineSpeechDenoiserDpdfNetModelConfig(
+    var model: String = "",
+)
+
 data class OfflineSpeechDenoiserModelConfig(
     var gtcrn: OfflineSpeechDenoiserGtcrnModelConfig = OfflineSpeechDenoiserGtcrnModelConfig(),
+    var dpdfnet: OfflineSpeechDenoiserDpdfNetModelConfig = OfflineSpeechDenoiserDpdfNetModelConfig(),
     var numThreads: Int = 1,
     var debug: Boolean = false,
     var provider: String = "cpu",

--- a/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt
+++ b/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt
@@ -644,10 +644,14 @@ class ASRHandler(private val reactContext: ReactApplicationContext) {
                 files.add(modelConfig.nemo.model)
             }
             "moonshine" -> {
-                files.add(modelConfig.moonshine.preprocessor)
                 files.add(modelConfig.moonshine.encoder)
-                files.add(modelConfig.moonshine.uncachedDecoder)
-                files.add(modelConfig.moonshine.cachedDecoder)
+                if (modelConfig.moonshine.mergedDecoder.isNotBlank()) {
+                    files.add(modelConfig.moonshine.mergedDecoder)
+                } else {
+                    files.add(modelConfig.moonshine.preprocessor)
+                    files.add(modelConfig.moonshine.uncachedDecoder)
+                    files.add(modelConfig.moonshine.cachedDecoder)
+                }
             }
             "sense_voice" -> {
                 files.add(modelConfig.senseVoice.model)

--- a/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt
+++ b/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt
@@ -142,6 +142,7 @@ class ASRHandler(private val reactContext: ReactApplicationContext) {
                     "modelFilePreprocessor" to "preprocessor",
                     "modelFileUncachedDecoder" to "uncachedDecoder",
                     "modelFileCachedDecoder" to "cachedDecoder",
+                    "modelFileMergedDecoder" to "mergedDecoder",
                     "modelFileConvFrontend" to "convFrontend",
                     "modelFileTokenizer" to "tokenizer"
                 )
@@ -491,26 +492,31 @@ class ASRHandler(private val reactContext: ReactApplicationContext) {
             }
             "moonshine" -> {
                 Log.i(TAG, "Setting up Moonshine model")
-                val preprocessorFile = modelFiles["preprocessor"] ?: "preprocess.onnx"
                 val encoderFile = modelFiles["encoder"] ?: "encode.onnx"
-                val uncachedDecoderFile = modelFiles["uncachedDecoder"] ?: "uncached_decode.onnx"
-                val cachedDecoderFile = modelFiles["cachedDecoder"] ?: "cached_decode.onnx"
-                
-                val preprocessorPath = File(modelDir, preprocessorFile).absolutePath
                 val encoderPath = File(modelDir, encoderFile).absolutePath
-                val uncachedDecoderPath = File(modelDir, uncachedDecoderFile).absolutePath
-                val cachedDecoderPath = File(modelDir, cachedDecoderFile).absolutePath
-                
-                Log.i(TAG, "Using preprocessor: $preprocessorPath")
                 Log.i(TAG, "Using encoder: $encoderPath")
-                Log.i(TAG, "Using uncachedDecoder: $uncachedDecoderPath")
-                Log.i(TAG, "Using cachedDecoder: $cachedDecoderPath")
-                
                 val moonshineConfig = OfflineMoonshineModelConfig()
-                moonshineConfig.preprocessor = preprocessorPath
                 moonshineConfig.encoder = encoderPath
-                moonshineConfig.uncachedDecoder = uncachedDecoderPath
-                moonshineConfig.cachedDecoder = cachedDecoderPath
+
+                val mergedDecoderFile = modelFiles["mergedDecoder"]
+                if (mergedDecoderFile != null) {
+                    val mergedDecoderPath = File(modelDir, mergedDecoderFile).absolutePath
+                    Log.i(TAG, "Using mergedDecoder: $mergedDecoderPath")
+                    moonshineConfig.mergedDecoder = mergedDecoderPath
+                } else {
+                    val preprocessorFile = modelFiles["preprocessor"] ?: "preprocess.onnx"
+                    val uncachedDecoderFile = modelFiles["uncachedDecoder"] ?: "uncached_decode.onnx"
+                    val cachedDecoderFile = modelFiles["cachedDecoder"] ?: "cached_decode.onnx"
+                    val preprocessorPath = File(modelDir, preprocessorFile).absolutePath
+                    val uncachedDecoderPath = File(modelDir, uncachedDecoderFile).absolutePath
+                    val cachedDecoderPath = File(modelDir, cachedDecoderFile).absolutePath
+                    Log.i(TAG, "Using preprocessor: $preprocessorPath")
+                    Log.i(TAG, "Using uncachedDecoder: $uncachedDecoderPath")
+                    Log.i(TAG, "Using cachedDecoder: $cachedDecoderPath")
+                    moonshineConfig.preprocessor = preprocessorPath
+                    moonshineConfig.uncachedDecoder = uncachedDecoderPath
+                    moonshineConfig.cachedDecoder = cachedDecoderPath
+                }
                 
                 modelConfig.moonshine = moonshineConfig
             }

--- a/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/PunctuationHandler.kt
+++ b/packages/sherpa-onnx.rn/android/src/main/kotlin/net/siteed/sherpaonnx/handlers/PunctuationHandler.kt
@@ -14,7 +14,8 @@ import java.util.concurrent.Executors
 class PunctuationHandler(private val reactContext: ReactApplicationContext) {
 
     private val executor = Executors.newSingleThreadExecutor()
-    private var punct: OnlinePunctuation? = null
+    private var onlinePunct: OnlinePunctuation? = null
+    private var offlinePunct: OfflinePunctuation? = null
 
     companion object {
         private const val TAG = "SherpaOnnxPunctuation"
@@ -31,8 +32,6 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
                 Log.i(TAG, "Initializing Punctuation with config: ${config.toHashMap()}")
 
                 val modelDir = AssetUtils.cleanFilePath(config.getString("modelDir") ?: "")
-                val cnnBilstm = config.getString("cnnBilstm") ?: "model.onnx"
-                val bpeVocab = config.getString("bpeVocab") ?: "bpe.vocab"
                 val numThreads = if (config.hasKey("numThreads")) config.getInt("numThreads") else 1
                 val debug = if (config.hasKey("debug")) config.getBoolean("debug") else false
                 val provider = config.getString("provider") ?: "cpu"
@@ -50,36 +49,60 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
                     modelDir
                 }
 
-                val cnnBilstmPath = File(actualModelDir, cnnBilstm).absolutePath
-                val bpeVocabPath = File(actualModelDir, bpeVocab).absolutePath
+                releaseCurrentPunctuation()
 
-                Log.i(TAG, "cnnBilstm: $cnnBilstmPath (exists: ${File(cnnBilstmPath).exists()})")
-                Log.i(TAG, "bpeVocab: $bpeVocabPath (exists: ${File(bpeVocabPath).exists()})")
+                val offlineModel = if (config.hasKey("model")) config.getString("model") else null
+                if (!offlineModel.isNullOrBlank()) {
+                    val modelPath = File(actualModelDir, offlineModel).absolutePath
+                    Log.i(TAG, "offline model: $modelPath (exists: ${File(modelPath).exists()})")
 
-                if (!File(cnnBilstmPath).exists()) {
-                    throw Exception("cnnBilstm file not found: $cnnBilstmPath")
+                    if (!File(modelPath).exists()) {
+                        throw Exception("model file not found: $modelPath")
+                    }
+
+                    offlinePunct = OfflinePunctuation(
+                        config = OfflinePunctuationConfig(
+                            model = OfflinePunctuationModelConfig(
+                                ctTransformer = modelPath,
+                                numThreads = numThreads,
+                                debug = debug,
+                                provider = provider,
+                            ),
+                        ),
+                    )
+
+                    Log.i(TAG, "Offline punctuation initialized successfully")
+                } else {
+                    val cnnBilstm = config.getString("cnnBilstm") ?: "model.onnx"
+                    val bpeVocab = config.getString("bpeVocab") ?: "bpe.vocab"
+
+                    val cnnBilstmPath = File(actualModelDir, cnnBilstm).absolutePath
+                    val bpeVocabPath = File(actualModelDir, bpeVocab).absolutePath
+
+                    Log.i(TAG, "cnnBilstm: $cnnBilstmPath (exists: ${File(cnnBilstmPath).exists()})")
+                    Log.i(TAG, "bpeVocab: $bpeVocabPath (exists: ${File(bpeVocabPath).exists()})")
+
+                    if (!File(cnnBilstmPath).exists()) {
+                        throw Exception("cnnBilstm file not found: $cnnBilstmPath")
+                    }
+                    if (!File(bpeVocabPath).exists()) {
+                        throw Exception("bpeVocab file not found: $bpeVocabPath")
+                    }
+
+                    val punctConfig = OnlinePunctuationConfig(
+                        model = OnlinePunctuationModelConfig(
+                            cnnBilstm = cnnBilstmPath,
+                            bpeVocab = bpeVocabPath,
+                            numThreads = numThreads,
+                            debug = debug,
+                            provider = provider,
+                        ),
+                    )
+
+                    onlinePunct = OnlinePunctuation(null, punctConfig)
+
+                    Log.i(TAG, "Online punctuation initialized successfully")
                 }
-                if (!File(bpeVocabPath).exists()) {
-                    throw Exception("bpeVocab file not found: $bpeVocabPath")
-                }
-
-                // Release previous instance
-                punct?.release()
-                punct = null
-
-                val punctConfig = OnlinePunctuationConfig(
-                    model = OnlinePunctuationModelConfig(
-                        cnnBilstm = cnnBilstmPath,
-                        bpeVocab = bpeVocabPath,
-                        numThreads = numThreads,
-                        debug = debug,
-                        provider = provider,
-                    ),
-                )
-
-                punct = OnlinePunctuation(null, punctConfig)
-
-                Log.i(TAG, "Punctuation initialized successfully")
 
                 val resultMap = Arguments.createMap()
                 resultMap.putBoolean("success", true)
@@ -87,7 +110,7 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
             } catch (e: Exception) {
                 Log.e(TAG, "Error initializing Punctuation: ${e.message}")
                 e.printStackTrace()
-                punct = null
+                releaseCurrentPunctuation()
                 reactContext.runOnUiQueueThread {
                     promise.reject("ERR_PUNCTUATION_INIT", "Failed to initialize Punctuation: ${e.message}")
                 }
@@ -98,13 +121,14 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
     fun addPunctuation(text: String, promise: Promise) {
         executor.execute {
             try {
-                val currentPunct = punct
-                    ?: throw Exception("Punctuation not initialized")
-
                 Log.d(TAG, "Adding punctuation to: $text")
 
                 val startTime = System.currentTimeMillis()
-                val result = currentPunct.addPunctuation(text)
+                val result = when {
+                    offlinePunct != null -> offlinePunct!!.addPunctuation(text)
+                    onlinePunct != null -> onlinePunct!!.addPunctuation(text)
+                    else -> throw Exception("Punctuation not initialized")
+                }
                 val durationMs = System.currentTimeMillis() - startTime
 
                 Log.i(TAG, "Punctuated text: $result in ${durationMs}ms")
@@ -127,8 +151,7 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
     fun release(promise: Promise) {
         executor.execute {
             try {
-                punct?.release()
-                punct = null
+                releaseCurrentPunctuation()
                 Log.i(TAG, "Punctuation released")
 
                 val resultMap = Arguments.createMap()
@@ -141,5 +164,12 @@ class PunctuationHandler(private val reactContext: ReactApplicationContext) {
                 }
             }
         }
+    }
+
+    private fun releaseCurrentPunctuation() {
+        onlinePunct?.release()
+        onlinePunct = null
+        offlinePunct?.release()
+        offlinePunct = null
     }
 }

--- a/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
+++ b/packages/sherpa-onnx.rn/ios/bridge/SherpaOnnxRnModule.mm
@@ -345,6 +345,7 @@ RCT_EXPORT_METHOD(initAsr:(JS::NativeSherpaOnnxSpec::SpecInitAsrConfig &)config
     NSString *modelFilePreprocessor = config.modelFilePreprocessor();
     NSString *modelFileUncachedDecoder = config.modelFileUncachedDecoder();
     NSString *modelFileCachedDecoder = config.modelFileCachedDecoder();
+    NSString *modelFileMergedDecoder = config.modelFileMergedDecoder();
     NSString *modelFileConvFrontend = config.modelFileConvFrontend();
     NSString *modelFileTokenizer = config.modelFileTokenizer();
 
@@ -384,6 +385,7 @@ RCT_EXPORT_METHOD(initAsr:(JS::NativeSherpaOnnxSpec::SpecInitAsrConfig &)config
     if (modelFilePreprocessor) [modelFiles setObject:modelFilePreprocessor forKey:@"preprocessor"];
     if (modelFileUncachedDecoder) [modelFiles setObject:modelFileUncachedDecoder forKey:@"uncachedDecoder"];
     if (modelFileCachedDecoder) [modelFiles setObject:modelFileCachedDecoder forKey:@"cachedDecoder"];
+    if (modelFileMergedDecoder) [modelFiles setObject:modelFileMergedDecoder forKey:@"mergedDecoder"];
     if (modelFileConvFrontend) [modelFiles setObject:modelFileConvFrontend forKey:@"convFrontend"];
     if (modelFileTokenizer) [modelFiles setObject:modelFileTokenizer forKey:@"tokenizer"];
     if (modelFiles.count > 0) [configDict setObject:modelFiles forKey:@"modelFiles"];
@@ -1292,6 +1294,7 @@ RCT_EXPORT_METHOD(initPunctuation:(JS::NativeSherpaOnnxSpec::SpecInitPunctuation
     NSMutableDictionary *configDict = [NSMutableDictionary dictionary];
     if (config.modelDir()) configDict[@"modelDir"] = config.modelDir();
     if (config.cnnBilstm()) configDict[@"cnnBilstm"] = config.cnnBilstm();
+    if (config.model()) configDict[@"model"] = config.model();
     if (config.bpeVocab()) configDict[@"bpeVocab"] = config.bpeVocab();
     if (config.numThreads()) configDict[@"numThreads"] = @((int)*config.numThreads());
     if (config.debug()) configDict[@"debug"] = @(*config.debug());

--- a/packages/sherpa-onnx.rn/ios/codegen/SherpaOnnxSpec/SherpaOnnxSpec.h
+++ b/packages/sherpa-onnx.rn/ios/codegen/SherpaOnnxSpec/SherpaOnnxSpec.h
@@ -121,6 +121,7 @@ namespace JS {
       NSString *modelFilePreprocessor() const;
       NSString *modelFileUncachedDecoder() const;
       NSString *modelFileCachedDecoder() const;
+      NSString *modelFileMergedDecoder() const;
       NSString *modelFileConvFrontend() const;
       NSString *modelFileTokenizer() const;
 
@@ -279,6 +280,7 @@ namespace JS {
     struct SpecInitPunctuationConfig {
       NSString *modelDir() const;
       NSString *cnnBilstm() const;
+      NSString *model() const;
       NSString *bpeVocab() const;
       std::optional<double> numThreads() const;
       std::optional<bool> debug() const;
@@ -820,6 +822,11 @@ inline NSString *JS::NativeSherpaOnnxSpec::SpecInitAsrConfig::modelFileCachedDec
   id const p = _v[@"modelFileCachedDecoder"];
   return RCTBridgingToOptionalString(p);
 }
+inline NSString *JS::NativeSherpaOnnxSpec::SpecInitAsrConfig::modelFileMergedDecoder() const
+{
+  id const p = _v[@"modelFileMergedDecoder"];
+  return RCTBridgingToOptionalString(p);
+}
 inline NSString *JS::NativeSherpaOnnxSpec::SpecInitAsrConfig::modelFileConvFrontend() const
 {
   id const p = _v[@"modelFileConvFrontend"];
@@ -1118,6 +1125,11 @@ inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::modelDir()
 inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::cnnBilstm() const
 {
   id const p = _v[@"cnnBilstm"];
+  return RCTBridgingToOptionalString(p);
+}
+inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::model() const
+{
+  id const p = _v[@"model"];
   return RCTBridgingToOptionalString(p);
 }
 inline NSString *JS::NativeSherpaOnnxSpec::SpecInitPunctuationConfig::bpeVocab() const

--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxASRHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxASRHandler.swift
@@ -261,16 +261,24 @@ import AVFoundation
             )
 
         case "moonshine":
-            let preprocessorFile = modelFiles["preprocessor"] ?? "preprocess.onnx"
             let encoderFile = modelFiles["encoder"] ?? "encode.onnx"
-            let uncachedDecoderFile = modelFiles["uncachedDecoder"] ?? "uncached_decode.onnx"
-            let cachedDecoderFile = modelFiles["cachedDecoder"] ?? "cached_decode.onnx"
-            moonshineConfig = sherpaOnnxOfflineMoonshineModelConfig(
-                preprocessor: (modelDir as NSString).appendingPathComponent(preprocessorFile),
-                encoder: (modelDir as NSString).appendingPathComponent(encoderFile),
-                uncachedDecoder: (modelDir as NSString).appendingPathComponent(uncachedDecoderFile),
-                cachedDecoder: (modelDir as NSString).appendingPathComponent(cachedDecoderFile)
-            )
+            let encoderPath = (modelDir as NSString).appendingPathComponent(encoderFile)
+            if let mergedDecoderFile = modelFiles["mergedDecoder"] {
+                moonshineConfig = sherpaOnnxOfflineMoonshineModelConfig(
+                    encoder: encoderPath,
+                    mergedDecoder: (modelDir as NSString).appendingPathComponent(mergedDecoderFile)
+                )
+            } else {
+                let preprocessorFile = modelFiles["preprocessor"] ?? "preprocess.onnx"
+                let uncachedDecoderFile = modelFiles["uncachedDecoder"] ?? "uncached_decode.onnx"
+                let cachedDecoderFile = modelFiles["cachedDecoder"] ?? "cached_decode.onnx"
+                moonshineConfig = sherpaOnnxOfflineMoonshineModelConfig(
+                    preprocessor: (modelDir as NSString).appendingPathComponent(preprocessorFile),
+                    encoder: encoderPath,
+                    uncachedDecoder: (modelDir as NSString).appendingPathComponent(uncachedDecoderFile),
+                    cachedDecoder: (modelDir as NSString).appendingPathComponent(cachedDecoderFile)
+                )
+            }
 
         case "sense_voice":
             let modelFile = modelFiles["model"] ?? "model.onnx"

--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxPunctuationHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxPunctuationHandler.swift
@@ -2,7 +2,13 @@ import Foundation
 import CSherpaOnnx
 
 @objc public class SherpaOnnxPunctuationHandler: NSObject {
+    private enum Engine {
+        case online
+        case offline
+    }
+
     private var punctPtr: OpaquePointer?
+    private var engine: Engine = .online
 
     private static let TAG = "[SherpaOnnxPunctuation]"
 
@@ -23,8 +29,6 @@ import CSherpaOnnx
             return ["success": false, "error": "modelDir is required"]
         }
 
-        let cnnBilstm = config["cnnBilstm"] as? String ?? "model.onnx"
-        let bpeVocab = config["bpeVocab"] as? String ?? "bpe.vocab"
         let numThreads = config["numThreads"] as? Int ?? 1
         let debug = config["debug"] as? Bool ?? false
         let provider = config["provider"] as? String ?? "cpu"
@@ -42,6 +46,44 @@ import CSherpaOnnx
                 actualModelDir = (modelDir as NSString).appendingPathComponent(subdirs[0])
             }
         }
+
+        if let model = config["model"] as? String, !model.isEmpty {
+            let modelPath = (actualModelDir as NSString).appendingPathComponent(model)
+            if !fm.fileExists(atPath: modelPath) {
+                return ["success": false, "error": "model file not found: \(modelPath)"]
+            }
+
+            cleanupResources()
+
+            let modelC = strdup(modelPath)!
+            let providerC = strdup(provider)!
+
+            var modelConfig = SherpaOnnxOfflinePunctuationModelConfig(
+                ct_transformer: modelC,
+                num_threads: Int32(numThreads),
+                debug: debug ? 1 : 0,
+                provider: providerC
+            )
+
+            var punctConfig = SherpaOnnxOfflinePunctuationConfig(model: modelConfig)
+            let ptr = SherpaOnnxCreateOfflinePunctuation(&punctConfig)
+
+            free(modelC)
+            free(providerC)
+
+            guard ptr != nil else {
+                return ["success": false, "error": "Failed to create OfflinePunctuation instance"]
+            }
+
+            punctPtr = ptr
+            engine = .offline
+
+            NSLog("%@ Offline punctuation initialized successfully", SherpaOnnxPunctuationHandler.TAG)
+            return ["success": true]
+        }
+
+        let cnnBilstm = config["cnnBilstm"] as? String ?? "model.onnx"
+        let bpeVocab = config["bpeVocab"] as? String ?? "bpe.vocab"
 
         let cnnBilstmPath = (actualModelDir as NSString).appendingPathComponent(cnnBilstm)
         let bpeVocabPath = (actualModelDir as NSString).appendingPathComponent(bpeVocab)
@@ -82,8 +124,9 @@ import CSherpaOnnx
         }
 
         punctPtr = ptr
+        engine = .online
 
-        NSLog("%@ Punctuation initialized successfully", SherpaOnnxPunctuationHandler.TAG)
+        NSLog("%@ Online punctuation initialized successfully", SherpaOnnxPunctuationHandler.TAG)
         return ["success": true]
     }
 
@@ -96,14 +139,23 @@ import CSherpaOnnx
 
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        let resultPtr = SherpaOnnxOnlinePunctuationAddPunct(punct, text)
-        let durationMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000.0
-
         var punctuated = ""
-        if let resultPtr = resultPtr {
-            punctuated = String(cString: resultPtr)
-            SherpaOnnxOnlinePunctuationFreeText(resultPtr)
+        switch engine {
+        case .online:
+            let resultPtr = SherpaOnnxOnlinePunctuationAddPunct(punct, text)
+            if let resultPtr = resultPtr {
+                punctuated = String(cString: resultPtr)
+                SherpaOnnxOnlinePunctuationFreeText(resultPtr)
+            }
+        case .offline:
+            let resultPtr = SherpaOfflinePunctuationAddPunct(punct, text)
+            if let resultPtr = resultPtr {
+                punctuated = String(cString: resultPtr)
+                SherpaOfflinePunctuationFreeText(resultPtr)
+            }
         }
+
+        let durationMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000.0
 
         NSLog("%@ Punctuated text: %@ in %.0fms", SherpaOnnxPunctuationHandler.TAG, punctuated, durationMs)
 
@@ -123,9 +175,15 @@ import CSherpaOnnx
 
     private func cleanupResources() {
         if let ptr = punctPtr {
-            SherpaOnnxDestroyOnlinePunctuation(ptr)
+            switch engine {
+            case .online:
+                SherpaOnnxDestroyOnlinePunctuation(ptr)
+            case .offline:
+                SherpaOnnxDestroyOfflinePunctuation(ptr)
+            }
             punctPtr = nil
         }
+        engine = .online
         NSLog("%@ Punctuation resources released", SherpaOnnxPunctuationHandler.TAG)
     }
 }

--- a/packages/sherpa-onnx.rn/src/NativeSherpaOnnxSpec.ts
+++ b/packages/sherpa-onnx.rn/src/NativeSherpaOnnxSpec.ts
@@ -170,6 +170,7 @@ export interface Spec extends TurboModule {
     modelFilePreprocessor?: string;
     modelFileUncachedDecoder?: string;
     modelFileCachedDecoder?: string;
+    modelFileMergedDecoder?: string;
     modelFileConvFrontend?: string;
     modelFileTokenizer?: string;
   }): Promise<{
@@ -528,6 +529,7 @@ export interface Spec extends TurboModule {
   initPunctuation(config: {
     modelDir: string;
     cnnBilstm?: string;
+    model?: string;
     bpeVocab?: string;
     numThreads?: number;
     debug?: boolean;

--- a/packages/sherpa-onnx.rn/src/SherpaOnnxAPI.ts
+++ b/packages/sherpa-onnx.rn/src/SherpaOnnxAPI.ts
@@ -156,6 +156,7 @@ const nativeAdapter: ApiInterface = {
       nativeConfig.modelFilePreprocessor = config.modelFiles.preprocessor;
       nativeConfig.modelFileUncachedDecoder = config.modelFiles.uncachedDecoder;
       nativeConfig.modelFileCachedDecoder = config.modelFiles.cachedDecoder;
+      nativeConfig.modelFileMergedDecoder = config.modelFiles.mergedDecoder;
       nativeConfig.modelFileConvFrontend = config.modelFiles.convFrontend;
       nativeConfig.modelFileTokenizer = config.modelFiles.tokenizer;
     }

--- a/packages/sherpa-onnx.rn/src/__tests__/PunctuationService.test.ts
+++ b/packages/sherpa-onnx.rn/src/__tests__/PunctuationService.test.ts
@@ -1,0 +1,55 @@
+import { PunctuationService } from '../services/PunctuationService';
+import type { ApiInterface } from '../types/api';
+
+function createMockApi() {
+  return {
+    validateLibraryLoaded: jest
+      .fn()
+      .mockResolvedValue({ loaded: true, status: 'ok' }),
+    initPunctuation: jest.fn().mockResolvedValue({ success: true }),
+    addPunctuation: jest
+      .fn()
+      .mockResolvedValue({ success: true, text: 'Hello.', durationMs: 1 }),
+    releasePunctuation: jest.fn().mockResolvedValue({ released: true }),
+  };
+}
+
+describe('PunctuationService', () => {
+  it('forwards model for offline CT-Transformer punctuation', async () => {
+    const api = createMockApi();
+    const service = new PunctuationService(api as unknown as ApiInterface);
+
+    await service.init({
+      modelDir: '/models/punctuation',
+      model: 'model.int8.onnx',
+    });
+
+    expect(api.initPunctuation).toHaveBeenCalledTimes(1);
+    expect(api.initPunctuation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelDir: '/models/punctuation',
+        model: 'model.int8.onnx',
+      })
+    );
+  });
+
+  it('keeps online CNN-BiLSTM config unchanged when model is absent', async () => {
+    const api = createMockApi();
+    const service = new PunctuationService(api as unknown as ApiInterface);
+
+    await service.init({
+      modelDir: '/models/punctuation',
+      cnnBilstm: 'model.onnx',
+      bpeVocab: 'bpe.vocab',
+    });
+
+    expect(api.initPunctuation).toHaveBeenCalledTimes(1);
+    const forwarded = api.initPunctuation.mock.calls[0][0] as Record<string, unknown>;
+    expect(forwarded).toMatchObject({
+      modelDir: '/models/punctuation',
+      cnnBilstm: 'model.onnx',
+      bpeVocab: 'bpe.vocab',
+    });
+    expect(forwarded).not.toHaveProperty('model');
+  });
+});

--- a/packages/sherpa-onnx.rn/src/__tests__/moonshineV2Contract.test.js
+++ b/packages/sherpa-onnx.rn/src/__tests__/moonshineV2Contract.test.js
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('node:fs');
+const path = require('node:path');
+
+function read(relativePath) {
+  return fs.readFileSync(path.resolve(__dirname, '..', '..', relativePath), 'utf8');
+}
+
+describe('Moonshine v2 bridge contract', () => {
+  it('threads modelFiles.mergedDecoder through native and web bridges', () => {
+    expect(read('src/types/interfaces.ts')).toContain('mergedDecoder?: string');
+    expect(read('src/SherpaOnnxAPI.ts')).toContain('modelFileMergedDecoder');
+    expect(read('src/NativeSherpaOnnxSpec.ts')).toContain('modelFileMergedDecoder?: string');
+    expect(read('android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt')).toContain(
+      '"modelFileMergedDecoder" to "mergedDecoder"'
+    );
+    expect(read('ios/handlers/SherpaOnnxASRHandler.swift')).toContain(
+      'mergedDecoder: (modelDir as NSString).appendingPathComponent(mergedDecoderFile)'
+    );
+    expect(read('src/web/features/asr.ts')).toContain('mf?.mergedDecoder');
+  });
+});

--- a/packages/sherpa-onnx.rn/src/__tests__/moonshineV2Contract.test.js
+++ b/packages/sherpa-onnx.rn/src/__tests__/moonshineV2Contract.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('node:fs');
 const path = require('node:path');
+const { buildOfflineAsrPlan } = require('../web/features/asr');
 
 function read(relativePath) {
   return fs.readFileSync(path.resolve(__dirname, '..', '..', relativePath), 'utf8');
@@ -21,5 +22,47 @@ describe('Moonshine v2 bridge contract', () => {
       'mergedDecoder: (modelDir as NSString).appendingPathComponent(mergedDecoderFile)'
     );
     expect(read('src/web/features/asr.ts')).toContain('mf?.mergedDecoder');
+  });
+
+  it('builds a Moonshine v2 web plan without v1 decoder files', () => {
+    const plan = buildOfflineAsrPlan(
+      '/models',
+      '/fs/moonshine-v2',
+      'moonshine',
+      {
+        modelDir: '/models',
+        modelType: 'moonshine',
+        modelFiles: {
+          encoder: 'encoder_model.ort',
+          mergedDecoder: 'decoder_model_merged.ort',
+          tokens: 'tokens.txt',
+        },
+      },
+      {
+        encoder: 'encoder_model.ort',
+        mergedDecoder: 'decoder_model_merged.ort',
+        tokens: 'tokens.txt',
+      },
+      {
+        debug: 0,
+        numThreads: 1,
+        sampleRate: 16000,
+        decodingMethod: 'greedy_search',
+        maxActivePaths: 4,
+      }
+    );
+
+    expect(plan.files.map((file) => file.fsPath)).toEqual([
+      '/fs/moonshine-v2/tokens.txt',
+      '/fs/moonshine-v2/encoder_model.ort',
+      '/fs/moonshine-v2/decoder_model_merged.ort',
+    ]);
+    expect(plan.recognizerConfig.modelConfig.moonshine).toEqual({
+      preprocessor: '',
+      encoder: '/fs/moonshine-v2/encoder_model.ort',
+      uncachedDecoder: '',
+      cachedDecoder: '',
+      mergedDecoder: '/fs/moonshine-v2/decoder_model_merged.ort',
+    });
   });
 });

--- a/packages/sherpa-onnx.rn/src/__tests__/moonshineV2Contract.test.js
+++ b/packages/sherpa-onnx.rn/src/__tests__/moonshineV2Contract.test.js
@@ -14,6 +14,9 @@ describe('Moonshine v2 bridge contract', () => {
     expect(read('android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt')).toContain(
       '"modelFileMergedDecoder" to "mergedDecoder"'
     );
+    expect(read('android/src/main/kotlin/net/siteed/sherpaonnx/handlers/ASRHandler.kt')).toContain(
+      'if (modelConfig.moonshine.mergedDecoder.isNotBlank())'
+    );
     expect(read('ios/handlers/SherpaOnnxASRHandler.swift')).toContain(
       'mergedDecoder: (modelDir as NSString).appendingPathComponent(mergedDecoderFile)'
     );

--- a/packages/sherpa-onnx.rn/src/services/PunctuationService.ts
+++ b/packages/sherpa-onnx.rn/src/services/PunctuationService.ts
@@ -32,6 +32,7 @@ export class PunctuationService {
       const nativeConfig: Record<string, unknown> = {
         modelDir: cleanFilePath(config.modelDir),
         cnnBilstm: config.cnnBilstm,
+        ...(config.model ? { model: config.model } : {}),
         bpeVocab: config.bpeVocab,
         numThreads: config.numThreads ?? 1,
         debug: config.debug ?? false,

--- a/packages/sherpa-onnx.rn/src/types/interfaces.ts
+++ b/packages/sherpa-onnx.rn/src/types/interfaces.ts
@@ -512,6 +512,8 @@ export interface AsrModelConfig {
     preprocessor?: string;
     uncachedDecoder?: string;
     cachedDecoder?: string;
+    /** Moonshine v2 merged decoder. When set, omit v1 preprocessor/decoder files. */
+    mergedDecoder?: string;
     /** Qwen3-ASR: filename of conv frontend onnx (default `conv_frontend.onnx`). */
     convFrontend?: string;
     /** Qwen3-ASR: directory name (relative to `modelDir`) holding the tokenizer files. */
@@ -1647,6 +1649,12 @@ export interface LanguageIdResult {
 export interface PunctuationModelConfig {
   modelDir: string;
   cnnBilstm?: string;
+  /**
+   * Offline CT-Transformer model filename, for example `model.onnx` or
+   * `model.int8.onnx`. When set, native platforms use the offline
+   * punctuation engine and ignore `cnnBilstm` / `bpeVocab`.
+   */
+  model?: string;
   bpeVocab?: string;
   numThreads?: number;
   debug?: boolean;

--- a/packages/sherpa-onnx.rn/src/web/features/asr.ts
+++ b/packages/sherpa-onnx.rn/src/web/features/asr.ts
@@ -151,7 +151,22 @@ function buildOfflineAsrPlan(
       };
       break;
     case 'moonshine':
-      mc.moonshine = { preprocessor: f('preprocessor', 'preprocessor.onnx'), encoder: f('encoder', 'encoder.onnx'), uncachedDecoder: f('uncachedDecoder', 'uncached_decoder.onnx'), cachedDecoder: f('cachedDecoder', 'cached_decoder.onnx') };
+      if (mf?.mergedDecoder) {
+        mc.moonshine = {
+          preprocessor: '',
+          encoder: f('encoder', 'encoder.onnx'),
+          uncachedDecoder: '',
+          cachedDecoder: '',
+          mergedDecoder: f('mergedDecoder', mf.mergedDecoder),
+        };
+      } else {
+        mc.moonshine = {
+          preprocessor: f('preprocessor', 'preprocessor.onnx'),
+          encoder: f('encoder', 'encoder.onnx'),
+          uncachedDecoder: f('uncachedDecoder', 'uncached_decoder.onnx'),
+          cachedDecoder: f('cachedDecoder', 'cached_decoder.onnx'),
+        };
+      }
       break;
     case 'sense_voice':
       mc.senseVoice = {

--- a/packages/sherpa-onnx.rn/src/web/features/asr.ts
+++ b/packages/sherpa-onnx.rn/src/web/features/asr.ts
@@ -98,7 +98,7 @@ interface OfflineAsrFile { url: string; fsPath: string; optional?: boolean }
  * model-type-specific logic stays in TypeScript on the main thread.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function buildOfflineAsrPlan(
+export function buildOfflineAsrPlan(
   fetchBase: string,
   modelDir: string,
   rawType: string,

--- a/packages/sherpa-onnx.rn/src/web/features/punctuation.ts
+++ b/packages/sherpa-onnx.rn/src/web/features/punctuation.ts
@@ -20,6 +20,12 @@ export function PunctuationMixin<TBase extends Constructor>(Base: TBase) {
         const debug = config?.debug ? 1 : 0;
         const numThreads = 1; // WASM is single-threaded
 
+        if (config?.model) {
+          console.warn(
+            '[Punctuation] Offline CT-Transformer punctuation is not supported on web; using online CNN-BiLSTM instead.'
+          );
+        }
+
         console.log(
           `[Punctuation] Loading model (threads=${numThreads}, debug=${debug})...`
         );

--- a/scripts/agentic/cdp-bridge.mjs
+++ b/scripts/agentic/cdp-bridge.mjs
@@ -310,18 +310,18 @@ function getInspectorOrigin(wsUrl) {
     if (!parsed.pathname.startsWith('/inspector/')) return undefined;
 
     const metroPort = parsed.port || loadPort();
-    const configuredAppRoot = fs.existsSync(AGENTIC_CONF_FILE);
-    const localMetroHost = readTextFile(path.join(AGENT_DIR, 'metro.host'));
-    const discoveredAppMetroHost = findAppMetroHost();
-    const metroHost = configuredAppRoot
-      ? localMetroHost || discoveredAppMetroHost
-      : discoveredAppMetroHost || localMetroHost;
-    if (metroHost) {
-      const httpProtocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
-      return `${httpProtocol}//${metroHost}:${metroPort}`;
+    const httpProtocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+
+    // Native targets are discovered through this local Metro process
+    // (`http://localhost:<port>/json/list`) and Expo validates the WebSocket
+    // Origin against that local host.  Using the LAN packager host recorded for
+    // physical-device launch causes Expo 56 to reject the inspector connection
+    // even though the app is already running.
+    if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+      return `${httpProtocol}//127.0.0.1:${metroPort}`;
     }
 
-    parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+    parsed.protocol = httpProtocol;
     parsed.pathname = '';
     parsed.search = '';
     parsed.hash = '';


### PR DESCRIPTION
## Summary
- Recreated fixes for #411 and #413 without merging existing PRs as-is.
- Fixed/revalidated audio-studio issues #415, #416, and #417.
- Deferred #414 as demo-only / DO-NOT-MERGE.
- Added a bounded upstream sanity update for Moonshine v2 `mergedDecoder` wiring; no upstream vendor refresh included.

## Issue coverage
- #411: restored the Android offline speech denoiser `dpdfnet` native struct field needed for JNI config compatibility; the RN denoising handler still exposes the existing GTCRN path only.
- #413: added offline CT-Transformer punctuation support for the TS API plus Android/iOS native paths while preserving online CNN-BiLSTM behavior. Web punctuation remains online-only and now warns when an offline model is requested; callers still need the online CNN-BiLSTM web assets.
- #415: iOS interruption-ended handling now runs even when the system omits interruption options, so system-paused recordings can auto-resume.
- #416: revalidated Android nullable `Promise.reject` signatures; no source change needed.
- #417: invalid iOS hardware audio formats now avoid tap installation, emit an error, and fail prepare/start instead of installing a synthetic fallback format or silently recording no buffers.
- #414: no product/library change; treated as demo-only.

## Validation
- `yarn workspace @siteed/sherpa-onnx.rn typecheck`
- `yarn workspace @siteed/audio-studio typecheck`
- `yarn workspace @siteed/audio-studio build`
- `yarn workspace @siteed/sherpa-onnx.rn prepare`
- `yarn workspace @siteed/sherpa-onnx.rn test PunctuationService --runInBand`
- `yarn workspace @siteed/sherpa-onnx.rn test moonshineV2Contract --runInBand`
- `yarn workspace @siteed/sherpa-onnx.rn test sherpaPrebuiltContract --runInBand`
- Scoped sherpa eslint on changed TS/tests
- `yarn workspace @siteed/audio-studio test:android:unit`
- `yarn workspace @siteed/audio-studio test:ios`
- `yarn ios` on configured iOS simulator; build/install passed and CDP health reached `/record` after the final iOS changes, including failed tap reinstall handling.
- iOS simulator CDP recording lifecycle smoke: `startRecording`/`stopRecording` succeeded for ~1.2s; simulator output was header-only (`size=44`), so this proves lifecycle/launch, not microphone capture.
- `ADB_SERIAL=21261FDF6001SP yarn android:device` on USB Pixel 6; build/install passed and CDP health reached `/record`.
- Android USB CDP recording smoke: `startRecording`/`stopRecording` succeeded for a 1.2s WAV session (`size=109408`).
- Android USB CDP Sherpa functional checks:
  - Offline CT-Transformer punctuation init/add/release succeeded; output: `hello world，how are you？i am fine。`.
  - GTCRN denoiser init/denoise/release succeeded; `sampleRate=16000`, `outputPath` produced.
  - Moonshine v2 init/recognize/release succeeded with `encoder_model.ort` + `decoder_model_merged.ort`; recognized sample text: `Ask not what your country can do for you. Ask what you can do for your country.`
- `git diff --check`

Note: full sherpa package lint still has existing generated/script lint failures outside this change; changed-file scoped lint passed.

## Future release packages
- `@siteed/audio-studio`
- `@siteed/sherpa-onnx.rn`
- Possibly `@siteed/expo-audio-studio` if the release flow requires republishing the wrapper package.

No merge or publish performed.

## Additional app validation after Sherpa package concern
- `cd apps/sherpa-voice && yarn typecheck` passed.
- `cd apps/sherpa-voice && yarn ios` previously passed build/install/launch on configured simulator; rechecked with `yarn ios:launch` after the CDP fix and CDP reached `/features` on `sherpa-voice-1`.
- `cd apps/sherpa-voice && ADB_SERIAL=21261FDF6001SP yarn android:device` previously passed build/install on the USB Pixel 6; rechecked with `yarn android:device:launch` after the CDP fix and CDP reached `/features`.
- Fixed native CDP inspector Origin handling so local Metro `/json/list` targets use `127.0.0.1:<port>` instead of the LAN packager host; this removes the false “no app target” result seen during Sherpa Voice Android validation.
- Android visual proof captured locally at `/tmp/sherpa-voice-android-current.png` showing the Sherpa Voice Features screen.
