### PR TITLE
fix(sherpa-onnx.rn/ios): Float config params silently ignored via SE-0170 NSNumber bridging

### DIFF
--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxDiarizationHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxDiarizationHandler.swift
@@ -35,10 +35,14 @@ import CSherpaOnnx
         let numThreads = config["numThreads"] as? Int ?? 1
         let debug = config["debug"] as? Bool ?? false
         let provider = config["provider"] as? String ?? "cpu"
-        let minDurationOn = config["minDurationOn"] as? Float ?? 0.3
-        let minDurationOff = config["minDurationOff"] as? Float ?? 0.5
+        // NSNumber bridging fix (Swift SE-0170): the RN bridge boxes JS numbers
+        // as double-backed NSNumbers, and `as? Float` on those returns nil unless
+        // the value is exactly Float32-representable — so non-dyadic config like
+        // 0.005 silently fell back to the default. `.floatValue` converts explicitly.
+        let minDurationOn = (config["minDurationOn"] as? NSNumber)?.floatValue ?? 0.3
+        let minDurationOff = (config["minDurationOff"] as? NSNumber)?.floatValue ?? 0.5
         let numClusters = config["numClusters"] as? Int ?? -1
-        let threshold = config["threshold"] as? Float ?? 0.5
+        let threshold = (config["threshold"] as? NSNumber)?.floatValue ?? 0.5
 
         let requestedSegModelFile = config["segmentationModelFile"] as? String
         let segModelPath: String

--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxKWSHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxKWSHandler.swift
@@ -32,8 +32,12 @@ import CSherpaOnnx
         let debug = config["debug"] as? Bool ?? false
         let provider = config["provider"] as? String ?? "cpu"
         let maxActivePaths = config["maxActivePaths"] as? Int ?? 4
-        let keywordsScore = config["keywordsScore"] as? Float ?? 1.5
-        let keywordsThreshold = config["keywordsThreshold"] as? Float ?? 0.25
+        // NSNumber bridging fix (Swift SE-0170): the RN bridge boxes JS numbers
+        // as double-backed NSNumbers, and `as? Float` on those returns nil unless
+        // the value is exactly Float32-representable — so non-dyadic config like
+        // 0.005 silently fell back to the default. `.floatValue` converts explicitly.
+        let keywordsScore = (config["keywordsScore"] as? NSNumber)?.floatValue ?? 1.5
+        let keywordsThreshold = (config["keywordsThreshold"] as? NSNumber)?.floatValue ?? 0.25
         let numTrailingBlanks = config["numTrailingBlanks"] as? Int ?? 2
         let modelType = config["modelType"] as? String ?? "zipformer2"
 

--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxTtsHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxTtsHandler.swift
@@ -61,9 +61,13 @@ import CSherpaOnnx
             let numThreads = config["numThreads"] as? Int ?? 1
             let debug = config["debug"] as? Bool ?? false
             let provider = "cpu"
-            let noiseScale = config["noiseScale"] as? Float ?? 0.667
-            let noiseScaleW = config["noiseScaleW"] as? Float ?? 0.8
-            let lengthScale = config["lengthScale"] as? Float ?? 1.0
+        // NSNumber bridging fix (Swift SE-0170): the RN bridge boxes JS numbers
+        // as double-backed NSNumbers, and `as? Float` on those returns nil unless
+        // the value is exactly Float32-representable — so non-dyadic config like
+        // 0.005 silently fell back to the default. `.floatValue` converts explicitly.
+            let noiseScale = (config["noiseScale"] as? NSNumber)?.floatValue ?? 0.667
+            let noiseScaleW = (config["noiseScaleW"] as? NSNumber)?.floatValue ?? 0.8
+            let lengthScale = (config["lengthScale"] as? NSNumber)?.floatValue ?? 1.0
             
             // --- Log Extracted Config --- 
             NSLog("TTS Init - Model dir (cleaned): \(modelDir)")
@@ -322,17 +326,17 @@ import CSherpaOnnx
             let fileNamePrefix = config["fileNamePrefix"] as? String
             
             // Apply custom parameters if provided
-            if let _ = config["lengthScale"] as? Float { // Use _ to ignore the value
+            if config["lengthScale"] as? NSNumber != nil { // Use _ to ignore the value
                 // Note: Unlike Android, we don't have direct access to modify these parameters 
                 // on existing TTS instance. Instead, we'd need to recreate the instance.
                 NSLog("lengthScale parameter provided but cannot be applied to existing instance in iOS")
             }
             
-            if let _ = config["noiseScale"] as? Float { // Use _ to ignore the value
+            if config["noiseScale"] as? NSNumber != nil { // Use _ to ignore the value
                 NSLog("noiseScale parameter provided but cannot be applied to existing instance in iOS")
             }
             
-            if let _ = config["noiseScaleW"] as? Float { // Use _ to ignore the value
+            if config["noiseScaleW"] as? NSNumber != nil { // Use _ to ignore the value
                 NSLog("noiseScaleW parameter provided but cannot be applied to existing instance in iOS")
             }
             

--- a/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxVADHandler.swift
+++ b/packages/sherpa-onnx.rn/ios/handlers/SherpaOnnxVADHandler.swift
@@ -28,12 +28,16 @@ import CSherpaOnnx
         }
 
         let modelFile = config["modelFile"] as? String ?? "silero_vad_v5.onnx"
-        let threshold = config["threshold"] as? Float ?? 0.5
-        let minSilenceDuration = config["minSilenceDuration"] as? Float ?? 0.25
-        let minSpeechDuration = config["minSpeechDuration"] as? Float ?? 0.25
+        // NSNumber bridging fix (Swift SE-0170): the RN bridge boxes JS numbers
+        // as double-backed NSNumbers, and `as? Float` on those returns nil unless
+        // the value is exactly Float32-representable — so non-dyadic config like
+        // 0.005 silently fell back to the default. `.floatValue` converts explicitly.
+        let threshold = (config["threshold"] as? NSNumber)?.floatValue ?? 0.5
+        let minSilenceDuration = (config["minSilenceDuration"] as? NSNumber)?.floatValue ?? 0.25
+        let minSpeechDuration = (config["minSpeechDuration"] as? NSNumber)?.floatValue ?? 0.25
         let windowSize = config["windowSize"] as? Int32 ?? 512
-        let maxSpeechDuration = config["maxSpeechDuration"] as? Float ?? 5.0
-        let bufferSizeInSeconds = config["bufferSizeInSeconds"] as? Float ?? 30.0
+        let maxSpeechDuration = (config["maxSpeechDuration"] as? NSNumber)?.floatValue ?? 5.0
+        let bufferSizeInSeconds = (config["bufferSizeInSeconds"] as? NSNumber)?.floatValue ?? 30.0
         let numThreads = config["numThreads"] as? Int32 ?? 1
         let debug = config["debug"] as? Bool ?? false
         let provider = config["provider"] as? String ?? "cpu"


### PR DESCRIPTION
## Problem

On iOS, numeric `Float` config values passed to the sherpa-onnx handlers are **silently dropped and replaced by their defaults**. Android is unaffected.

### Root cause

React Native / Expo bridges JS numbers to **`double`-backed `NSNumber`s**. Under [Swift SE-0170](https://github.com/apple/swift-evolution/blob/main/proposals/0170-nsnumber_bridge.md), `someDoubleNSNumber as? Float` returns **`nil` unless the value is exactly representable in 32-bit float**. Most real-world config values aren't:

```swift
NSNumber(value: 0.005) as? Float   // nil  → falls back to default
NSNumber(value: 0.1)   as? Float   // nil
NSNumber(value: 0.667) as? Float   // nil
NSNumber(value: 0.25)  as? Float   // 0.25 (dyadic, happens to survive)
NSNumber(value: 5.5)   as? Float   // 5.5  (dyadic, survives)
```

So the current `config["x"] as? Float ?? default` pattern means any non-dyadic value is thrown away. Concrete impact we hit in production (a keyword-spotting app):

- **KWS `keywordsThreshold`** — every sensible threshold (0.005, 0.01, 0.02, 0.05, 0.1, 0.15 …) is non-dyadic, so it always fell back to **0.25**. The threshold was effectively un-configurable on iOS and pinned ~50× stricter than intended; the keyword was frequently missed. `keywordsScore` (5.5 etc.) happened to survive because it's dyadic, which masked the bug.
- **VAD `threshold` / `minSilenceDuration` / `minSpeechDuration`** — 0.1 → 0.25, so endpointing silently differed from Android.
- **TTS `noiseScale` / `noiseScaleW` / `lengthScale`** and the `if let _ = … as? Float` presence guards — dropped / mis-detected.
- **Diarization `minDurationOn` / `minDurationOff` / `threshold`**.

Android reads the same params via `getDouble().toFloat()` and was always correct — this is an iOS-only asymmetry.

## Fix

Read the value through `NSNumber` and convert explicitly, which never depends on exact float representability:

```swift
let keywordsThreshold = (config["keywordsThreshold"] as? NSNumber)?.floatValue ?? 0.25
```

Presence-check guards that ignored the value now use `config["x"] as? NSNumber != nil`.

Touches all four handlers with the pattern: `SherpaOnnxKWSHandler`, `SherpaOnnxVADHandler`, `SherpaOnnxTtsHandler`, `SherpaOnnxDiarizationHandler`. No API or behavior change on values that already worked.

## Verification

In a shipping app (Expo dev client, iOS device), an offline KWS self-test that feeds byte-identical audio straight into the live spotter went from **~2/10 detections → 9–10/10**, matching Android, purely from this change. `NSNumber(0.005) as? Float == nil` reproduced directly in a Swift toplevel.

## Notes

- Discovered the same class of bug applies to every `as? Float` on bridged config in these handlers, so all are fixed together.
- Happy to adjust style (e.g. a small `NSDictionary` helper) if you'd prefer a shared extraction.